### PR TITLE
Simplify StakeAddrInfo

### DIFF
--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -67,10 +67,7 @@ def _check_staking(
         stake_addr_info = cluster_obj.get_stake_addr_info(owner.stake.address)
 
         # check that the stake address was delegated
-        assert (
-            stake_addr_info and stake_addr_info.delegation
-        ), f"Stake address was not delegated yet: {stake_addr_info}"
-
+        assert stake_addr_info.delegation, f"Stake address was not delegated yet: {stake_addr_info}"
         assert stake_pool_id == stake_addr_info.delegation, "Stake address delegated to wrong pool"
 
         assert (
@@ -382,12 +379,9 @@ class TestStakePool:
         pool_owner = pool_owners[0]
         src_register_balance = cluster.get_address_balance(pool_owner.payment.address)
 
-        src_register_stake_addr_info = cluster.get_stake_addr_info(pool_owner.stake.address)
-        src_register_reward = (
-            src_register_stake_addr_info.reward_account_balance
-            if src_register_stake_addr_info
-            else 0
-        )
+        src_register_reward = cluster.get_stake_addr_info(
+            pool_owner.stake.address
+        ).reward_account_balance
 
         # deregister stake pool
         __, tx_raw_output = cluster.deregister_stake_pool(
@@ -416,14 +410,12 @@ class TestStakePool:
         for owner_rec in pool_owners:
             stake_addr_info = cluster.get_stake_addr_info(owner_rec.stake.address)
             assert (
-                stake_addr_info and not stake_addr_info.delegation
+                not stake_addr_info.delegation
             ), f"Stake address is still delegated: {stake_addr_info}"
 
         # check that the deposit was returned to reward account
-        stake_addr_info = cluster.get_stake_addr_info(pool_owner.stake.address)
         assert (
-            stake_addr_info
-            and stake_addr_info.reward_account_balance
+            cluster.get_stake_addr_info(pool_owner.stake.address).reward_account_balance
             == src_register_reward + cluster.get_pool_deposit()
         )
 
@@ -499,7 +491,7 @@ class TestStakePool:
         for owner_rec in pool_owners:
             stake_addr_info = cluster.get_stake_addr_info(owner_rec.stake.address)
             assert (
-                stake_addr_info and not stake_addr_info.delegation
+                not stake_addr_info.delegation
             ), f"Stake address is still delegated: {stake_addr_info}"
 
         src_address = pool_owners[0].payment.address
@@ -541,7 +533,7 @@ class TestStakePool:
         for owner_rec in pool_owners:
             stake_addr_info = cluster.get_stake_addr_info(owner_rec.stake.address)
             assert (
-                stake_addr_info and stake_addr_info.delegation
+                stake_addr_info.delegation
             ), f"Stake address is not delegated yet: {stake_addr_info}"
 
             assert (

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -89,9 +89,7 @@ def _delegate_stake_addr(
 
     # check that the stake address was delegated
     stake_addr_info = cluster_obj.get_stake_addr_info(stake_addr_rec.address)
-    assert (
-        stake_addr_info and stake_addr_info.delegation
-    ), f"Stake address was not delegated yet: {stake_addr_info}"
+    assert stake_addr_info.delegation, f"Stake address was not delegated yet: {stake_addr_info}"
 
     assert stake_pool_id == stake_addr_info.delegation, "Stake address delegated to wrong pool"
 
@@ -177,4 +175,6 @@ class TestDelegateAddr:
 
         # check that the stake address is no longer delegated
         stake_addr_info = cluster.get_stake_addr_info(pool_user.stake.address)
-        assert stake_addr_info is None, f"Stake address is still delegated: {stake_addr_info}"
+        assert (
+            not stake_addr_info.delegation
+        ), f"Stake address is still delegated: {stake_addr_info}"

--- a/cardano_node_tests/utils/clusterlib.py
+++ b/cardano_node_tests/utils/clusterlib.py
@@ -49,6 +49,9 @@ class StakeAddrInfo(NamedTuple):
     delegation: str
     reward_account_balance: int
 
+    def __bool__(self) -> bool:
+        return bool(self.address)
+
 
 class UTXOData(NamedTuple):
     utxo_hash: str
@@ -692,11 +695,11 @@ class ClusterLib:
         )
         return pool_id
 
-    def get_stake_addr_info(self, stake_addr: str) -> Optional[StakeAddrInfo]:
+    def get_stake_addr_info(self, stake_addr: str) -> StakeAddrInfo:
         """Return info about stake pool address."""
         output_json = json.loads(self.query_cli(["stake-address-info", "--address", stake_addr]))
         if not output_json:
-            return None
+            return StakeAddrInfo(address="", delegation="", reward_account_balance=0)
 
         address_rec = list(output_json)[0]
         address = address_rec.get("address") or ""


### PR DESCRIPTION
Make it falsy when no data, so no need to return None instead -
simplifies checking of it's attributes (no need to check for None
first).