### PR TITLE
Save env before processing artifacts

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -60,10 +60,10 @@ def _run_cluster_cleanup(
     cluster_manager_obj._log("running cluster cleanup")
     # stop cluster
     cluster_manager_obj.stop()
-    # process artifacts
-    devops_cluster.process_artifacts(pytest_tmp_dir=pytest_tmp_dir, request=request)
     # save environment info for Allure
     helpers.save_env_for_allure(request)
+    # process artifacts
+    devops_cluster.process_artifacts(pytest_tmp_dir=pytest_tmp_dir, request=request)
 
 
 @pytest.yield_fixture(scope="session")


### PR DESCRIPTION
In case we raise failure during processing, env is not saved.