### PR TITLE
Created cabal_build_tests

### DIFF
--- a/cabal_build_tests/fedora/Dockerfile
+++ b/cabal_build_tests/fedora/Dockerfile
@@ -1,0 +1,11 @@
+FROM fedora:latest
+
+# workaround for timezone manual intervention
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV TAGGED_VERSION ''
+COPY install-node.sh /
+RUN chmod +x /install-node.sh
+
+CMD ./install-node.sh $TAGGED_VERSION

--- a/cabal_build_tests/install-node.sh
+++ b/cabal_build_tests/install-node.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+### Builds cardano-node on Ubuntu or Fedora using Cabal and verifys successful installation
+### Please note: sudo is not used because user is root
+### Please note: 'source ~/.bashrc' cmd is not used because Docker runs this script as subscript
+
+echo ""
+
+if [[$TAGGED_VERSION == "null" ]]
+then
+	printf "Please specify TAGGED_VERSION on docker run.\ne.g. '-e TAGGED_VERSION=1.23.0'"
+fi
+
+echo "Using tagged version $TAGGED_VERSION"
+cd ~
+
+# Install dependencies
+echo "Install dependencies"
+if [[ $(cat /etc/os-release) == *"fedora"* ]]
+then
+	echo "Running on Fedora"
+	yum update -y
+	yum install git gcc gcc-c++ tmux gmp-devel make tar xz wget zlib-devel libtool autoconf -y
+	yum install systemd-devel ncurses-devel ncurses-compat-libs -y
+elif [[ $(cat /etc/os-release) == *"ubuntu"* ]]
+then
+	echo "Running on Ubuntu"
+	apt-get update -y
+	apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf -y
+else
+	echo "/etc/os-relase does not contain 'fedora' or 'ubuntu'"
+	echo "$(cat /etc/os-release)"
+	exit 1
+fi
+
+# Download, unpack, install and update Cabal
+echo "Download, unpack, install and update Cabal"
+wget https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
+tar -xf cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
+rm cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz cabal.sig
+mkdir -p ~/.local/bin
+mv cabal ~/.local/bin/
+
+if [[ $PATH != *"~/.local/bin"* ]]
+then
+	#echo "\$PATH does not contain ~/.local/bin - Adding..."
+	#echo "export PATH=\"~/.local/bin:\$PATH\"" >> ~/.bashrc
+	#echo "END OF BASHRC IS $(tail -n1 ~/.bashrc)" #REMOVE
+	#bash -c 'source ~/.bashrc' # CANT USE source IN THIS SCRIPT BECAUSE DOCKER RUNS THIS AS SUBSCRIPT
+	export PATH="~/.local/bin:$PATH"
+else
+	echo "$PATH already contains ~/.local/bin"
+fi
+
+
+cabal update
+
+if [[ $(cabal --version) != *"cabal-install version 3.2.0.0"* ]]
+then
+        echo "cabal version $(cabal --version) is not 3.2.0.0"
+	exit 1
+else
+	echo "cabal version 3.2.0.0 is correct"
+fi
+
+# Download and install GHC
+echo "Download and install GHC"
+wget https://downloads.haskell.org/ghc/8.10.2/ghc-8.10.2-x86_64-deb9-linux.tar.xz
+tar -xf ghc-8.10.2-x86_64-deb9-linux.tar.xz
+rm ghc-8.10.2-x86_64-deb9-linux.tar.xz
+cd ghc-8.10.2
+./configure
+make install
+
+cd ~
+
+# Install Libsodium
+echo "Install Lobsodium"
+git clone https://github.com/input-output-hk/libsodium
+cd libsodium
+git checkout 66f017f1
+./autogen.sh
+./configure
+make
+make install
+
+export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# Download the source code for cardano-node
+echo "Download the source code for cardano-node"
+cd ~
+git clone https://github.com/input-output-hk/cardano-node.git
+cd cardano-node
+git fetch --all --tags
+
+if [[ $(git tag) != *"$TAGGED_VERSION"* ]]
+then
+	echo "$(git tag) does not contain $TAGGED_VERSION"
+	exit 1
+fi
+
+git checkout tags/$TAGGED_VERSION
+
+# Build and install the node
+echo "Build and install the node"
+cabal build all
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-$TAGGED_VERSION/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-$TAGGED_VERSION/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+
+# Verify node is installed
+echo "Verify node is installed"
+if [[ $(cardano-cli --version) == *"$TAGGED_VERSION"* ]]
+then
+	echo "$(cardano-cli --version)"
+else
+	echo "$(cardano-cli --version) does not contain $TAGGED_VERSION"
+	exit 1
+fi
+
+printf "\nSuccess\n"

--- a/cabal_build_tests/install-node.sh
+++ b/cabal_build_tests/install-node.sh
@@ -6,13 +6,13 @@
 
 echo ""
 
-if [[$TAGGED_VERSION == "null" ]]
+if [[ $TAGGED_VERSION == "null" ]]
 then
 	printf "Please specify TAGGED_VERSION on docker run.\ne.g. '-e TAGGED_VERSION=1.23.0'"
 fi
 
 echo "Using tagged version $TAGGED_VERSION"
-cd ~
+cd ~ || exit 1
 
 # Install dependencies
 echo "Install dependencies"
@@ -29,7 +29,7 @@ then
 	apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf -y
 else
 	echo "/etc/os-relase does not contain 'fedora' or 'ubuntu'"
-	echo "$(cat /etc/os-release)"
+	cat /etc/os-release
 	exit 1
 fi
 
@@ -47,7 +47,7 @@ then
 	#echo "export PATH=\"~/.local/bin:\$PATH\"" >> ~/.bashrc
 	#echo "END OF BASHRC IS $(tail -n1 ~/.bashrc)" #REMOVE
 	#bash -c 'source ~/.bashrc' # CANT USE source IN THIS SCRIPT BECAUSE DOCKER RUNS THIS AS SUBSCRIPT
-	export PATH="~/.local/bin:$PATH"
+	export PATH=~/.local/bin:"$PATH"
 else
 	echo "$PATH already contains ~/.local/bin"
 fi
@@ -68,16 +68,16 @@ echo "Download and install GHC"
 wget https://downloads.haskell.org/ghc/8.10.2/ghc-8.10.2-x86_64-deb9-linux.tar.xz
 tar -xf ghc-8.10.2-x86_64-deb9-linux.tar.xz
 rm ghc-8.10.2-x86_64-deb9-linux.tar.xz
-cd ghc-8.10.2
+cd ghc-8.10.2 || exit 1
 ./configure
 make install
 
-cd ~
+cd ~ || exit 1
 
 # Install Libsodium
 echo "Install Lobsodium"
 git clone https://github.com/input-output-hk/libsodium
-cd libsodium
+cd libsodium || exit 1
 git checkout 66f017f1
 ./autogen.sh
 ./configure
@@ -89,9 +89,9 @@ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # Download the source code for cardano-node
 echo "Download the source code for cardano-node"
-cd ~
+cd ~ || exit 1
 git clone https://github.com/input-output-hk/cardano-node.git
-cd cardano-node
+cd cardano-node || exit 1
 git fetch --all --tags
 
 if [[ $(git tag) != *"$TAGGED_VERSION"* ]]
@@ -100,22 +100,25 @@ then
 	exit 1
 fi
 
-git checkout tags/$TAGGED_VERSION
+git checkout "tags/$TAGGED_VERSION"
 
 # Build and install the node
 echo "Build and install the node"
 cabal build all
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-$TAGGED_VERSION/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-$TAGGED_VERSION/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+cp -p "dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-$TAGGED_VERSION/x/cardano-node/build/cardano-node/cardano-node" ~/.local/bin/
+cp -p "dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-$TAGGED_VERSION/x/cardano-cli/build/cardano-cli/cardano-cli" ~/.local/bin/
 
 # Verify node is installed
 echo "Verify node is installed"
 if [[ $(cardano-cli --version) == *"$TAGGED_VERSION"* ]]
 then
-	echo "$(cardano-cli --version)"
+	cardano-cli --version
 else
 	echo "$(cardano-cli --version) does not contain $TAGGED_VERSION"
 	exit 1
 fi
 
-printf "\nSuccess\n"
+printf "\nSuccess\n\n"
+echo "You can use 'docker exec -it <container-id> /bin/bash' in a separate session to play in the environment."
+echo "Press any key to stop container."
+read

--- a/cabal_build_tests/readme.md
+++ b/cabal_build_tests/readme.md
@@ -1,0 +1,17 @@
+# README for Dockerized cardano-node Cabal build tests
+## Prerequisites
+- Docker Engine is installed
+- User is in group 'docker'
+
+## Run tests
+
+### To test cardano-node Cabal build on Ubuntu:
+./run-ubuntu.sh \<cardano-node tag>
+
+### To test cardano-node Cabal build on Fedora:
+
+./run-fedora.sh \<cardano-node tag>
+
+If "Success" is shown at the end and exit with code 0 then build has completed successfully and verified with cardano-cli.
+
+Please note: Leaving container running interactively after script ends is todo.

--- a/cabal_build_tests/readme.md
+++ b/cabal_build_tests/readme.md
@@ -6,12 +6,11 @@
 ## Run tests
 
 ### To test cardano-node Cabal build on Ubuntu:
-./run-ubuntu.sh \<cardano-node tag>
+`./run-ubuntu.sh \<cardano-node tag>`
 
 ### To test cardano-node Cabal build on Fedora:
 
-./run-fedora.sh \<cardano-node tag>
+`./run-fedora.sh \<cardano-node tag>`
 
 If "Success" is shown at the end and exit with code 0 then build has completed successfully and verified with cardano-cli.
 
-Please note: Leaving container running interactively after script ends is todo.

--- a/cabal_build_tests/run-fedora.sh
+++ b/cabal_build_tests/run-fedora.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build . -f fedora/Dockerfile -t cardano-node-fedora && \
+	docker run -it -e TAGGED_VERSION=$1 cardano-node-fedora

--- a/cabal_build_tests/run-fedora.sh
+++ b/cabal_build_tests/run-fedora.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build . -f fedora/Dockerfile -t cardano-node-fedora && \
-	docker run -it -e TAGGED_VERSION=$1 cardano-node-fedora
+	docker run --security-opt label:disable -it -e TAGGED_VERSION=$1 cardano-node-fedora

--- a/cabal_build_tests/run-ubuntu.sh
+++ b/cabal_build_tests/run-ubuntu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build . -f ubuntu/Dockerfile -t cardano-node-ubuntu && \
+	docker run -it -e TAGGED_VERSION=$1 cardano-node-ubuntu

--- a/cabal_build_tests/run-ubuntu.sh
+++ b/cabal_build_tests/run-ubuntu.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build . -f ubuntu/Dockerfile -t cardano-node-ubuntu && \
-	docker run -it -e TAGGED_VERSION=$1 cardano-node-ubuntu
+	docker run --security-opt label:disable -it -e TAGGED_VERSION=$1 cardano-node-ubuntu

--- a/cabal_build_tests/ubuntu/Dockerfile
+++ b/cabal_build_tests/ubuntu/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+
+# workaround for timezone manual intervention
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV TAGGED_VERSION ''
+COPY install-node.sh /
+RUN chmod +x /install-node.sh
+
+ENTRYPOINT ./install-node.sh $TAGGED_VERSION


### PR DESCRIPTION
Two news tests that build Ubuntu/Fedora Docker images and are run following Cabal build instructions in doc/getting-started/install.md. Successful build is verified using cardano-cli.