### PR TITLE
Run tests in parallel on multiple cluster instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ALLURE_DIR ?= .reports/
 	mkdir -p docs/build
 
 # run all tests, generate allure report
-TEST_THREADS ?= 8
+TEST_THREADS ?= 15
 tests: .dirs
 	pytest cardano_node_tests $(PYTEST_ARGS) -n $(TEST_THREADS) --artifacts-base-dir=$(ARTIFACTS_DIR) --cli-coverage-dir=$(COVERAGE_DIR) --alluredir=$(ALLURE_DIR)
 

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -5,8 +5,10 @@ from typing import Any
 from typing import Generator
 
 import pytest
+from _pytest.config import Config
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempdirFactory
+from xdist import workermanage
 
 from cardano_node_tests.utils import clusterlib
 from cardano_node_tests.utils import devops_cluster
@@ -14,6 +16,9 @@ from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import parallel_run
 
 LOGGER = logging.getLogger(__name__)
+
+# make sure there's enough time to stop all cluster instances at the end of session
+workermanage.NodeManager.EXIT_TIMEOUT = 30
 
 
 def pytest_addoption(parser: Any) -> None:
@@ -51,19 +56,21 @@ def change_dir(tmp_path_factory: TempdirFactory) -> None:
 
 
 def _stop_all_cluster_instances(
-    tmp_path_factory: TempdirFactory, worker_id: str, request: FixtureRequest, pytest_tmp_dir: Path
+    tmp_path_factory: TempdirFactory, worker_id: str, pytest_config: Config, pytest_tmp_dir: Path
 ) -> None:
     """Stop all cluster instances after all tests are finished."""
     cluster_manager_obj = parallel_run.ClusterManager(
-        tmp_path_factory=tmp_path_factory, worker_id=worker_id, request=request
+        tmp_path_factory=tmp_path_factory, worker_id=worker_id, pytest_config=pytest_config
     )
     cluster_manager_obj._log("running `_stop_all_cluster_instances`")
+
     # stop all cluster instances
-    cluster_manager_obj.stop_all_clusters()
+    with helpers.ignore_interrupt():
+        cluster_manager_obj.stop_all_clusters()
     # save environment info for Allure
-    helpers.save_env_for_allure(request)
+    helpers.save_env_for_allure(pytest_config)
     # save artifacts
-    devops_cluster.save_artifacts(pytest_tmp_dir=pytest_tmp_dir, request=request)
+    devops_cluster.save_artifacts(pytest_tmp_dir=pytest_tmp_dir, pytest_config=pytest_config)
 
 
 @pytest.yield_fixture(scope="session")
@@ -75,13 +82,13 @@ def cluster_cleanup(
     if not worker_id or worker_id == "master":
         yield
         cluster_manager_obj = parallel_run.ClusterManager(
-            tmp_path_factory=tmp_path_factory, worker_id=worker_id, request=request
+            tmp_path_factory=tmp_path_factory, worker_id=worker_id, pytest_config=request.config
         )
         cluster_manager_obj.save_worker_cli_coverage()
         _stop_all_cluster_instances(
             tmp_path_factory=tmp_path_factory,
             worker_id=worker_id,
-            request=request,
+            pytest_config=request.config,
             pytest_tmp_dir=pytest_tmp_dir,
         )
         return
@@ -94,7 +101,7 @@ def cluster_cleanup(
 
     with helpers.FileLockIfXdist(f"{lock_dir}/{parallel_run.CLUSTER_LOCK}"):
         cluster_manager_obj = parallel_run.ClusterManager(
-            tmp_path_factory=tmp_path_factory, worker_id=worker_id, request=request
+            tmp_path_factory=tmp_path_factory, worker_id=worker_id, pytest_config=request.config
         )
         cluster_manager_obj.save_worker_cli_coverage()
 
@@ -103,7 +110,7 @@ def cluster_cleanup(
             _stop_all_cluster_instances(
                 tmp_path_factory=tmp_path_factory,
                 worker_id=worker_id,
-                request=request,
+                pytest_config=request.config,
                 pytest_tmp_dir=pytest_tmp_dir,
             )
 
@@ -122,7 +129,7 @@ def cluster_manager(
     request: FixtureRequest,
 ) -> Generator[parallel_run.ClusterManager, None, None]:
     cluster_manager_obj = parallel_run.ClusterManager(
-        tmp_path_factory=tmp_path_factory, worker_id=worker_id, request=request
+        tmp_path_factory=tmp_path_factory, worker_id=worker_id, pytest_config=request.config
     )
     yield cluster_manager_obj
     cluster_manager_obj.on_test_stop()

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -125,6 +125,7 @@ class TestBasic:
         assert cluster.epoch_length == 1200
         check_epoch_length(cluster)
 
+    @pytest.mark.run(order=2)
     @allure.link(helpers.get_vcs_link())
     def test_slot_length(self, cluster_slot_length: clusterlib.ClusterLib):
         """Test the *slotLength* configuration."""

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -17,11 +17,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 @pytest.fixture(scope="module")
@@ -107,6 +112,7 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
     assert epoch_no + 1 == cluster_obj.get_last_block_epoch()
 
 
+@pytest.mark.run(order=3)
 class TestBasic:
     """Basic tests for node configuration."""
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -21,11 +21,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 @pytest.fixture
@@ -71,6 +76,7 @@ def cluster_kes(
 pytestmark = pytest.mark.usefixtures("temp_dir")
 
 
+@pytest.mark.run(order=3)
 class TestKES:
     """Basic tests for KES period."""
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -76,10 +76,10 @@ def cluster_kes(
 pytestmark = pytest.mark.usefixtures("temp_dir")
 
 
-@pytest.mark.run(order=3)
 class TestKES:
     """Basic tests for KES period."""
 
+    @pytest.mark.run(order=3)
     @allure.link(helpers.get_vcs_link())
     def test_expired_kes(
         self,
@@ -109,6 +109,7 @@ class TestKES:
 
         assert cluster.get_last_block_slot_no() == init_slot, "Unexpected new slots"
 
+    @pytest.mark.run(order=1)
     @allure.link(helpers.get_vcs_link())
     def test_opcert_past_kes_period(
         self,
@@ -204,6 +205,7 @@ class TestKES:
                     stake_pool_id_dec in blocks_made
                 ), f"The pool '{pool_name}' has not produced blocks in epoch {this_epoch}"
 
+    @pytest.mark.run(order=2)
     @allure.link(helpers.get_vcs_link())
     def test_update_valid_opcert(
         self,

--- a/cardano_node_tests/tests/test_multisig.py
+++ b/cardano_node_tests/tests/test_multisig.py
@@ -17,11 +17,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 # use the "temp_dir" fixture for all tests automatically
@@ -122,7 +127,8 @@ class TestBasic:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_addr{i}" for i in range(20)], cluster_obj=cluster
+            *[f"multi_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(20)],
+            cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
 
@@ -381,7 +387,8 @@ class TestNegative:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_neg_addr{i}" for i in range(10)], cluster_obj=cluster
+            *[f"multi_neg_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(10)],
+            cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
 

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -28,11 +28,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 @pytest.fixture(scope="module")
@@ -1231,7 +1236,7 @@ class TestStakePool:
         )
 
 
-@pytest.mark.run(order=1)
+@pytest.mark.run(order=2)
 class TestPoolCost:
     """Tests for stake pool cost."""
 
@@ -1249,7 +1254,7 @@ class TestPoolCost:
 
         cluster = cluster_mincost
         rand_str = clusterlib.get_rand_str()
-        temp_template = f"{helpers.get_func_name()}_{rand_str}"
+        temp_template = f"{helpers.get_func_name()}_{rand_str}_ci{cluster_manager.cluster_instance}"
 
         pool_owners = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
@@ -1367,7 +1372,7 @@ class TestNegative:
 
         created_users = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
-            name_template="test_negative",
+            name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
             no_of_addr=2,
         )
         cluster_manager.cache.test_data[data_key] = created_users

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -228,6 +228,7 @@ class TestDelegateAddr:
             pool_name=pool_name,
         )
 
+    @pytest.mark.run(order=2)
     @allure.link(helpers.get_vcs_link())
     def test_deregister(
         self,

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -19,11 +19,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 @pytest.fixture
@@ -49,7 +54,7 @@ def pool_users(
 
     created_users = clusterlib_utils.create_pool_users(
         cluster_obj=cluster,
-        name_template="test_staking_pool_users",
+        name_template=f"test_staking_pool_users_ci{cluster_manager.cluster_instance}",
         no_of_addr=2,
     )
     cluster_manager.cache.test_data[data_key] = created_users
@@ -172,6 +177,7 @@ def _delegate_stake_addr(
     return pool_user
 
 
+@pytest.mark.run(order=3)
 class TestDelegateAddr:
     """Tests for address delegation to stake pools."""
 
@@ -664,6 +670,7 @@ class TestNegative:
         assert "StakeKeyNonZeroAccountBalanceDELEG" in str(excinfo.value)
 
 
+@pytest.mark.run(order=1)
 class TestRewards:
     """Tests for checking expected rewards."""
 

--- a/cardano_node_tests/tests/test_transaction_fees.py
+++ b/cardano_node_tests/tests/test_transaction_fees.py
@@ -20,11 +20,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 # use the "temp_dir" fixture for all tests automatically
@@ -47,7 +52,9 @@ class TestFee:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            "addr_test_fee0", "addr_test_fee1", cluster_obj=cluster
+            f"addr_test_fee_ci{cluster_manager.cluster_instance}_0",
+            f"addr_test_fee_ci{cluster_manager.cluster_instance}_1",
+            cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
 
@@ -201,7 +208,7 @@ class TestExpectedFees:
 
         created_users = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
-            name_template="test_expected_fees",
+            name_template=f"test_expected_fees_ci{cluster_manager.cluster_instance}",
             no_of_addr=201,
         )
         cluster_manager.cache.test_data[data_key] = created_users

--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -34,11 +34,16 @@ ADDR_ALPHABET = list(f"{string.ascii_lowercase}{string.digits}")
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 # use the "temp_dir" fixture for all tests automatically
@@ -61,7 +66,9 @@ class TestBasic:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            "addr_basic0", "addr_basic1", cluster_obj=cluster
+            f"addr_basic_ci{cluster_manager.cluster_instance}_0",
+            f"addr_basic_ci{cluster_manager.cluster_instance}_1",
+            cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
 
@@ -71,7 +78,6 @@ class TestBasic:
             cluster_obj=cluster,
             faucet_data=cluster_manager.cache.addrs_data["user1"],
         )
-
         return addrs
 
     @pytest.mark.parametrize("amount", (1, 10, 200, 2000, 100_000))
@@ -287,7 +293,7 @@ class TestMultiInOut:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_in_out_addr{i}" for i in range(201)],
+            *[f"multi_in_out_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(201)],
             cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
@@ -550,7 +556,9 @@ class TestNotBalanced:
             return cached_value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            "addr_not_balanced0", "addr_not_balanced1", cluster_obj=cluster
+            f"addr_not_balanced_ci{cluster_manager.cluster_instance}_0",
+            f"addr_not_balanced_ci{cluster_manager.cluster_instance}_1",
+            cluster_obj=cluster,
         )
         cluster_manager.cache.test_data[data_key] = addrs
 
@@ -701,7 +709,7 @@ class TestNegative:
 
         created_users = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
-            name_template="test_negative",
+            name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
             no_of_addr=2,
         )
         cluster_manager.cache.test_data[data_key] = created_users
@@ -1218,7 +1226,7 @@ class TestMetadata:
             return cached_value  # type: ignore
 
         addr = clusterlib_utils.create_payment_addr_records(
-            "addr_test_metadata0", cluster_obj=cluster
+            f"addr_test_metadata_ci{cluster_manager.cluster_instance}_0", cluster_obj=cluster
         )[0]
         cluster_manager.cache.test_data[data_key] = addr
 

--- a/cardano_node_tests/tests/test_update_proposal.py
+++ b/cardano_node_tests/tests/test_update_proposal.py
@@ -15,11 +15,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def temp_dir(tmp_path_factory: TempdirFactory):
-    """Create a temporary dir and change to it."""
-    tmp_path = Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__)))
-    with helpers.change_cwd(tmp_path):
-        yield tmp_path
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
 
 
 @pytest.fixture
@@ -31,6 +36,7 @@ def cluster_update_proposal(cluster_manager: parallel_run.ClusterManager) -> clu
 pytestmark = pytest.mark.usefixtures("temp_dir")
 
 
+@pytest.mark.run(order=3)
 class TestBasic:
     """Basic tests for update proposal."""
 

--- a/cardano_node_tests/utils/cluster_instances.py
+++ b/cardano_node_tests/utils/cluster_instances.py
@@ -1,0 +1,163 @@
+"""Functionality for setting up new DevOps cluster instance."""
+import logging
+import os
+import re
+from pathlib import Path
+from typing import List
+from typing import NamedTuple
+
+from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils.types import FileType
+
+LOGGER = logging.getLogger(__name__)
+
+PORTS_OFFSET = 500
+
+
+class InstanceFiles(NamedTuple):
+    start_script: Path
+    stop_script: Path
+    dir: Path
+
+
+class InstancePorts(NamedTuple):
+    webserver: int
+    bft1: int
+    pool1: int
+    pool2: int
+    supervisor: int
+    ekg: int
+    prometheus: int
+    offset: int
+
+
+def _get_nix_paths(infile: Path, search_str: str) -> List[Path]:
+    """Return path of nix files."""
+    with open(infile) as in_fp:
+        content = in_fp.read()
+
+    nix_files = re.findall(f"/nix/store/({search_str})", content)
+    nix_store = Path("/nix/store")
+    nix_paths = [nix_store / c for c in nix_files]
+
+    return nix_paths
+
+
+def get_instance_ports(instance_num: int) -> InstancePorts:
+    """Return ports mapping for given cluster instance."""
+    offset = PORTS_OFFSET + instance_num
+    base = 3000 + offset
+
+    ports = InstancePorts(
+        webserver=base,
+        bft1=base + 1,
+        pool1=base + 2,
+        pool2=base + 3,
+        supervisor=10001 + offset,
+        ekg=12588 + instance_num,
+        prometheus=12898 + instance_num,
+        offset=offset,
+    )
+    return ports
+
+
+def _reconfigure_file(infile: Path, destdir: Path, instance_num: int) -> Path:
+    """Reconfigure scripts and config files for operating on new cluster instance.
+
+    Recursive function.
+    """
+    fname = infile.name
+    destname = fname
+
+    with open(infile) as in_fp:
+        content = in_fp.read()
+
+    instance_ports = get_instance_ports(instance_num)
+    new_content = content.replace("/state-cluster", f"/state-cluster{instance_num}")
+    new_content = new_content.replace("3000", str(3000 + instance_ports.offset))
+    new_content = new_content.replace("9001", str(instance_ports.supervisor))
+    new_content = new_content.replace(
+        "supervisorctl ", f"supervisorctl -s http://127.0.0.1:{instance_ports.supervisor} "
+    )
+
+    if fname == "start-cluster":
+        # reconfigure path to supervisor config
+        supervisor_conf = _get_nix_paths(infile, r"[^/]+-supervisor\.conf")[0]
+        dest_supervisor_conf = (destdir / supervisor_conf.name).resolve()
+        new_content = new_content.replace(str(supervisor_conf), str(dest_supervisor_conf))
+        _reconfigure_file(infile=supervisor_conf, destdir=destdir, instance_num=instance_num)
+
+        # reconfigure path to node.json file
+        _node_json = re.search(r"cp (.*node\.json) \./state-cluster[0-9]?/config.json", new_content)
+        if not _node_json:
+            raise RuntimeError("Failed to find `node.json` in the `start-cluster` script.")
+        node_json = Path(_node_json.group(1))
+        dest_node_json = (destdir / node_json.name).resolve()
+        new_content = new_content.replace(str(node_json), str(dest_node_json))
+        _reconfigure_file(infile=node_json, destdir=destdir, instance_num=instance_num)
+    elif fname.endswith("-supervisor.conf"):
+        # reconfigure supervisor settings
+        node_commands = _get_nix_paths(infile, r"[^/]+-cardano-node")
+        for ncmd in node_commands:
+            dest_ncmd = (destdir / ncmd.name).resolve()
+            new_content = new_content.replace(str(ncmd), str(dest_ncmd))
+            _reconfigure_file(infile=ncmd, destdir=destdir, instance_num=instance_num)
+    elif fname.endswith("-cardano-node"):
+        # reconfigure path to topology config file
+        topology_yaml = _get_nix_paths(infile, r"[^/]+-topology\.yaml")[0]
+        dest_topology_yaml = (destdir / topology_yaml.name).resolve()
+        new_content = new_content.replace(str(topology_yaml), str(dest_topology_yaml))
+        # reconfigure ports in topology config
+        _reconfigure_file(infile=topology_yaml, destdir=destdir, instance_num=instance_num)
+    elif fname.endswith("node.json"):
+        # reconfigure metrics ports in node.json
+        new_content = new_content.replace("12788", str(instance_ports.ekg))
+        new_content = new_content.replace("12798", str(instance_ports.prometheus))
+
+    dest_file = destdir / destname
+    with open(dest_file, "w") as out_fp:
+        out_fp.write(new_content)
+
+    # make files without extension executable
+    if "." not in fname:
+        dest_file.chmod(0o755)
+
+    return dest_file
+
+
+def _get_cardano_node_socket_path(instance_num: int) -> Path:
+    """Return path to socket file in the given cluster instance."""
+    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).resolve()
+    state_cluster_dirname = f"state-cluster{instance_num}"
+    state_cluster = socket_path.parent.parent / state_cluster_dirname
+    new_socket_path = state_cluster / socket_path.name
+    return new_socket_path
+
+
+def set_cardano_node_socket_path(instance_num: int) -> None:
+    """Set the `CARDANO_NODE_SOCKET_PATH` env variable for the given cluster instance."""
+    socket_path = _get_cardano_node_socket_path(instance_num)
+    os.environ["CARDANO_NODE_SOCKET_PATH"] = str(socket_path)
+
+
+def prepare_files(
+    destdir: FileType,
+    instance_num: int,
+    start_script: FileType = "",
+    stop_script: FileType = "",
+) -> InstanceFiles:
+    """Prepare files for starting and stoping cluster instance."""
+    start_script = (
+        Path(start_script or helpers.get_cmd_path("start-cluster")).expanduser().resolve()
+    )
+    stop_script = Path(stop_script or helpers.get_cmd_path("stop-cluster")).expanduser().resolve()
+    destdir = Path(destdir).expanduser().resolve()
+
+    new_start_script = _reconfigure_file(
+        infile=start_script, destdir=destdir, instance_num=instance_num
+    )
+    new_stop_script = _reconfigure_file(
+        infile=stop_script, destdir=destdir, instance_num=instance_num
+    )
+
+    return InstanceFiles(start_script=new_start_script, stop_script=new_stop_script, dir=destdir)

--- a/cardano_node_tests/utils/clusterlib.py
+++ b/cardano_node_tests/utils/clusterlib.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import json
 import logging
+import os
 import random
 import string
 import subprocess
@@ -254,10 +255,13 @@ class ClusterLib:
                 break
 
             stderr_dec = stderr.decode()
-            err_msg = f"An error occurred running a CLI command `{cmd_str}`: {stderr_dec}"
+            err_msg = (
+                f"An error occurred running a CLI command `{cmd_str}` on path "
+                f"`{os.getcwd()}`: {stderr_dec}"
+            )
             if "resource exhausted" in stderr_dec:
                 LOGGER.error(err_msg)
-                time.sleep(1)
+                time.sleep(0.4)
                 continue
             raise CLIError(err_msg)
         else:

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -7,6 +7,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from _pytest.config import Config
 from _pytest.fixtures import FixtureRequest
 
 from cardano_node_tests.utils import clusterlib
@@ -415,11 +416,9 @@ def update_params(
             )
 
 
-def save_cli_coverage(
-    cluster_obj: clusterlib.ClusterLib, request: FixtureRequest
-) -> Optional[Path]:
+def save_cli_coverage(cluster_obj: clusterlib.ClusterLib, pytest_config: Config) -> Optional[Path]:
     """Save CLI coverage info."""
-    cli_coverage_dir = request.config.getoption("--cli-coverage-dir")
+    cli_coverage_dir = pytest_config.getoption("--cli-coverage-dir")
     if not (cli_coverage_dir and cluster_obj.cli_coverage):
         return None
 

--- a/cardano_node_tests/utils/devops_cluster.py
+++ b/cardano_node_tests/utils/devops_cluster.py
@@ -11,7 +11,7 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 
-from _pytest.fixtures import FixtureRequest
+from _pytest.config import Config
 
 from cardano_node_tests.utils import cluster_instances
 from cardano_node_tests.utils import clusterlib
@@ -288,9 +288,9 @@ def save_collected_artifacts(pytest_tmp_dir: Path, artifacts_dir: Path) -> Optio
     return dest_dir
 
 
-def save_artifacts(pytest_tmp_dir: Path, request: FixtureRequest) -> None:
+def save_artifacts(pytest_tmp_dir: Path, pytest_config: Config) -> None:
     """Save tests and cluster artifacts."""
-    artifacts_base_dir = request.config.getoption("--artifacts-base-dir")
+    artifacts_base_dir = pytest_config.getoption("--artifacts-base-dir")
     if not artifacts_base_dir:
         return
 

--- a/cardano_node_tests/utils/devops_cluster.py
+++ b/cardano_node_tests/utils/devops_cluster.py
@@ -1,3 +1,4 @@
+"""Functionality for interacting with the DevOps cluster."""
 import logging
 import os
 import pickle
@@ -12,6 +13,7 @@ from typing import Optional
 
 from _pytest.fixtures import FixtureRequest
 
+from cardano_node_tests.utils import cluster_instances
 from cardano_node_tests.utils import clusterlib
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import helpers
@@ -34,19 +36,20 @@ def get_cluster_env() -> dict:
     state_dir = socket_path.parent
     work_dir = state_dir.parent
     repo_dir = Path(os.environ.get("CARDANO_NODE_REPO_PATH") or work_dir)
+    instance_num = int(state_dir.name.replace("state-cluster", "") or 0)
 
     cluster_env = {
         "socket_path": socket_path,
         "state_dir": state_dir,
         "repo_dir": repo_dir,
         "work_dir": work_dir,
+        "instance_num": instance_num,
     }
     return cluster_env
 
 
-def start_cluster(cmd: str = "") -> clusterlib.ClusterLib:
+def start_cluster(cmd: str) -> clusterlib.ClusterLib:
     """Start cluster."""
-    cmd = cmd or "start-cluster"
     LOGGER.info(f"Starting cluster with `{cmd}`.")
     cluster_env = get_cluster_env()
     helpers.run_shell_command(cmd, workdir=cluster_env["work_dir"])
@@ -55,12 +58,12 @@ def start_cluster(cmd: str = "") -> clusterlib.ClusterLib:
     return clusterlib.ClusterLib(cluster_env["state_dir"])
 
 
-def stop_cluster() -> None:
+def stop_cluster(cmd: str) -> None:
     """Stop cluster."""
-    LOGGER.info("Stopping cluster.")
+    LOGGER.info(f"Stopping cluster with `{cmd}`.")
     cluster_env = get_cluster_env()
     try:
-        helpers.run_shell_command("stop-cluster", workdir=cluster_env["work_dir"])
+        helpers.run_shell_command(cmd, workdir=cluster_env["work_dir"])
     except Exception as exc:
         LOGGER.debug(f"Failed to stop cluster: {exc}")
 
@@ -69,8 +72,12 @@ def restart_node(node_name: str) -> None:
     """Restart single node of the running cluster."""
     LOGGER.info(f"Restarting cluster node `{node_name}`.")
     cluster_env = get_cluster_env()
+    supervisor_port = cluster_instances.get_instance_ports(cluster_env["instance_num"]).supervisor
     try:
-        helpers.run_command(f"supervisorctl restart {node_name}", workdir=cluster_env["work_dir"])
+        helpers.run_command(
+            f"supervisorctl -s http://localhost:{supervisor_port} restart {node_name}",
+            workdir=cluster_env["work_dir"],
+        )
     except Exception as exc:
         LOGGER.debug(f"Failed to restart cluster node `{node_name}`: {exc}")
 
@@ -130,17 +137,24 @@ def setup_test_addrs(cluster_obj: clusterlib.ClusterLib, destination_dir: FileTy
     """Create addresses and their keys for usage in tests."""
     destination_dir = Path(destination_dir).expanduser()
     destination_dir.mkdir(parents=True, exist_ok=True)
+    cluster_env = get_cluster_env()
+    instance_num = cluster_env["instance_num"]
     addrs = ("user1",)
 
     LOGGER.debug("Creating addresses and keys for tests.")
     addrs_data: Dict[str, Dict[str, Any]] = {}
     for addr_name in addrs:
-        stake = cluster_obj.gen_stake_addr_and_keys(name=addr_name, destination_dir=destination_dir)
+        addr_name_instance = f"{addr_name}_ci{instance_num}"
+        stake = cluster_obj.gen_stake_addr_and_keys(
+            name=addr_name_instance, destination_dir=destination_dir
+        )
         payment = cluster_obj.gen_payment_addr_and_keys(
-            name=addr_name, stake_vkey_file=stake.vkey_file, destination_dir=destination_dir
+            name=addr_name_instance,
+            stake_vkey_file=stake.vkey_file,
+            destination_dir=destination_dir,
         )
         stake_addr_registration_cert = cluster_obj.gen_stake_addr_registration_cert(
-            addr_name=addr_name,
+            addr_name=addr_name_instance,
             stake_vkey_file=stake.vkey_file,
             destination_dir=destination_dir,
         )
@@ -161,7 +175,6 @@ def setup_test_addrs(cluster_obj: clusterlib.ClusterLib, destination_dir: FileTy
 
     pools_data = load_devops_pools_data(cluster_obj)
 
-    cluster_env = get_cluster_env()
     data_file = Path(cluster_env["state_dir"]) / ADDR_DATA
     with open(data_file, "wb") as out_data:
         pickle.dump({**addrs_data, **pools_data}, out_data)
@@ -191,7 +204,7 @@ def copy_startup_files(destdir: Path) -> StartupFiles:
     for fpath in node_config_paths:
         conf_name_orig = str(fpath)
         if conf_name_orig.endswith("node.json"):
-            conf_name = "config.json"
+            conf_name = "node.json"
         elif conf_name_orig.endswith("genesis.spec.json"):
             conf_name = "genesis.spec.json"
         else:
@@ -208,7 +221,7 @@ def copy_startup_files(destdir: Path) -> StartupFiles:
             new_str=str(dest_file),
         )
 
-    config_json = destdir / "config.json"
+    config_json = destdir / "node.json"
     genesis_spec_json = destdir / "genesis.spec.json"
     assert config_json.exists() and genesis_spec_json.exists()
 
@@ -225,7 +238,7 @@ def load_addrs_data() -> dict:
         return pickle.load(in_data)  # type: ignore
 
 
-def save_cluster_artifacts(artifacts_dir: Path) -> Optional[Path]:
+def save_cluster_artifacts(artifacts_dir: Path, clean: bool = False) -> Optional[Path]:
     """Save cluster artifacts."""
     cluster_env = get_cluster_env()
     if not cluster_env.get("state_dir"):
@@ -242,11 +255,21 @@ def save_cluster_artifacts(artifacts_dir: Path) -> Optional[Path]:
     for fpath in files_list:
         shutil.copy(fpath, dest_dir)
     for dname in dirs_to_copy:
-        shutil.copytree(
-            state_dir / dname, dest_dir / dname, symlinks=True, ignore_dangling_symlinks=True
-        )
+        src_dir = state_dir / dname
+        if not src_dir.exists():
+            continue
+        shutil.copytree(src_dir, dest_dir / dname, symlinks=True, ignore_dangling_symlinks=True)
+
+    if not os.listdir(dest_dir):
+        dest_dir.rmdir()
+        return None
 
     LOGGER.info(f"Cluster artifacts saved to '{dest_dir}'.")
+
+    if clean:
+        LOGGER.info(f"Cleaning cluster artifacts in '{state_dir}'.")
+        shutil.rmtree(state_dir, ignore_errors=True)
+
     return dest_dir
 
 

--- a/cardano_node_tests/utils/parallel_run.py
+++ b/cardano_node_tests/utils/parallel_run.py
@@ -359,7 +359,9 @@ class ClusterManager:
             if errors:
                 logfiles.report_artifacts_errors(errors)
 
-    def _get_marked_tests_status(self, cache: dict, instance_num: int) -> MarkedTestsStatus:
+    def _get_marked_tests_status(
+        self, cache: Dict[int, MarkedTestsStatus], instance_num: int
+    ) -> MarkedTestsStatus:
         """Return marked tests status for cluster instance."""
         if instance_num not in cache:
             cache[instance_num] = MarkedTestsStatus()
@@ -460,7 +462,7 @@ class ClusterManager:
         mark_start_here = False
         first_iteration = True
         sleep_delay = 1
-        marked_tests_cache: dict = {}
+        marked_tests_cache: Dict[int, MarkedTestsStatus] = {}
 
         if start_cmd:
             if not (singleton or mark):

--- a/cardano_node_tests/utils/parallel_run.py
+++ b/cardano_node_tests/utils/parallel_run.py
@@ -1,9 +1,12 @@
+"""Functionality for parallel execution of tests on DevOps cluster instances."""
 import contextlib
 import dataclasses
 import datetime
 import os
 import random
+import time
 from pathlib import Path
+from typing import Dict
 from typing import Generator
 from typing import Optional
 
@@ -11,6 +14,7 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempdirFactory
 
+from cardano_node_tests.utils import cluster_instances
 from cardano_node_tests.utils import clusterlib
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import devops_cluster
@@ -31,6 +35,23 @@ TEST_RUNNING_GLOB = ".test_running"
 TEST_CURR_MARK_GLOB = ".curr_test_mark"
 TEST_MARK_STARTING_GLOB = ".starting_marked_tests"
 
+WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", 1))
+CLUSTERS_COUNT = WORKERS_COUNT if WORKERS_COUNT <= 9 else 9
+CLUSTER_DIR_TEMPLATE = "cluster"
+
+
+def _kill_supervisor(instance_num: int) -> None:
+    """Kill supervisor process."""
+    port = f":{cluster_instances.get_instance_ports(instance_num).supervisor}"
+    netstat = helpers.run_command("netstat -plnt").decode().splitlines()
+    for line in netstat:
+        if port not in line:
+            continue
+        line = line.replace("  ", " ").strip()
+        pid = line.split(" ")[-1].split("/")[0]
+        os.kill(int(pid), 15)
+        return
+
 
 @dataclasses.dataclass
 class ClusterManagerCache:
@@ -40,11 +61,17 @@ class ClusterManagerCache:
     last_checksum: str = ""
 
 
+@dataclasses.dataclass
+class MarkedTestsStatus:
+    last_seen_mark: str = ""
+    no_marked_tests_iter: int = 0
+
+
 class ClusterManager:
-    manager_cache = ClusterManagerCache()
+    manager_cache: Dict[int, ClusterManagerCache] = {}
 
     @classmethod
-    def get_cache(cls) -> ClusterManagerCache:
+    def get_cache(cls) -> Dict[int, ClusterManagerCache]:
         return cls.manager_cache
 
     def __init__(
@@ -60,16 +87,48 @@ class ClusterManager:
         if self.is_xdist:
             self.lock_dir = self.pytest_tmp_dir.parent
             self.range_num = 5
+            self.num_of_instances = CLUSTERS_COUNT
         else:
             self.lock_dir = self.pytest_tmp_dir
             self.range_num = 1
+            self.num_of_instances = 1
 
         self.cluster_lock = f"{self.lock_dir}/{CLUSTER_LOCK}"
         self.lock_log = self._init_log()
 
+        self._cluster_instance = -1
+
+    @property
+    def cluster_instance(self) -> int:
+        if self._cluster_instance == -1:
+            raise RuntimeError("Cluster instance not set.")
+        return self._cluster_instance
+
     @property
     def cache(self) -> ClusterManagerCache:
-        return self.get_cache()
+        _cache = self.get_cache()
+        instance_cache = _cache.get(self.cluster_instance)
+        if not instance_cache:
+            instance_cache = ClusterManagerCache()
+            _cache[self.cluster_instance] = instance_cache
+        return instance_cache
+
+    @property
+    def instance_dir(self) -> Path:
+        instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{self.cluster_instance}"
+        return instance_dir
+
+    @property
+    def ports(self) -> cluster_instances.InstancePorts:
+        """Return port mappings for current cluster instance."""
+        return cluster_instances.get_instance_ports(self.cluster_instance)
+
+    def _create_startup_files_dir(self, instance_num: int) -> Path:
+        instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{instance_num}"
+        rand_str = clusterlib.get_rand_str(8)
+        startup_files_dir = instance_dir / "startup_files" / rand_str
+        startup_files_dir.mkdir(exist_ok=True, parents=True)
+        return startup_files_dir
 
     def _init_log(self) -> Path:
         """Return path to run log file."""
@@ -101,22 +160,23 @@ class ClusterManager:
             with open(self.lock_log, "a") as logfile:
                 logfile.write(f"{datetime.datetime.now()} on {self.worker_id}: {msg}\n")
 
-    def _is_restart_needed(self) -> bool:
+    def _is_restart_needed(self, instance_num: int) -> bool:
         """Check if it is necessary to restart cluster."""
-        if not (self.lock_dir / SESSION_RUNNING_FILE).exists():
+        instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{instance_num}"
+        if not (instance_dir / SESSION_RUNNING_FILE).exists():
             return True
-        if list(self.lock_dir.glob(f"{RESTART_NEEDED_GLOB}_*")):
+        if list(instance_dir.glob(f"{RESTART_NEEDED_GLOB}_*")):
             return True
         return False
 
-    def _save_cluster_artifacts(self) -> None:
+    def _save_cluster_artifacts(self, clean: bool = False) -> None:
         """Save cluster artifacts (logs, certs, etc.) to pytest temp dir."""
-        self._log("called `_save_cluster_artifacts`")
+        self._log(f"c{self.cluster_instance}: called `_save_cluster_artifacts`")
         cluster_obj = self.cache.cluster_obj
         if not cluster_obj:
             return
 
-        devops_cluster.save_cluster_artifacts(artifacts_dir=self.pytest_tmp_dir)
+        devops_cluster.save_cluster_artifacts(artifacts_dir=self.pytest_tmp_dir, clean=clean)
 
     def save_cli_coverage(self) -> None:
         """Save CLI coverage info collected by this `cluster_obj` instance."""
@@ -127,15 +187,60 @@ class ClusterManager:
 
         clusterlib_utils.save_cli_coverage(cluster_obj, self.request)
 
-    def _restart(self, start_cmd: str = "") -> clusterlib.ClusterLib:
-        """Restart cluster."""
-        self._log(f"called `_restart`, start_cmd='{start_cmd}'")
-        self.stop()
+    def save_worker_cli_coverage(self) -> None:
+        """Save CLI coverage info collected by this pytest worker."""
+        self._log("called `save_worker_cli_coverage`")
+        worker_cache = self.get_cache()
+        for cache_instance in worker_cache.values():
+            cluster_obj = cache_instance.cluster_obj
+            if not cluster_obj:
+                continue
 
-        try:
-            cluster_obj = devops_cluster.start_cluster(cmd=start_cmd)
-        except Exception:
-            self._log("failed to start cluster, exiting pytest")
+            clusterlib_utils.save_cli_coverage(cluster_obj, self.request)
+
+    def _restart(  # noqa: C901
+        self, start_cmd: str = "", stop_cmd: str = ""
+    ) -> clusterlib.ClusterLib:
+        """Restart cluster."""
+        self._log(
+            f"c{self.cluster_instance}: called `_restart`, start_cmd='{start_cmd}', "
+            f"stop_cmd='{stop_cmd}'"
+        )
+
+        startup_files = cluster_instances.prepare_files(
+            destdir=self._create_startup_files_dir(self.cluster_instance),
+            instance_num=self.cluster_instance,
+            start_script=start_cmd,
+            stop_script=stop_cmd,
+        )
+
+        self._log(
+            f"c{self.cluster_instance}: in `_restart`, new files "
+            f"start_cmd='{startup_files.start_script}', "
+            f"stop_cmd='{startup_files.stop_script}'"
+        )
+
+        for i in range(3):
+            if i > 0:
+                self._log(f"c{self.cluster_instance}: failed to start cluster, retrying")
+                time.sleep(0.2)
+
+            self.stop_cluster(cmd=str(startup_files.stop_script))
+            try:
+                _kill_supervisor(self.cluster_instance)
+            except Exception:
+                pass
+
+            try:
+                cluster_obj = devops_cluster.start_cluster(cmd=str(startup_files.start_script))
+            except Exception:
+                pass
+            else:
+                break
+        else:
+            if helpers.IS_XDIST:
+                # just leave this instance unusable
+                raise RuntimeError("Failed to start cluster")
             pytest.exit(msg="Failed to start cluster", returncode=1)
 
         # setup faucet addresses
@@ -143,29 +248,48 @@ class ClusterManager:
         devops_cluster.setup_test_addrs(cluster_obj, tmp_path)
 
         # remove status files that are no longer valid after restart
-        for f in self.lock_dir.glob(f"{RESTART_IN_PROGRESS_GLOB}_*"):
+        for f in self.instance_dir.glob(f"{RESTART_IN_PROGRESS_GLOB}_*"):
             os.remove(f)
-        for f in self.lock_dir.glob(f"{RESTART_NEEDED_GLOB}_*"):
+        for f in self.instance_dir.glob(f"{RESTART_NEEDED_GLOB}_*"):
             os.remove(f)
 
         # create file that indicates that the session is running
-        session_running_file = self.lock_dir / SESSION_RUNNING_FILE
+        session_running_file = self.instance_dir / SESSION_RUNNING_FILE
         if not session_running_file.exists():
             open(session_running_file, "a").close()
 
         return cluster_obj
 
-    def stop(self) -> None:
-        """Stop cluster."""
-        self._log("called `stop`")
-        devops_cluster.stop_cluster()
-        self._save_cluster_artifacts()
+    def stop_cluster(self, cmd: str) -> None:
+        """Stop cluster instance."""
+        self._log(f"called `stop_cluster`, cmd='{cmd}'")
+        devops_cluster.stop_cluster(cmd=cmd)
+        self._save_cluster_artifacts(clean=True)
+
+    def stop_all_clusters(self) -> None:
+        """Stop all cluster instances."""
+        self._log("called `stop_all_clusters`")
+        for instance_num in range(self.num_of_instances):
+            instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{instance_num}"
+            if not (instance_dir / SESSION_RUNNING_FILE).exists():
+                continue
+
+            startup_files = cluster_instances.prepare_files(
+                destdir=self._create_startup_files_dir(instance_num),
+                instance_num=instance_num,
+            )
+            cluster_instances.set_cardano_node_socket_path(instance_num)
+            self._log(
+                f"stopping cluster instance {instance_num} with `{startup_files.stop_script}`"
+            )
+            devops_cluster.stop_cluster(cmd=str(startup_files.stop_script))
+            devops_cluster.save_cluster_artifacts(artifacts_dir=self.pytest_tmp_dir, clean=True)
 
     def set_needs_restart(self) -> None:
         """Indicate that the cluster needs restart."""
         with helpers.FileLockIfXdist(self.cluster_lock):
-            self._log("called `set_needs_restart`")
-            open(self.lock_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a").close()
+            self._log(f"c{self.cluster_instance}: called `set_needs_restart`")
+            open(self.instance_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a").close()
 
     @contextlib.contextmanager
     def restart_on_failure(self) -> Generator:
@@ -176,51 +300,57 @@ class ClusterManager:
             self.set_needs_restart()
             raise
 
-    def _on_marked_test_stop(self) -> None:
+    def _on_marked_test_stop(self, instance_num: int) -> None:
         """Perform actions after marked tests are finished."""
-        self._log("in `_on_marked_test_stop`")
+        self._log(f"c{instance_num}: in `_on_marked_test_stop`")
+        instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{instance_num}"
 
         # set cluster to be restarted if needed
-        restart_after_mark_files = list(self.lock_dir.glob(f"{RESTART_AFTER_MARK_GLOB}_*"))
+        restart_after_mark_files = list(instance_dir.glob(f"{RESTART_AFTER_MARK_GLOB}_*"))
         if restart_after_mark_files:
             for f in restart_after_mark_files:
                 os.remove(f)
-            self._log("in `_on_marked_test_stop`, creating 'restart needed' file")
-            open(self.lock_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a").close()
+            self._log(
+                f"c{instance_num}: in `_on_marked_test_stop`, " "creating 'restart needed' file"
+            )
+            open(instance_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a").close()
 
         # remove file that indicates that tests with the mark are running
-        test_curr_mark = list(self.lock_dir.glob(f"{TEST_CURR_MARK_GLOB}_*"))
+        test_curr_mark = list(instance_dir.glob(f"{TEST_CURR_MARK_GLOB}_*"))
         if test_curr_mark:
             os.remove(test_curr_mark[0])
 
     def on_test_stop(self) -> None:
         """Perform actions after the test finished."""
+        if self._cluster_instance == -1:
+            return
+
         with helpers.FileLockIfXdist(self.cluster_lock):
-            self._log("called `on_test_stop`")
+            self._log(f"c{self.cluster_instance}: called `on_test_stop`")
 
             # remove resource locking files created by the worker
             resource_locking_files = list(
-                self.lock_dir.glob(f"{RESOURCE_LOCKED_GLOB}_*_{self.worker_id}")
+                self.instance_dir.glob(f"{RESOURCE_LOCKED_GLOB}_*_{self.worker_id}")
             )
             for f in resource_locking_files:
                 os.remove(f)
 
             # remove "resource in use" files created by the worker
             resource_in_use_files = list(
-                self.lock_dir.glob(f"{RESOURCE_IN_USE_GLOB}_*_{self.worker_id}")
+                self.instance_dir.glob(f"{RESOURCE_IN_USE_GLOB}_*_{self.worker_id}")
             )
             for f in resource_in_use_files:
                 os.remove(f)
 
             # remove file that indicates that a test is running on the worker
             try:
-                os.remove(self.lock_dir / f"{TEST_RUNNING_GLOB}_{self.worker_id}")
+                os.remove(self.instance_dir / f"{TEST_RUNNING_GLOB}_{self.worker_id}")
             except FileNotFoundError:
                 pass
 
             # remove file that indicates the test was singleton
             try:
-                os.remove(self.lock_dir / TEST_SINGLETON_FILE)
+                os.remove(self.instance_dir / TEST_SINGLETON_FILE)
             except FileNotFoundError:
                 pass
 
@@ -228,6 +358,87 @@ class ClusterManager:
             errors = logfiles.search_cluster_artifacts()
             if errors:
                 logfiles.report_artifacts_errors(errors)
+
+    def _get_marked_tests_status(self, cache: dict, instance_num: int) -> MarkedTestsStatus:
+        """Return marked tests status for cluster instance."""
+        if instance_num not in cache:
+            cache[instance_num] = MarkedTestsStatus()
+        marked_tests_status: MarkedTestsStatus = cache[instance_num]
+        return marked_tests_status
+
+    def _update_marked_tests(
+        self,
+        marked_tests_status: MarkedTestsStatus,
+        active_mark_name: str,
+        started_tests: list,
+        instance_num: int,
+    ) -> None:
+        if started_tests or marked_tests_status.last_seen_mark != active_mark_name:
+            marked_tests_status.no_marked_tests_iter = 0
+        else:
+            marked_tests_status.no_marked_tests_iter += 1
+
+        # check if there is a stale mark status file
+        if marked_tests_status.no_marked_tests_iter >= 10:
+            self._log(
+                f"c{instance_num}: no marked tests running for a while, "
+                "cleaning the mark status file"
+            )
+            self._on_marked_test_stop(instance_num)
+
+        marked_tests_status.last_seen_mark = active_mark_name
+
+    def _are_resources_usable(
+        self, resources: UnpackableSequence, instance_dir: Path, instance_num: int
+    ) -> bool:
+        """Check if resources are locked or in use."""
+        for res in resources:
+            res_locked = list(instance_dir.glob(f"{RESOURCE_LOCKED_GLOB}_{res}_*"))
+            if res_locked:
+                self._log(f"c{instance_num}: resource '{res}' locked, cannot start")
+                break
+            res_used = list(instance_dir.glob(f"{RESOURCE_IN_USE_GLOB}_{res}_*"))
+            if res_used:
+                self._log(f"c{instance_num}: resource '{res}' in use, " "cannot lock and start")
+                break
+        else:
+            self._log(
+                f"c{instance_num}: none of the resources in '{resources}' "
+                "locked or in use, can start and lock"
+            )
+            return True
+        return False
+
+    def _are_resources_locked(
+        self, resources: UnpackableSequence, instance_dir: Path, instance_num: int
+    ) -> bool:
+        """Check if resources are locked."""
+        res_locked = []
+        for res in resources:
+            res_locked = list(instance_dir.glob(f"{RESOURCE_LOCKED_GLOB}_{res}_*"))
+            if res_locked:
+                self._log(f"c{instance_num}: resource '{res}' locked, cannot start")
+                break
+
+        if not res_locked:
+            self._log(
+                f"c{instance_num}: none of the resources in '{resources}' locked, " "can start"
+            )
+        return bool(res_locked)
+
+    def _reload_cluster_obj(self, state_dir: Path) -> None:
+        """Realod cluster data if necessary."""
+        addrs_data_checksum = helpers.checksum(state_dir / devops_cluster.ADDR_DATA)
+        if addrs_data_checksum == self.cache.last_checksum:
+            return
+
+        # save CLI coverage collected by the old `cluster_obj` instance
+        self.save_cli_coverage()
+        # replace the old `cluster_obj` instance and reload data
+        self.cache.cluster_obj = clusterlib.ClusterLib(state_dir)
+        self.cache.test_data = {}
+        self.cache.addrs_data = devops_cluster.load_addrs_data()
+        self.cache.last_checksum = addrs_data_checksum
 
     def get(  # noqa: C901
         self,
@@ -243,22 +454,20 @@ class ClusterManager:
         It checks current conditions and waits if the conditions don't allow to start the test
         right away.
         """
-        # pylint: disable=too-many-statements,too-many-branches
+        # pylint: disable=too-many-statements,too-many-branches,too-many-locals
+        selected_instance = -1
         restart_here = False
         mark_start_here = False
         first_iteration = True
         sleep_delay = 1
-        no_marked_tests_iter = 0
-        last_seen_mark = ""
-        test_running_file = self.lock_dir / f"{TEST_RUNNING_GLOB}_{self.worker_id}"
-        cluster_obj = self.cache.cluster_obj
+        marked_tests_cache: dict = {}
 
         if start_cmd:
             if not (singleton or mark):
                 raise AssertionError(
                     "Custom start command can be used only together with `singleton` or `mark`"
                 )
-            # always clean after test(s) that started custom cluster
+            # always clean after test(s) that started cluster with custom configuration
             cleanup = True
 
         # iterate until it is possible to start the test
@@ -267,212 +476,253 @@ class ClusterManager:
                 helpers.xdist_sleep(random.random() * sleep_delay)
 
             with helpers.FileLockIfXdist(self.cluster_lock):
+                test_on_worker = list(
+                    self.lock_dir.glob(
+                        f"{CLUSTER_DIR_TEMPLATE}*/{TEST_RUNNING_GLOB}_{self.worker_id}"
+                    )
+                )
+
                 # test is already running, nothing to set up
-                if first_iteration and test_running_file.exists() and cluster_obj:
-                    self._log(f"{test_running_file} already exists")
-                    return cluster_obj
+                if (
+                    first_iteration
+                    and test_on_worker
+                    and self._cluster_instance != -1
+                    and self.cache.cluster_obj
+                ):
+                    self._log(f"{test_on_worker[0]} already exists")
+                    return self.cache.cluster_obj
 
                 first_iteration = False  # needs to be set here, before the first `continue`
+                self._cluster_instance = -1
 
-                # singleton test is running, so no other test can be started
-                if (self.lock_dir / TEST_SINGLETON_FILE).exists():
-                    self._log("singleton test in progress, cannot run")
-                    sleep_delay = 5
-                    continue
+                # try all existing cluster instances
+                for instance_num in range(self.num_of_instances):
+                    # if instance to run the test on was already decided, skip all other instances
+                    # pylint: disable=consider-using-in
+                    if selected_instance != -1 and instance_num != selected_instance:
+                        continue
 
-                restart_in_progress = list(self.lock_dir.glob(f"{RESTART_IN_PROGRESS_GLOB}_*"))
-                # cluster restart planned, no new tests can start
-                if not restart_here and restart_in_progress:
-                    self._log("restart in progress, cannot run")
-                    continue
+                    instance_dir = self.lock_dir / f"{CLUSTER_DIR_TEMPLATE}{instance_num}"
+                    instance_dir.mkdir(exist_ok=True)
 
-                started_tests = list(self.lock_dir.glob(f"{TEST_RUNNING_GLOB}_*"))
+                    # singleton test is running, so no other test can be started
+                    if (instance_dir / TEST_SINGLETON_FILE).exists():
+                        self._log(f"c{instance_num}: singleton test in progress, cannot run")
+                        sleep_delay = 5
+                        continue
 
-                # "marked tests" = group of tests marked with a specific mark.
-                # While these tests are running, no unmarked test can start.
-                # Check if it is indicated that marked tests will start next.
-                marked_tests_starting = list(self.lock_dir.glob(f"{TEST_MARK_STARTING_GLOB}_*"))
-                if not mark_start_here and marked_tests_starting:
-                    self._log("marked tests starting, cannot run")
-                    sleep_delay = 2
-                    continue
-                if mark_start_here and marked_tests_starting:
-                    if started_tests:
-                        self._log("unmarked tests running, cannot start marked test")
+                    restart_in_progress = list(instance_dir.glob(f"{RESTART_IN_PROGRESS_GLOB}_*"))
+                    # cluster restart planned, no new tests can start
+                    if not restart_here and restart_in_progress:
+                        self._log(f"c{instance_num}: restart in progress, cannot run")
+                        continue
+
+                    started_tests = list(instance_dir.glob(f"{TEST_RUNNING_GLOB}_*"))
+
+                    # "marked tests" = group of tests marked with a specific mark.
+                    # While these tests are running, no unmarked test can start.
+                    # Check if it is indicated that marked tests will start next.
+                    marked_tests_starting = list(instance_dir.glob(f"{TEST_MARK_STARTING_GLOB}_*"))
+                    marked_tests_starting_my = list(
+                        instance_dir.glob(f"{TEST_MARK_STARTING_GLOB}_{mark}_*")
+                    )
+                    if not mark_start_here and marked_tests_starting_my:
+                        self._log(
+                            f"c{instance_num}: marked tests starting with my mark, cannot run"
+                        )
+                        selected_instance = instance_num
                         sleep_delay = 2
                         continue
-                    os.remove(marked_tests_starting[0])
-                    mark_start_here = False
+                    if not mark_start_here and marked_tests_starting:
+                        self._log(f"c{instance_num}: marked tests starting, cannot run")
+                        sleep_delay = 2
+                        continue
+                    if mark_start_here and marked_tests_starting:
+                        if started_tests:
+                            self._log(
+                                f"c{instance_num}: unmarked tests running, cannot start marked test"
+                            )
+                            sleep_delay = 2
+                            continue
+                        os.remove(marked_tests_starting[0])
+                        mark_start_here = False
 
-                test_curr_mark = list(self.lock_dir.glob(f"{TEST_CURR_MARK_GLOB}_*"))
-                first_marked_test = bool(mark and not test_curr_mark)
+                    test_curr_mark = list(instance_dir.glob(f"{TEST_CURR_MARK_GLOB}_*"))
+                    first_marked_test = bool(mark and not test_curr_mark)
 
-                # indicate that it is planned to start marked tests as soon as all currently running
-                # tests are finished
-                if first_marked_test and started_tests:
-                    self._log(f"unmarked tests running, wants to start '{mark}'")
-                    mark_start_here = True
-                    open(self.lock_dir / f"{TEST_MARK_STARTING_GLOB}_{self.worker_id}", "a").close()
-                    sleep_delay = 2
-                    continue
-
-                # marked tests are already running
-                if test_curr_mark:
-                    active_mark_file = test_curr_mark[0].name
-
-                    # check if there is a stale mark status file
-                    if started_tests or last_seen_mark != active_mark_file:
-                        no_marked_tests_iter = 0
-                    else:
-                        no_marked_tests_iter += 1
-                    if no_marked_tests_iter >= 10:
+                    # indicate that it is planned to start marked tests as soon as
+                    # all currently running tests are finished
+                    if first_marked_test and started_tests:
                         self._log(
-                            "no marked tests running for a while, cleaning the mark status file"
+                            f"c{instance_num}: unmarked tests running, wants to start '{mark}'"
                         )
-                        self._on_marked_test_stop()
-
-                    last_seen_mark = active_mark_file
-
-                    if not mark:
-                        self._log("marked tests running, I don't have mark")
-                        sleep_delay = 5
+                        mark_start_here = True
+                        selected_instance = instance_num
+                        open(
+                            instance_dir / f"{TEST_MARK_STARTING_GLOB}_{mark}_{self.worker_id}", "a"
+                        ).close()
+                        sleep_delay = 2
                         continue
 
-                    # check if this test has the same mark as currently running marked tests,
-                    # so it can run
-                    if f"{TEST_CURR_MARK_GLOB}_{mark}" not in active_mark_file:
-                        self._log(f"marked tests running, I have different mark - {mark}")
-                        sleep_delay = 5
-                        continue
-
-                    self._log(f"in marked tests branch, I have required mark '{mark}'")
-
-                # reset counter of cycles with no marked test running
-                no_marked_tests_iter = 0
-
-                # this test is a singleton - no other test can run while this one is running
-                if singleton and started_tests:
-                    self._log("tests are running, cannot start singleton")
-                    sleep_delay = 5
-                    continue
-
-                # this test wants to lock some resources, check if these are not locked or in use
-                if lock_resources:
-                    res_usable = False
-                    for res in lock_resources:
-                        res_locked = list(self.lock_dir.glob(f"{RESOURCE_LOCKED_GLOB}_{res}_*"))
-                        if res_locked:
-                            self._log(f"resource '{res}' locked, cannot start")
-                            break
-                        res_used = list(self.lock_dir.glob(f"{RESOURCE_IN_USE_GLOB}_{res}_*"))
-                        if res_used:
-                            self._log(f"resource '{res}' in use, cannot lock and start")
-                            break
-                    else:
-                        res_usable = True
-
-                    if not res_usable:
-                        sleep_delay = 5
-                        continue
-                    self._log(
-                        f"none of the resources in '{lock_resources}' locked or in use, "
-                        "can start and lock"
+                    # get marked tests status
+                    marked_tests_status = self._get_marked_tests_status(
+                        cache=marked_tests_cache, instance_num=instance_num
                     )
 
-                # filter out `lock_resources` from the list of `use_resources`
-                if use_resources and lock_resources:
-                    use_resources = list(set(use_resources) - set(lock_resources))
+                    # marked tests are already running
+                    if test_curr_mark:
+                        active_mark_file = test_curr_mark[0].name
 
-                # this test wants to use some resources, check if these are not locked
-                if use_resources:
-                    res_locked = []
-                    for res in use_resources:
-                        res_locked = list(self.lock_dir.glob(f"{RESOURCE_LOCKED_GLOB}_{res}_*"))
-                        if res_locked:
-                            self._log(f"resource '{res}' locked, cannot start")
-                            break
-                    if res_locked:
+                        self._update_marked_tests(
+                            marked_tests_status=marked_tests_status,
+                            active_mark_name=active_mark_file,
+                            started_tests=started_tests,
+                            instance_num=instance_num,
+                        )
+
+                        if not mark:
+                            self._log(f"c{instance_num}: marked tests running, I don't have mark")
+                            sleep_delay = 5
+                            continue
+
+                        # check if this test has the same mark as currently running marked tests,
+                        # so it can run
+                        if f"{TEST_CURR_MARK_GLOB}_{mark}" not in active_mark_file:
+                            self._log(
+                                f"c{instance_num}: marked tests running, "
+                                f"I have different mark - {mark}"
+                            )
+                            sleep_delay = 5
+                            continue
+
+                        self._log(
+                            f"c{instance_num}: in marked tests branch, "
+                            f"I have required mark '{mark}'"
+                        )
+
+                    # reset counter of cycles with no marked test running
+                    marked_tests_status.no_marked_tests_iter = 0
+
+                    # this test is a singleton - no other test can run while this one is running
+                    if singleton and started_tests:
+                        self._log(f"c{instance_num}: tests are running, cannot start singleton")
                         sleep_delay = 5
                         continue
-                    self._log(f"none of the resources in '{use_resources}' locked, can start")
 
-                # indicate that there will be cluster restart
-                new_cmd_restart = bool(start_cmd and (first_marked_test or singleton))
-                if not restart_here and (new_cmd_restart or self._is_restart_needed()):
-                    self._log("setting to restart cluster")
-                    restart_here = True
-                    open(
-                        self.lock_dir / f"{RESTART_IN_PROGRESS_GLOB}_{self.worker_id}", "a"
-                    ).close()
+                    # this test wants to lock some resources, check if these are not
+                    # locked or in use
+                    if lock_resources:
+                        res_usable = self._are_resources_usable(
+                            resources=lock_resources,
+                            instance_dir=instance_dir,
+                            instance_num=instance_num,
+                        )
+                        if not res_usable:
+                            sleep_delay = 5
+                            continue
 
-                # cluster restart will be performed by this worker
-                if restart_here:
-                    if started_tests:
-                        self._log("tests are running, cannot restart")
+                    # filter out `lock_resources` from the list of `use_resources`
+                    if use_resources and lock_resources:
+                        use_resources = list(set(use_resources) - set(lock_resources))
+
+                    # this test wants to use some resources, check if these are not locked
+                    if use_resources:
+                        res_locked = self._are_resources_locked(
+                            resources=use_resources,
+                            instance_dir=instance_dir,
+                            instance_num=instance_num,
+                        )
+                        if res_locked:
+                            sleep_delay = 5
+                            continue
+
+                    # indicate that the cluster will be restarted
+                    new_cmd_restart = bool(start_cmd and (first_marked_test or singleton))
+                    if not restart_here and (
+                        new_cmd_restart or self._is_restart_needed(instance_num)
+                    ):
+                        self._log(f"c{instance_num}: setting to restart cluster")
+                        restart_here = True
+                        selected_instance = instance_num
+                        open(
+                            instance_dir / f"{RESTART_IN_PROGRESS_GLOB}_{self.worker_id}", "a"
+                        ).close()
+
+                    # cluster restart will be performed by this worker
+                    if restart_here and started_tests:
+                        self._log(f"c{instance_num}: tests are running, cannot restart")
                         sleep_delay = 2
                         continue
-                    self._log("calling restart")
-                    restart_here = False
-                    self._restart(start_cmd=start_cmd)
 
-                # from this point on, all conditions needed to start the test are met
+                    # we've found suitable cluster instance
+                    self._cluster_instance = instance_num
+                    cluster_instances.set_cardano_node_socket_path(instance_num)
 
-                # this test is a singleton
-                if singleton:
-                    self._log("starting singleton")
-                    open(self.lock_dir / TEST_SINGLETON_FILE, "a").close()
+                    if restart_here:
+                        self._log(f"c{instance_num}: calling restart")
+                        restart_here = False
+                        # TODO: every instance is waiting until restart is finished
+                        # because of global cluster lock
+                        self._restart(start_cmd=start_cmd)
 
-                # this test is a first marked test
-                if first_marked_test:
-                    self._log(f"starting '{mark}' tests")
-                    open(self.lock_dir / f"{TEST_CURR_MARK_GLOB}_{mark}", "a").close()
+                    # from this point on, all conditions needed to start the test are met
 
-                # create status file for each in-use resource
-                _ = [
-                    open(
-                        self.lock_dir / f"{RESOURCE_IN_USE_GLOB}_{r}_{self.worker_id}", "a"
-                    ).close()
-                    for r in use_resources
-                ]
+                    # this test is a singleton
+                    if singleton:
+                        self._log(f"c{instance_num}: starting singleton")
+                        open(self.instance_dir / TEST_SINGLETON_FILE, "a").close()
 
-                # create status file for each locked resource
-                _ = [
-                    open(
-                        self.lock_dir / f"{RESOURCE_LOCKED_GLOB}_{r}_{self.worker_id}", "a"
-                    ).close()
-                    for r in lock_resources
-                ]
+                    # this test is a first marked test
+                    if first_marked_test:
+                        self._log(f"c{instance_num}: starting '{mark}' tests")
+                        open(self.instance_dir / f"{TEST_CURR_MARK_GLOB}_{mark}", "a").close()
 
-                # cleanup = cluster restart after test (group of tests) is finished
-                if cleanup:
-                    # cleanup after group of test that are marked with a marker
-                    if mark:
-                        self._log("cleanup and mark")
+                    # create status file for each in-use resource
+                    _ = [
                         open(
-                            self.lock_dir / f"{RESTART_AFTER_MARK_GLOB}_{self.worker_id}", "a"
+                            self.instance_dir / f"{RESOURCE_IN_USE_GLOB}_{r}_{self.worker_id}", "a"
                         ).close()
-                    # cleanup after single test (e.g. singleton)
-                    else:
-                        self._log("cleanup and not mark")
-                        open(self.lock_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a").close()
+                        for r in use_resources
+                    ]
 
-                self._log(f"creating {test_running_file}")
+                    # create status file for each locked resource
+                    _ = [
+                        open(
+                            self.instance_dir / f"{RESOURCE_LOCKED_GLOB}_{r}_{self.worker_id}", "a"
+                        ).close()
+                        for r in lock_resources
+                    ]
+
+                    # cleanup = cluster restart after test (group of tests) is finished
+                    if cleanup:
+                        # cleanup after group of test that are marked with a marker
+                        if mark:
+                            self._log(f"c{instance_num}: cleanup and mark")
+                            open(
+                                self.instance_dir / f"{RESTART_AFTER_MARK_GLOB}_{self.worker_id}",
+                                "a",
+                            ).close()
+                        # cleanup after single test (e.g. singleton)
+                        else:
+                            self._log(f"c{instance_num}: cleanup and not mark")
+                            open(
+                                self.instance_dir / f"{RESTART_NEEDED_GLOB}_{self.worker_id}", "a"
+                            ).close()
+
+                    break
+                else:
+                    # if the test cannot run on any instance, return to top-level loop
+                    continue
+
+                test_running_file = self.instance_dir / f"{TEST_RUNNING_GLOB}_{self.worker_id}"
+                self._log(f"c{self.cluster_instance}: creating {test_running_file}")
                 open(test_running_file, "a").close()
 
                 cluster_env = devops_cluster.get_cluster_env()
                 state_dir = Path(cluster_env["state_dir"])
 
                 # check if it is necessary to reload data
-                # must be lock-protected because `load_addrs_data` is reading file from disk
-                addrs_data_checksum = helpers.checksum(state_dir / devops_cluster.ADDR_DATA)
-                if addrs_data_checksum != self.cache.last_checksum:
-                    # save CLI coverage collected by the old `cluster_obj` instance
-                    self.save_cli_coverage()
-                    # replace the old `cluster_obj` instance and reload data
-                    self.cache.cluster_obj = clusterlib.ClusterLib(state_dir)
-                    self.cache.test_data = {}
-                    self.cache.addrs_data = devops_cluster.load_addrs_data()
-                    self.cache.last_checksum = addrs_data_checksum
+                self._reload_cluster_obj(state_dir=state_dir)
 
                 cluster_obj = self.cache.cluster_obj
                 if not cluster_obj:


### PR DESCRIPTION
Right now we run our test on several pytest workers, but just single cluster instance. This slows things considerably, given we need to "lock" the cluster in case some test modifies global state, like cluster config, pools pledge, etc. (or there's a chance for that, like in case of failure).
Initial measurements showed that with 15 pytest workers and 9 cluster instances the test are able to finish in ~ 1h 15m instead of 6+ hours.