### PR TITLE
Add rand str to timestamped CLI coverage dump

### DIFF
--- a/cabal_build_tests/readme.md
+++ b/cabal_build_tests/readme.md
@@ -13,4 +13,3 @@
 `./run-fedora.sh \<cardano-node tag>`
 
 If "Success" is shown at the end and exit with code 0 then build has completed successfully and verified with cardano-cli.
-

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -422,7 +422,7 @@ def save_cli_coverage(cluster_obj: clusterlib.ClusterLib, pytest_config: Config)
     if not (cli_coverage_dir and cluster_obj.cli_coverage):
         return None
 
-    json_file = Path(cli_coverage_dir) / f"cli_coverage_{get_timestamped_rand_str(0)}.json"
+    json_file = Path(cli_coverage_dir) / f"cli_coverage_{get_timestamped_rand_str()}.json"
     with open(json_file, "w") as out_json:
         json.dump(cluster_obj.cli_coverage, out_json, indent=4)
     LOGGER.info(f"Coverage files saved to '{cli_coverage_dir}'.")

--- a/cardano_node_tests/utils/parallel_run.py
+++ b/cardano_node_tests/utils/parallel_run.py
@@ -191,7 +191,11 @@ class ClusterManager:
         )
 
     def save_worker_cli_coverage(self) -> None:
-        """Save CLI coverage info collected by this pytest worker."""
+        """Save CLI coverage info collected by this pytest worker.
+
+        Must be done when session of the worker is about to finish, because there's no other job to
+        call `_reload_cluster_obj` and thus save CLI coverage of the old `cluster_obj` instance.
+        """
         self._log("called `save_worker_cli_coverage`")
         worker_cache = self.get_cache()
         for cache_instance in worker_cache.values():


### PR DESCRIPTION
When collecting coverage at the end of worker session, there can
potentially be naming collision.