### PR TITLE
Update Cabal build tests inline with documentation

### DIFF
--- a/cabal_build_tests/readme.md
+++ b/cabal_build_tests/readme.md
@@ -6,10 +6,10 @@
 ## Run tests
 
 ### To test cardano-node Cabal build on Ubuntu:
-`./run-ubuntu.sh \<cardano-node tag>`
+`./run-ubuntu.sh <cardano-node tag>`
 
 ### To test cardano-node Cabal build on Fedora:
 
-`./run-fedora.sh \<cardano-node tag>`
+`./run-fedora.sh <cardano-node tag>`
 
 If "Success" is shown at the end and exit with code 0 then build has completed successfully and verified with cardano-cli.


### PR DESCRIPTION
Considered updated made:
https://github.com/input-output-hk/cardano-node/commit/283a9fe203f3bb84bec763a9cc2c9baf12235564
and
https://github.com/input-output-hk/cardano-node/commit/17d883ef30b4370c5f7dadb6b52ce948e7f90976