### PR TITLE
Remove sync tests requirements from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,3 @@ install_requires =
     pytest-ordering
     pytest-xdist
     setuptools>=21.0.0
-    pandas
-    requests
-    psutil


### PR DESCRIPTION
The requirements for sync tests are listed directly in Github Actions.

The cardano-node-tests pip package is not needed for sync tests and thus
there's no need to install sync test requirements as part of cardano-node-tests
package.