### PR TITLE
Ability to check and compare node versions and cardano eras

### DIFF
--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -17,11 +17,11 @@ import pytest
 from _pytest.tmpdir import TempdirFactory
 from packaging import version
 
-from cardano_node_tests.utils import cluster_instances
 from cardano_node_tests.utils import clusterlib
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import parallel_run
+from cardano_node_tests.utils.devops_cluster import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -701,9 +701,7 @@ class TestNegative:
 
 
 @pytest.mark.skipif(
-    cluster_instances.TX_ERA == "shelley"
-    or cluster_instances.CLUSTER_ERA == "shelley"
-    or helpers.NODE_VERSION < version.parse("1.24.0"),
+    VERSIONS.transaction_era < VERSIONS.ALLEGRA or VERSIONS.node < version.parse("1.24.0"),
     reason="runs on version >= 1.24.0 and with Allegra+ TX",
 )
 class TestTimeLocking:
@@ -1089,9 +1087,7 @@ class TestTimeLocking:
 
 
 @pytest.mark.skipif(
-    cluster_instances.TX_ERA == "shelley"
-    or cluster_instances.CLUSTER_ERA == "shelley"
-    or helpers.NODE_VERSION < version.parse("1.24.0"),
+    VERSIONS.transaction_era < VERSIONS.ALLEGRA or VERSIONS.node < version.parse("1.24.0"),
     reason="runs on version >= 1.24.0 and with Allegra+ TX",
 )
 class TestAuxiliaryScripts:

--- a/cardano_node_tests/utils/devops_cluster.py
+++ b/cardano_node_tests/utils/devops_cluster.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 from typing import Optional
 
 from _pytest.config import Config
+from packaging import version
 
 from cardano_node_tests.utils import cluster_instances
 from cardano_node_tests.utils import clusterlib
@@ -22,6 +23,30 @@ from cardano_node_tests.utils.types import FileType
 LOGGER = logging.getLogger(__name__)
 
 ADDRS_DATA = "addrs_data.pickle"
+
+
+class Versions:
+    BYRON = 1
+    SHELLEY = 2
+    ALLEGRA = 3
+    MARY = 4
+
+    def __init__(self) -> None:
+        cluster_era = cluster_instances.CLUSTER_ERA
+        transaction_era = cluster_instances.TX_ERA or cluster_era
+        self.cluster_era = getattr(self, cluster_era.upper(), 1)
+        self.transaction_era = getattr(self, transaction_era.upper(), 1)
+        self.node = version.parse(helpers.CARDANO_VERSION["cardano-node"])
+
+    def __repr__(self) -> str:
+        return (
+            f"<Versions: cluster_era={self.cluster_era}, "
+            f"transaction_era={self.transaction_era}, "
+            f"node={helpers.CARDANO_VERSION['cardano-node']}>"
+        )
+
+
+VERSIONS = Versions()
 
 
 class StartupFiles(NamedTuple):

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -22,7 +22,6 @@ import hypothesis
 from _pytest.config import Config
 from _pytest.tmpdir import TempdirFactory
 from filelock import FileLock
-from packaging import version
 
 from cardano_node_tests.utils.types import FileType
 
@@ -80,7 +79,6 @@ def get_cardano_version() -> dict:
 
 
 CARDANO_VERSION = get_cardano_version()
-NODE_VERSION = version.parse(CARDANO_VERSION["cardano-node"])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
To be able to e.g. skip tests when node version or cardano era doesn't
match.