### PR TITLE
Better fixture caching

### DIFF
--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -176,16 +176,15 @@ class TestMinting:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new issuers addresses."""
-        data_key = id(TestMinting)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"token_minting_ci{cluster_manager.cluster_instance}_{i}" for i in range(3)],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[f"token_minting_ci{cluster_manager.cluster_instance}_{i}" for i in range(3)],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -424,16 +423,15 @@ class TestTransfer:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new payment addresses."""
-        data_key = id(TestTransfer)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"token_transfer_ci{cluster_manager.cluster_instance}_{i}" for i in range(10)],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[f"token_transfer_ci{cluster_manager.cluster_instance}_{i}" for i in range(10)],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -452,13 +450,12 @@ class TestTransfer:
         cluster: clusterlib.ClusterLib,
         payment_addrs: List[clusterlib.AddressRecord],
     ) -> NewToken:
-        data_key = id(TestTransfer) + 1
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        new_token = self._new_token(cluster_obj=cluster, payment_addrs=payment_addrs)
-        cluster_manager.cache.test_data[data_key] = new_token
+            new_token = self._new_token(cluster_obj=cluster, payment_addrs=payment_addrs)
+            fixture_cache.value = new_token
 
         return new_token
 

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1248,21 +1248,23 @@ class TestPoolCost:
         cluster_mincost: clusterlib.ClusterLib,
     ):
         """Create class scoped pool owners."""
-        data_key = id(TestPoolCost)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
-
         cluster = cluster_mincost
-        rand_str = clusterlib.get_rand_str()
-        temp_template = f"{helpers.get_func_name()}_{rand_str}_ci{cluster_manager.cluster_instance}"
 
-        pool_owners = clusterlib_utils.create_pool_users(
-            cluster_obj=cluster,
-            name_template=temp_template,
-            no_of_addr=1,
-        )
-        cluster_manager.cache.test_data[data_key] = pool_owners
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
+
+            rand_str = clusterlib.get_rand_str()
+            temp_template = (
+                f"{helpers.get_func_name()}_{rand_str}_ci{cluster_manager.cluster_instance}"
+            )
+
+            pool_owners = clusterlib_utils.create_pool_users(
+                cluster_obj=cluster,
+                name_template=temp_template,
+                no_of_addr=1,
+            )
+            fixture_cache.value = pool_owners
 
         # fund source address
         clusterlib_utils.fund_from_faucet(
@@ -1366,17 +1368,16 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.PoolUser]:
         """Create pool users."""
-        data_key = id(TestNegative)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        created_users = clusterlib_utils.create_pool_users(
-            cluster_obj=cluster,
-            name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
-            no_of_addr=2,
-        )
-        cluster_manager.cache.test_data[data_key] = created_users
+            created_users = clusterlib_utils.create_pool_users(
+                cluster_obj=cluster,
+                name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
+                no_of_addr=2,
+            )
+            fixture_cache.value = created_users
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -137,16 +137,15 @@ class TestBasic:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new payment addresses."""
-        data_key = id(TestBasic)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(20)],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[f"multi_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(20)],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -558,16 +557,15 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new payment addresses."""
-        data_key = id(TestNegative)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_neg_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(10)],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[f"multi_neg_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(10)],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -750,19 +748,18 @@ class TestTimeLocking:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new payment addresses."""
-        data_key = id(TestTimeLocking)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[
-                f"multi_addr_time_locking_ci{cluster_manager.cluster_instance}_{i}"
-                for i in range(20)
-            ],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[
+                    f"multi_addr_time_locking_ci{cluster_manager.cluster_instance}_{i}"
+                    for i in range(20)
+                ],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -1149,19 +1146,18 @@ class TestAuxiliaryScripts:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create new payment addresses."""
-        data_key = id(TestAuxiliaryScripts)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[
-                f"multi_addr_aux_scripts_ci{cluster_manager.cluster_instance}_{i}"
-                for i in range(20)
-            ],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[
+                    f"multi_addr_aux_scripts_ci{cluster_manager.cluster_instance}_{i}"
+                    for i in range(20)
+                ],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -47,17 +47,16 @@ def pool_users(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.PoolUser]:
     """Create pool users."""
-    data_key = id(pool_users)
-    cached_value = cluster_manager.cache.test_data.get(data_key)
-    if cached_value:
-        return cached_value  # type: ignore
+    with cluster_manager.cache_fixture() as fixture_cache:
+        if fixture_cache.value:
+            return fixture_cache.value  # type: ignore
 
-    created_users = clusterlib_utils.create_pool_users(
-        cluster_obj=cluster,
-        name_template=f"test_staking_pool_users_ci{cluster_manager.cluster_instance}",
-        no_of_addr=2,
-    )
-    cluster_manager.cache.test_data[data_key] = created_users
+        created_users = clusterlib_utils.create_pool_users(
+            cluster_obj=cluster,
+            name_template=f"test_staking_pool_users_ci{cluster_manager.cluster_instance}",
+            no_of_addr=2,
+        )
+        fixture_cache.value = created_users
 
     # fund source addresses
     clusterlib_utils.fund_from_faucet(

--- a/cardano_node_tests/tests/test_transaction_fees.py
+++ b/cardano_node_tests/tests/test_transaction_fees.py
@@ -46,17 +46,16 @@ class TestFee:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create 2 new payment addresses."""
-        data_key = id(TestFee)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            f"addr_test_fee_ci{cluster_manager.cluster_instance}_0",
-            f"addr_test_fee_ci{cluster_manager.cluster_instance}_1",
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                f"addr_test_fee_ci{cluster_manager.cluster_instance}_0",
+                f"addr_test_fee_ci{cluster_manager.cluster_instance}_1",
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -201,17 +200,16 @@ class TestExpectedFees:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.PoolUser]:
         """Create pool users."""
-        data_key = id(TestExpectedFees)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        created_users = clusterlib_utils.create_pool_users(
-            cluster_obj=cluster,
-            name_template=f"test_expected_fees_ci{cluster_manager.cluster_instance}",
-            no_of_addr=201,
-        )
-        cluster_manager.cache.test_data[data_key] = created_users
+            created_users = clusterlib_utils.create_pool_users(
+                cluster_obj=cluster,
+                name_template=f"test_expected_fees_ci{cluster_manager.cluster_instance}",
+                no_of_addr=201,
+            )
+            fixture_cache.value = created_users
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(

--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -112,17 +112,16 @@ class TestBasic:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create 2 new payment addresses."""
-        data_key = id(TestBasic)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            f"addr_basic_ci{cluster_manager.cluster_instance}_0",
-            f"addr_basic_ci{cluster_manager.cluster_instance}_1",
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                f"addr_basic_ci{cluster_manager.cluster_instance}_0",
+                f"addr_basic_ci{cluster_manager.cluster_instance}_1",
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -380,16 +379,18 @@ class TestMultiInOut:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create 11 new payment addresses."""
-        data_key = id(TestMultiInOut)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"multi_in_out_addr_ci{cluster_manager.cluster_instance}_{i}" for i in range(201)],
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                *[
+                    f"multi_in_out_addr_ci{cluster_manager.cluster_instance}_{i}"
+                    for i in range(201)
+                ],
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -643,17 +644,16 @@ class TestNotBalanced:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create 2 new payment addresses."""
-        data_key = id(TestNotBalanced)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addrs = clusterlib_utils.create_payment_addr_records(
-            f"addr_not_balanced_ci{cluster_manager.cluster_instance}_0",
-            f"addr_not_balanced_ci{cluster_manager.cluster_instance}_1",
-            cluster_obj=cluster,
-        )
-        cluster_manager.cache.test_data[data_key] = addrs
+            addrs = clusterlib_utils.create_payment_addr_records(
+                f"addr_not_balanced_ci{cluster_manager.cluster_instance}_0",
+                f"addr_not_balanced_ci{cluster_manager.cluster_instance}_1",
+                cluster_obj=cluster,
+            )
+            fixture_cache.value = addrs
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -801,17 +801,16 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.PoolUser]:
         """Create pool users."""
-        data_key = id(TestNegative)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        created_users = clusterlib_utils.create_pool_users(
-            cluster_obj=cluster,
-            name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
-            no_of_addr=2,
-        )
-        cluster_manager.cache.test_data[data_key] = created_users
+            created_users = clusterlib_utils.create_pool_users(
+                cluster_obj=cluster,
+                name_template=f"test_negative_ci{cluster_manager.cluster_instance}",
+                no_of_addr=2,
+            )
+            fixture_cache.value = created_users
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(
@@ -1251,15 +1250,14 @@ class TestMetadata:
         cluster: clusterlib.ClusterLib,
     ) -> clusterlib.AddressRecord:
         """Create new payment address."""
-        data_key = id(TestMetadata)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
 
-        addr = clusterlib_utils.create_payment_addr_records(
-            f"addr_test_metadata_ci{cluster_manager.cluster_instance}_0", cluster_obj=cluster
-        )[0]
-        cluster_manager.cache.test_data[data_key] = addr
+            addr = clusterlib_utils.create_payment_addr_records(
+                f"addr_test_metadata_ci{cluster_manager.cluster_instance}_0", cluster_obj=cluster
+            )[0]
+            fixture_cache.value = addr
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(

--- a/cardano_node_tests/tests/test_update_proposal.py
+++ b/cardano_node_tests/tests/test_update_proposal.py
@@ -47,18 +47,17 @@ class TestBasic:
         cluster_update_proposal: clusterlib.ClusterLib,
     ) -> clusterlib.AddressRecord:
         """Create new payment address."""
-        data_key = id(TestBasic)
-        cached_value = cluster_manager.cache.test_data.get(data_key)
-        if cached_value:
-            return cached_value  # type: ignore
-
         cluster = cluster_update_proposal
 
-        addr = clusterlib_utils.create_payment_addr_records(
-            f"addr_test_basic_update_proposal_ci{cluster_manager.cluster_instance}_0",
-            cluster_obj=cluster,
-        )[0]
-        cluster_manager.cache.test_data[data_key] = addr
+        with cluster_manager.cache_fixture() as fixture_cache:
+            if fixture_cache.value:
+                return fixture_cache.value  # type: ignore
+
+            addr = clusterlib_utils.create_payment_addr_records(
+                f"addr_test_basic_update_proposal_ci{cluster_manager.cluster_instance}_0",
+                cluster_obj=cluster,
+            )[0]
+            fixture_cache.value = addr
 
         # fund source addresses
         clusterlib_utils.fund_from_faucet(


### PR DESCRIPTION
Introduces context manager that handles fixture values caching.

It is used to cache function-scoped fixture, so the value can be reused if another tests run on the same cluster instance.