### PR TITLE
Tests for cardano-cli query output files

### DIFF
--- a/cardano_node_tests/tests/test_ledger_state.py
+++ b/cardano_node_tests/tests/test_ledger_state.py
@@ -1,0 +1,59 @@
+"""Tests for ledger state."""
+import json
+import logging
+from pathlib import Path
+
+import allure
+import pytest
+from _pytest.tmpdir import TempdirFactory
+
+from cardano_node_tests.utils import clusterlib
+from cardano_node_tests.utils import helpers
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    return Path(tmp_path_factory.mktemp(helpers.get_id_for_mktemp(__file__))).resolve()
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
+
+
+# use the "temp_dir" fixture for all tests automatically
+pytestmark = pytest.mark.usefixtures("temp_dir")
+
+
+LEDGER_STATE_KEYS = (
+    "blocksBefore",
+    "blocksCurrent",
+    "lastEpoch",
+    "possibleRewardUpdate",
+    "stakeDistrib",
+    "stateBefore",
+)
+
+
+@pytest.mark.testnets
+class TestLedgerState:
+    """Basic tests for ledger state."""
+
+    @allure.link(helpers.get_vcs_link())
+    def test_ledger_state_keys(self, cluster: clusterlib.ClusterLib):
+        """Check output of `query ledger-state`."""
+        ledger_state = cluster.get_ledger_state()
+        assert tuple(sorted(ledger_state)) == LEDGER_STATE_KEYS
+
+    @allure.link(helpers.get_vcs_link())
+    def test_ledger_state_outfile(self, cluster: clusterlib.ClusterLib):
+        """Check output file produced by `query ledger-state`."""
+        ledger_state = json.loads(
+            cluster.query_cli(["ledger-state", *cluster.era_arg, "--out-file", "/dev/stdout"])
+        )
+        assert tuple(sorted(ledger_state)) == LEDGER_STATE_KEYS

--- a/cardano_node_tests/tests/test_protocol.py
+++ b/cardano_node_tests/tests/test_protocol.py
@@ -1,4 +1,5 @@
 """Tests for protocol state and protocol parameters."""
+import json
 import logging
 from pathlib import Path
 
@@ -59,6 +60,14 @@ class TestProtocol:
     def test_protocol_state_keys(self, cluster: clusterlib.ClusterLib):
         """Check output of `query protocol-state`."""
         protocol_state = cluster.get_protocol_state()
+        assert tuple(sorted(protocol_state)) == PROTOCOL_STATE_KEYS
+
+    @allure.link(helpers.get_vcs_link())
+    def test_protocol_state_outfile(self, cluster: clusterlib.ClusterLib):
+        """Check output file produced by `query protocol-state`."""
+        protocol_state: dict = json.loads(
+            cluster.query_cli(["protocol-state", *cluster.era_arg, "--out-file", "/dev/stdout"])
+        )
         assert tuple(sorted(protocol_state)) == PROTOCOL_STATE_KEYS
 
     @allure.link(helpers.get_vcs_link())


### PR DESCRIPTION
For `ledger-state` and `protocol-state` commands.

Tests bug https://github.com/input-output-hk/cardano-node/issues/2461

ATM the tests are expected to fail.