### PR TITLE
Revert the waiting for blocks

### DIFF
--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -748,6 +748,7 @@ class TestManyUTXOs:
             tx_files=tx_files,
             join_txouts=False,
         )
+        cluster_obj.wait_for_new_block(new_blocks=2)
 
     @pytest.fixture
     def many_utxos(


### PR DESCRIPTION
It's needed so we don't try to use the same UTxO from multiple TXs.