### PR TITLE
[Not to be merged] Add my first test for checking node tip query

### DIFF
--- a/cardano_node_tests/tests/test_query_tip.py
+++ b/cardano_node_tests/tests/test_query_tip.py
@@ -1,0 +1,55 @@
+"""Tests for Node Tip Query."""
+import logging
+from pathlib import Path
+
+import allure
+import pytest
+from _pytest.tmpdir import TempdirFactory
+from cardano_clusterlib import clusterlib
+
+from cardano_node_tests.utils import clusterlib_utils
+from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import helpers
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def create_temp_dir(tmp_path_factory: TempdirFactory):
+    """Create a temporary dir."""
+    p = Path(tmp_path_factory.getbasetemp()).joinpath(helpers.get_id_for_mktemp(__file__)).resolve()
+    p.mkdir(exist_ok=True, parents=True)
+    return p
+
+
+@pytest.fixture
+def temp_dir(create_temp_dir: Path):
+    """Change to a temporary dir."""
+    with helpers.change_cwd(create_temp_dir):
+        yield create_temp_dir
+
+
+# use the "temp_dir" fixture for all tests automatically
+pytestmark = pytest.mark.usefixtures("temp_dir")
+
+
+NODE_TIP_DATA = {
+    "epoch": 21,
+    "hash": "ba84636689deed56f8a4455e55484eaae7328e6f7404ade3d0184a7852beeeb4",
+    "slot": 2654576,
+    "block": 2653061
+}
+
+
+class TestNodeTipQuery:
+    """Basic tests for node tip."""
+
+    @allure.link(helpers.get_vcs_link())
+    @pytest.mark.skipif(
+        bool(configuration.TX_ERA),
+        reason="different TX eras doesn't affect this test, pointless to run",
+    )
+    def test_node_tip_query(self, cluster: clusterlib.ClusterLib):
+        """Check output of `cardano-cli query tip`."""
+        node_tip = clusterlib_utils.get_node_tip(cluster_obj=cluster)
+        assert dict(node_tip) == NODE_TIP_DATA

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -536,6 +536,32 @@ def new_tokens(
     return tokens_to_mint
 
 
+def node_tip(
+    cluster_obj: clusterlib.ClusterLib,
+) -> str:
+    """Get output of `cardano-cli query tip`."""
+    cardano_query_tip_cmd = " ".join(
+        [
+            "cardano-cli",
+            "query",
+            "tip",
+            *cluster_obj.magic_args,
+        ]
+    )
+    return helpers.run_command(cardano_query_tip_cmd, shell=True).decode("utf-8").strip()
+
+
+def get_node_tip(
+    cluster_obj: clusterlib.ClusterLib,
+) -> dict:
+    """Return the current node tip."""
+    node_tip_json = node_tip(cluster_obj)
+    if not node_tip:
+        return {}
+    node_tip: dict = json.loads(node_tip_json)
+    return node_tip
+
+
 def filtered_ledger_state(
     cluster_obj: clusterlib.ClusterLib,
 ) -> str:


### PR DESCRIPTION
My first attempt to add simple "test", it will obviously fail as it comparing some arbitrary hard-coded numbers - but I just wanted to check if I will manage to interact with cluster and get some response about node state.

I am running into following issue when running this test: 

```
(.env) artur@artur-linux-desktop:~/Projects/cardano-node-tests$ pytest -k "test_query_tip" cardano_node_tests
================================================================================================================================= test session starts ==================================================================================================================================
platform linux -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/artur/Projects/cardano-node-tests/.env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/artur/Projects/cardano-node-tests/.hypothesis/examples')
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-73-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.2.4', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'hypothesis': '6.12.0', 'allure-pytest': '2.8.40', 'xdist': '2.2.1', 'html': '3.1.1', 'metadata': '1.11.0', 'forked': '1.3.0', 'ordering': '0.6'}, 'cardano-node': '1.26.2', 'cardano-node rev': '3531289c9f79eab7ac5d3272ce6e6821504fec4c', 'ghc': 'ghc-8.10', 'cardano-node-tests rev': 'aead8510dcf32ed47cc830df474f6e174148cc5b', 'cardano-node-tests url': 'https://github.com/input-output-hk/cardano-node-tests/tree/aead8510dcf32ed47cc830df474f6e174148cc5b', 'HAS_DBSYNC': 'False'}
rootdir: /home/artur/Projects/cardano-node-tests, configfile: pytest.ini
plugins: hypothesis-6.12.0, allure-pytest-2.8.40, xdist-2.2.1, html-3.1.1, metadata-1.11.0, forked-1.3.0, ordering-0.6
collected 229 items / 228 deselected / 1 skipped                                                                                                                                                                                                                                       

cardano_node_tests/tests/test_query_tip.py::TestNodeTipQuery::test_node_tip_query 
------------------------------------------------------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.tests.conftest:conftest.py:93 Changed CWD to '/tmp/pytest-of-artur/pytest-9'.
ERROR                                                                                                                                                                                                                                                                            [100%]

======================================================================================================================================== ERRORS ========================================================================================================================================
________________________________________________________________________________________________________________ ERROR at setup of TestNodeTipQuery.test_node_tip_query ________________________________________________________________________________________________________________

cluster_manager = <cardano_node_tests.utils.cluster_management.ClusterManager object at 0x7f7b414aa3d0>

    @pytest.fixture
    def cluster(
        cluster_manager: cluster_management.ClusterManager,
    ) -> clusterlib.ClusterLib:
        """Return instance of `clusterlib.ClusterLib`."""
>       return cluster_manager.get()

/home/artur/Projects/cardano-node-tests/cardano_node_tests/tests/conftest.py:199: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/artur/Projects/cardano-node-tests/cardano_node_tests/utils/cluster_management.py:328: in get
    return _ClusterGetter(self).get(
/home/artur/Projects/cardano-node-tests/cardano_node_tests/utils/cluster_management.py:611: in get
    return self._reuse_dev_cluster()
/home/artur/Projects/cardano-node-tests/cardano_node_tests/utils/cluster_management.py:575: in _reuse_dev_cluster
    cluster_obj = cluster_nodes.get_cluster_type().get_cluster_obj()
/home/artur/Projects/cardano-node-tests/cardano_node_tests/utils/cluster_nodes.py:119: in get_cluster_obj
    cluster_obj = clusterlib.ClusterLib(
/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:244: in __init__
    self._check_protocol()
/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:261: in _check_protocol
    self.refresh_pparams_file()
/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:450: in refresh_pparams_file
    self.query_cli(["protocol-parameters", "--out-file", str(self.pparams_file)])
/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:437: in query_cli
    stdout = self.cli(
/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:418: in cli
    return self.cli_base(cmd)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ClusterLib: protocol=cardano, tx_era=>, cli_args = ['cardano-cli', 'query', 'protocol-parameters', '--out-file', '/home/artur/Projects/cardano-node/state-cluster0/pparams-eets.json', '--testnet-magic', ...]

    def cli_base(self, cli_args: List[str]) -> CLIOut:
        """Run a command.
    
        Args:
            cli_args: A list consisting of command and it's arguments.
    
        Returns:
            CLIOut: A tuple containing command stdout and stderr.
        """
        cmd_str = " ".join(cli_args)
        LOGGER.debug("Running `%s`", cmd_str)
    
        # re-run the command when running into
        # Network.Socket.connect: <socket: X>: resource exhausted (Resource temporarily unavailable)
        # or
        # MuxError (MuxIOException writev: resource vanished (Broken pipe)) "(sendAll errored)"
        for __ in range(3):
            with subprocess.Popen(cli_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
                stdout, stderr = p.communicate()
    
                if p.returncode == 0:
                    break
    
            stderr_dec = stderr.decode()
            err_msg = (
                f"An error occurred running a CLI command `{cmd_str}` on path "
                f"`{os.getcwd()}`: {stderr_dec}"
            )
            if "resource exhausted" in stderr_dec or "resource vanished" in stderr_dec:
                LOGGER.error(err_msg)
                time.sleep(0.4)
                continue
>           raise CLIError(err_msg)
E           cardano_clusterlib.clusterlib.CLIError: An error occurred running a CLI command `cardano-cli query protocol-parameters --out-file /home/artur/Projects/cardano-node/state-cluster0/pparams-eets.json --testnet-magic 42 --cardano-mode` on path `/tmp/pytest-of-artur/pytest-9/test_query_tip_py`: 
E           cardano-cli: Network.Socket.connect: <socket: 11>: does not exist (No such file or directory)

/home/artur/Projects/cardano-node-tests/.env/lib/python3.8/site-packages/cardano_clusterlib/clusterlib.py:401: CLIError
---------------------------------------------------------------------------------------------------------------------------------- Captured log setup ----------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.tests.conftest:conftest.py:93 Changed CWD to '/tmp/pytest-of-artur/pytest-9'.
=============================================================================================================================== short test summary info ================================================================================================================================
SKIPPED [1] cardano_node_tests/tests/test_metrics.py:19: metrics data are not stable yet
ERROR cardano_node_tests/tests/test_query_tip.py::TestNodeTipQuery::test_node_tip_query - cardano_clusterlib.clusterlib.CLIError: An error occurred running a CLI command `cardano-cli query protocol-parameters --out-file /home/artur/Projects/cardano-node/state-cluster0/pparams-...
===================================================================================================================== 1 skipped, 228 deselected, 1 error in 0.44s ======================================================================================================================
(.env) artur@artur-linux-desktop:~/Projects/cardano-node-tests$
``` 

So it is missing socket file(s) but I already started cluster in separate tab before running this test (in nix-shell):

```[nix-shell:~/Projects/cardano-node-tests]$ scripts/destination/dir/start-cluster-hfc
Generating Pool 1 Secrets
Generating Pool 1 Metadata
Generating Pool 2 Secrets
Generating Pool 2 Metadata
Generating Pool 3 Secrets
Generating Pool 3 Metadata
Waiting 5 seconds for bft node to start
Moving funds out of Byron genesis
Transaction successfully submitted.
Waiting 202 sec for Shelley era to start
Submitting update proposal to transfer to Allegra, transfering funds to pool owners, registering pools and delegations
Transaction successfully submitted.
Waiting 202 sec for Allegra era to start
Submitting update proposal to transfer to Mary, set d = 0
Transaction successfully submitted.
Waiting 212 sec for Mary era to start
Cluster started. Run `stop-cluster` to stop
(.env) 
```
No idea what I am doing wrong.