### PR TITLE
Add more metadata and nix check

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -1,3 +1,4 @@
+import distutils.spawn
 import logging
 import os
 from pathlib import Path
@@ -58,6 +59,11 @@ def pytest_configure(config: Any) -> None:
         "cardano-node-tests url"
     ] = f"{helpers.GITHUB_URL}/tree/{helpers.get_current_commit()}"
     config._metadata["HAS_DBSYNC"] = str(configuration.HAS_DBSYNC)
+    config._metadata["CARDANO_NODE_SOCKET_PATH"] = os.environ.get("CARDANO_NODE_SOCKET_PATH")
+    config._metadata["cardano-cli exe"] = distutils.spawn.find_executable("cardano-cli") or ""
+
+    if "nix/store" not in config._metadata["cardano-cli exe"]:
+        LOGGER.warning("WARNING: Not using `cardano-cli` from nix!")
 
 
 def _skip_all_tests(config: Any, items: list) -> None:


### PR DESCRIPTION
Will warn when `cardano-cli` is not running from nix:
```
$ pytest cardano-node-tests/cardano_node_tests/tests/test_transactions.py
WARNING: Not running `cardano-cli` from nix!
================================= test session starts =============
```

Also adds `CARDANO_NODE_SOCKET_PATH` and path to `cardano-cli` to metadata:
```
$ pytest cardano-node-tests/cardano_node_tests/tests/test_transactions.py
================================= test session starts =============
...
metadata: {..., 'cardano-cli exe': '/nix/store/bbfssn60bdq7r33xkgb2l4d9kxxdzn70-cardano-cli-exe-cardano-cli-1.27.0/bin/cardano-cli', 'CARDANO_NODE_SOCKET_PATH': '/home/martink/Source/repos/cardano-node/state-cluster0/bft1.socket'}
...
```