### PR TITLE
Exclude tests that require rewards from running on testnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifndef PYTEST_ARGS
 	pytest -s cardano_node_tests -m testnets --skipall --alluredir=$(ALLURE_DIR) >/dev/null
 endif
 # run tests for real and produce Allure results
-	pytest cardano_node_tests $(PYTEST_ARGS) $(CI_ARGS) -n $(TEST_THREADS) -m testnets --artifacts-base-dir=$(ARTIFACTS_DIR) --cli-coverage-dir=$(COVERAGE_DIR) --alluredir=$(ALLURE_DIR)
+	pytest cardano_node_tests $(PYTEST_ARGS) $(CI_ARGS) -n $(TEST_THREADS) -m "testnets and not rewards" --artifacts-base-dir=$(ARTIFACTS_DIR) --cli-coverage-dir=$(COVERAGE_DIR) --alluredir=$(ALLURE_DIR)
 
 # run linters
 lint:

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -295,6 +295,7 @@ class TestDelegateAddr:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.run(order=2)
+    @pytest.mark.rewards
     @pytest.mark.dbsync
     @pytest.mark.skipif(
         cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.TESTNET_NOPOOLS,
@@ -798,6 +799,7 @@ class TestRewards:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
+    @pytest.mark.rewards
     @pytest.mark.skipif(
         cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.TESTNET,
         reason="supposed to run on testnet with pools",

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ filterwarnings =
     ignore:.*You can change it to a module- or session-scoped fixture.*:FutureWarning
 markers =
     dbsync: test(s) for node + cardano-db-sync
+    rewards: test(s) that work with staking rewards
     testnets: test(s) can run on testnets, like Shelley_qa


### PR DESCRIPTION
For now, enable once stable testing pools are active on given testnet.