### PR TITLE
Temporary workaround for `QueryEncoderUnsupportedQuery`

### DIFF
--- a/cardano_node_tests/cluster_scripts/mary/config-bft1.json
+++ b/cardano_node_tests/cluster_scripts/mary/config-bft1.json
@@ -151,5 +151,6 @@
             "scRotation": null
         }
     ],
+    "TestEnableDevelopmentNetworkProtocols": true,
     "TestShelleyHardForkAtEpoch": 1
 }

--- a/cardano_node_tests/cluster_scripts/mary/config-pool1.json
+++ b/cardano_node_tests/cluster_scripts/mary/config-pool1.json
@@ -151,5 +151,6 @@
             "scRotation": null
         }
     ],
+    "TestEnableDevelopmentNetworkProtocols": true,
     "TestShelleyHardForkAtEpoch": 1
 }

--- a/cardano_node_tests/cluster_scripts/mary/config-pool2.json
+++ b/cardano_node_tests/cluster_scripts/mary/config-pool2.json
@@ -151,5 +151,6 @@
             "scRotation": null
         }
     ],
+    "TestEnableDevelopmentNetworkProtocols": true,
     "TestShelleyHardForkAtEpoch": 1
 }

--- a/cardano_node_tests/cluster_scripts/mary/config-pool3.json
+++ b/cardano_node_tests/cluster_scripts/mary/config-pool3.json
@@ -151,5 +151,6 @@
             "scRotation": null
         }
     ],
+    "TestEnableDevelopmentNetworkProtocols": true,
     "TestShelleyHardForkAtEpoch": 1
 }


### PR DESCRIPTION
```
$ cardano-cli query tip --testnet-magic 42

cardano-cli: QueryEncoderUnsupportedQuery Query GetSystemStart TopLevelQueryDisabled
```

Will be reverted once this issue is fixed.