### PR TITLE
Replace pytest-ordering with pytest-order

### DIFF
--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -126,7 +126,7 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
     assert epoch + 1 == cluster_obj.get_epoch()
 
 
-@pytest.mark.run(order=3)
+@pytest.mark.order(3)
 @pytest.mark.skipif(
     bool(configuration.TX_ERA),
     reason="different TX eras doesn't affect this test, pointless to run",
@@ -144,7 +144,7 @@ class TestBasic:
         check_epoch_length(cluster)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.run(order=2)
+    @pytest.mark.order(2)
     def test_slot_length(self, cluster_slot_length: clusterlib.ClusterLib):
         """Test the *slotLength* configuration."""
         cluster = cluster_slot_length

--- a/cardano_node_tests/tests/test_governance.py
+++ b/cardano_node_tests/tests/test_governance.py
@@ -40,7 +40,7 @@ def temp_dir(create_temp_dir: Path):
 pytestmark = pytest.mark.usefixtures("temp_dir")
 
 
-@pytest.mark.run(order=3)
+@pytest.mark.order(3)
 class TestUpdateProposal:
     """Tests for update proposal."""
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -86,7 +86,7 @@ class TestKES:
     """Basic tests for KES period."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.run(order=3)
+    @pytest.mark.order(3)
     @pytest.mark.skipif(
         bool(configuration.TX_ERA),
         reason="different TX eras doesn't affect this test, pointless to run",
@@ -121,7 +121,7 @@ class TestKES:
         assert cluster.get_slot_no() == init_slot, "Unexpected new slots"
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.run(order=1)
+    @pytest.mark.order(1)
     def test_opcert_future_kes_period(
         self,
         cluster_lock_pool2: clusterlib.ClusterLib,
@@ -233,7 +233,7 @@ class TestKES:
             )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.run(order=2)
+    @pytest.mark.order(2)
     def test_update_valid_opcert(
         self,
         cluster_lock_pool2: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -477,7 +477,7 @@ def _create_register_pool_tx_delegate_stake_tx(
     return pool_creation_out
 
 
-@pytest.mark.run(order=2)
+@pytest.mark.order(2)
 @pytest.mark.testnets
 class TestStakePool:
     """General tests for stake pools."""
@@ -1476,7 +1476,7 @@ class TestStakePool:
         )
 
 
-@pytest.mark.run(order=2)
+@pytest.mark.order(2)
 class TestPoolCost:
     """Tests for stake pool cost."""
 

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -235,7 +235,7 @@ def _delegate_stake_add(
 
 
 @pytest.mark.testnets
-@pytest.mark.run(order=3)
+@pytest.mark.order(3)
 class TestDelegateAddr:
     """Tests for address delegation to stake pools."""
 
@@ -324,7 +324,7 @@ class TestDelegateAddr:
             assert delegation_out.pool_id == tx_db_record.stake_delegation[0].pool_id
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.run(order=2)
+    @pytest.mark.order(2)
     @pytest.mark.dbsync
     def test_deregister(
         self,
@@ -796,7 +796,7 @@ class TestNegative:
         assert "StakeKeyNonZeroAccountBalanceDELEG" in str(excinfo.value)
 
 
-@pytest.mark.run(order=1)
+@pytest.mark.order(1)
 class TestRewards:
     """Tests for checking expected rewards."""
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -39,7 +39,7 @@ let
           cardano-clusterlib
           pytest-allure
           pytest-html
-          pytest-ordering
+          pytest-order
           pytest_xdist
           pyyaml
           setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 # linting
 mypy==0.812
 pre-commit
-pylint
+pylint==2.8.3
 
 # documentation
 Sphinx==3.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pydantic
 pytest
 pytest-html
 pytest-metadata
-pytest-ordering
+pytest-order
 pytest-xdist
 pyyaml
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     pytest
     pytest-html
     pytest-metadata
-    pytest-ordering
+    pytest-order
     pytest-xdist
     pyyaml
     requests


### PR DESCRIPTION
Fixes nix build issue

```
Package ‘python3.8-pytest-ordering-unstable-2019-06-19’ in /nix/store/r2ygiv90x2qg2bpxilzabfad1ixnprv6-nixpkgs-unstable-src/pkgs/development/python-modules/pytest-ordering/default.nix:27 is marked as broken, refusing to evaluate.
```