### PR TITLE
Skip the `TestManyUTXOs` tests when cluster era != Tx era

### DIFF
--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -1062,6 +1062,10 @@ class TestMultiInOut:
         )
 
 
+@pytest.mark.skipif(
+    VERSIONS.cluster_era != VERSIONS.transaction_era,
+    reason="expensive test, skip when cluster era is different from TX era",
+)
 class TestManyUTXOs:
     """Test transaction with many UTxOs and small amounts of Lovelace."""
 


### PR DESCRIPTION
These tests require lot of memory, relieve CI a bit.