### PR TITLE
Remove workaround with `tomli` dependency

### DIFF
--- a/nix/cardano-clusterlib.nix
+++ b/nix/cardano-clusterlib.nix
@@ -2,10 +2,10 @@
 
 buildPythonPackage rec {
   pname = "cardano-clusterlib";
-  version = "0.1.37";
+  version = "0.1.38";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08shsp4l31sqqpjpf5lx4hvvrh81nsscgl0c5njyqh54qx64phbh";
+    sha256 = "036f96ax5kjl6zhkaw2jlk6j9n6xlbpkp9rp17haj6b33cai5bsb";
   };
   doCheck = false;
   nativeBuildInputs = [ setuptools_scm ];

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ zip_safe = False
 include_package_data = True
 packages = find:
 setup_requires =
-    tomli
     setuptools_scm
 install_requires =
     allure-pytest


### PR DESCRIPTION
It broke nix-shell and is no longer needed.