### PR TITLE
Remove `dbsync` mark from non-dbsync tests

### DIFF
--- a/cardano_node_tests/tests/test_plutus_spend_build.py
+++ b/cardano_node_tests/tests/test_plutus_spend_build.py
@@ -951,7 +951,6 @@ class TestBuildLocking:
         assert "Expected key witnessed collateral" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.testnets
     def test_no_datum_txin(
         self,

--- a/cardano_node_tests/tests/test_plutus_spend_raw.py
+++ b/cardano_node_tests/tests/test_plutus_spend_raw.py
@@ -963,7 +963,6 @@ class TestLocking:
         assert "InsufficientCollateral" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.testnets
     def test_no_datum_txin(
         self,


### PR DESCRIPTION
2 tests were mistakenly marked with `dbsync` tag.