### PR TITLE
Simplify getting cluster instance num

### DIFF
--- a/cardano_node_tests/tests/test_metrics.py
+++ b/cardano_node_tests/tests/test_metrics.py
@@ -135,7 +135,7 @@ class TestPrometheus:
         # pylint: disable=unused-argument
         prometheus_port = (
             cluster_nodes.get_cluster_type()
-            .cluster_scripts.get_instance_ports(cluster_nodes.get_cluster_env().instance_num)
+            .cluster_scripts.get_instance_ports(cluster_nodes.get_instance_num())
             .prometheus_pool1
         )
 
@@ -162,7 +162,7 @@ class TestEKG:
         # pylint: disable=unused-argument
         ekg_port = (
             cluster_nodes.get_cluster_type()
-            .cluster_scripts.get_instance_ports(cluster_nodes.get_cluster_env().instance_num)
+            .cluster_scripts.get_instance_ports(cluster_nodes.get_instance_num())
             .ekg_pool1
         )
 

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -295,7 +295,7 @@ def get_cluster_type() -> ClusterType:
 
 def get_cardano_node_socket_path(instance_num: int) -> Path:
     """Return path to socket file in the given cluster instance."""
-    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).resolve()
+    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"])
     state_cluster_dirname = f"state-cluster{instance_num}"
     state_cluster = socket_path.parent.parent / state_cluster_dirname
     new_socket_path = state_cluster / socket_path.name
@@ -316,9 +316,16 @@ def set_cluster_env(instance_num: int) -> None:
         os.environ["PGUSER"] = "postgres"
 
 
+def get_instance_num() -> int:
+    """Get cardano cluster instance number."""
+    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"])
+    instance_num = int(socket_path.parent.name.replace("state-cluster", "") or 0)
+    return instance_num
+
+
 def get_cluster_env() -> ClusterEnv:
     """Get cardano cluster environment."""
-    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).expanduser().resolve()
+    socket_path = Path(os.environ["CARDANO_NODE_SOCKET_PATH"])
     state_dir = socket_path.parent
     work_dir = state_dir.parent
     instance_num = int(state_dir.name.replace("state-cluster", "") or 0)

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -3,6 +3,12 @@ import os
 from pathlib import Path
 
 
+# resolve CARDANO_NODE_SOCKET_PATH
+os.environ["CARDANO_NODE_SOCKET_PATH"] = str(
+    Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).expanduser().resolve()
+)
+
+
 CLUSTER_ERA = os.environ.get("CLUSTER_ERA") or ""
 if CLUSTER_ERA not in ("", "mary", "alonzo"):
     raise RuntimeError(f"Invalid CLUSTER_ERA: {CLUSTER_ERA}")

--- a/cardano_node_tests/utils/dbsync_conn.py
+++ b/cardano_node_tests/utils/dbsync_conn.py
@@ -39,7 +39,7 @@ class DBSync:
 
     @classmethod
     def conn(cls) -> psycopg2.extensions.connection:
-        instance_num = cluster_nodes.get_cluster_env().instance_num
+        instance_num = cluster_nodes.get_instance_num()
         conn = cls.conn_cache.get(instance_num)
 
         if conn is None or conn.closed == 1:
@@ -49,7 +49,7 @@ class DBSync:
 
     @classmethod
     def reconn(cls) -> psycopg2.extensions.connection:
-        instance_num = cluster_nodes.get_cluster_env().instance_num
+        instance_num = cluster_nodes.get_instance_num()
         conn = cls.conn_cache.get(instance_num)
         cls._close(instance_num=instance_num, conn=conn)
         conn = cls._conn(instance_num=instance_num)


### PR DESCRIPTION
This is needed often, so standalone `get_instance_num` added.