### PR TITLE
Fix issue with nix unexpected argument

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,6 +2,7 @@
 , crossSystem ? null
 , config ? {}
 , sourcesOverride ? {}
+, ...
 }:
 
 let


### PR DESCRIPTION
Error details: 

```
trap 'kill -- $$' INT TERM QUIT; mkdir -p /scratch/cardano-node-tests
./.buildkite/nightly_dbsync.sh
error: anonymous function at /var/lib/buildkite-agent-iohk/builds/packet-ipxe-5-ci5-1/input-output-hk/cardano-node-tests-dbsync/nix/default.nix:1:1 called with unexpected argument 'inNixShell'
 
       at «string»:1:18:
 
            1| {...}@args: with import <nixpkgs> args; (pkgs.runCommandCC or pkgs.runCommand) "shell" { buildInputs = [ (niv) (nix) (gnugrep) (gnumake) (gnutar) (coreutils) (adoptopenjdk-jre-bin) (curl) (git) ]; } ""
             |                  ^
 
       … while evaluating anonymous lambda
 
       at «string»:1:1:
 
            1| {...}@args: with import <nixpkgs> args; (pkgs.runCommandCC or pkgs.runCommand) "shell" { buildInputs = [ (niv) (nix) (gnugrep) (gnumake) (gnutar) (coreutils) (adoptopenjdk-jre-bin) (curl) (git) ]; } ""
             | ^
 
       … from call site
🚨 Error: The command exited with status 1
user command error: exit status 1
```