### PR TITLE
Fix skips when both cluster and transaction era are specified

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -45,7 +45,7 @@ class TestCLI:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
     @pytest.mark.skipif(
-        VERSIONS.cluster_era != VERSIONS.transaction_era,
+        VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
         reason="different TX eras doesn't affect this test",
     )
     def test_protocol_mode(self, cluster: clusterlib.ClusterLib):
@@ -64,7 +64,7 @@ class TestCLI:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.cluster_era != VERSIONS.transaction_era,
+        VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
         reason="different TX eras doesn't affect this test",
     )
     def test_whole_utxo(self, cluster: clusterlib.ClusterLib):
@@ -82,7 +82,7 @@ class TestCLI:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.cluster_era != VERSIONS.transaction_era,
+        VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
         reason="different TX eras doesn't affect this test",
     )
     @pytest.mark.skipif(

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -12,8 +12,8 @@ from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import cluster_management
 from cardano_node_tests.utils import cluster_nodes
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
 
 @pytest.mark.order(3)
 @pytest.mark.skipif(
-    bool(configuration.TX_ERA),
+    VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
     reason="different TX eras doesn't affect this test, pointless to run",
 )
 class TestBasic:

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -18,6 +18,7 @@ from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import logfiles
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -324,7 +325,7 @@ class TestKES:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        bool(configuration.TX_ERA),
+        VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
         reason="different TX eras doesn't affect this test, pointless to run",
     )
     def test_no_kes_period_arg(

--- a/cardano_node_tests/tests/test_ledger_state.py
+++ b/cardano_node_tests/tests/test_ledger_state.py
@@ -8,8 +8,8 @@ from _pytest.tmpdir import TempdirFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import clusterlib_utils
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class TestLedgerState:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        bool(configuration.TX_ERA),
+        VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
         reason="different TX eras doesn't affect this test, pointless to run",
     )
     def test_ledger_state_keys(self, cluster: clusterlib.ClusterLib):

--- a/cardano_node_tests/tests/test_metrics.py
+++ b/cardano_node_tests/tests/test_metrics.py
@@ -12,6 +12,7 @@ from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import model_ekg
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ def get_ekg_metrics(port: int) -> requests.Response:
 
 
 @pytest.mark.skipif(
-    bool(configuration.TX_ERA),
+    VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
     reason="different TX eras doesn't affect this test, pointless to run",
 )
 class TestPrometheus:
@@ -147,7 +148,7 @@ class TestPrometheus:
 
 
 @pytest.mark.skipif(
-    bool(configuration.TX_ERA),
+    VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
     reason="different TX eras doesn't affect this test, pointless to run",
 )
 class TestEKG:

--- a/cardano_node_tests/tests/test_protocol.py
+++ b/cardano_node_tests/tests/test_protocol.py
@@ -8,8 +8,8 @@ import pytest
 from _pytest.tmpdir import TempdirFactory
 from cardano_clusterlib import clusterlib
 
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ PROTOCOL_PARAM_KEYS = (
 
 @pytest.mark.testnets
 @pytest.mark.skipif(
-    bool(configuration.TX_ERA),
+    VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
     reason="different TX eras doesn't affect this test, pointless to run",
 )
 class TestProtocol:

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -15,7 +15,7 @@ class Versions:
     ALONZO = 5
 
     DEFAULT_CLUSTER_ERA = 5
-    DEFAULT_TX_ERA = 4
+    DEFAULT_TX_ERA = 5
     LAST_KNOWN_ERA = 5
 
     MAP = {1: "byron", 2: "shelley", 3: "allegra", 4: "mary", 5: "alonzo"}


### PR DESCRIPTION
Some tests are meant to run only with default transaction era. These tests were skipped when transaction era was specified. However in nightly CI jobs the transaction era is always specified, so these tests were always skipped.

This PR changes the logic so that the tests run with default transaction era regardless whether it was specified or not.