### PR TITLE
Update scripts to use db-sync instead of db-sync-extended

### DIFF
--- a/.buildkite/nightly_dbsync.sh
+++ b/.buildkite/nightly_dbsync.sh
@@ -37,7 +37,7 @@ fi
 git rev-parse HEAD
 
 # build db-sync
-nix-build -A cardano-db-sync-extended -o db-sync-node-extended
+nix-build -A cardano-db-sync -o db-sync-node
 export DBSYNC_REPO="$PWD"
 
 pushd "$REPODIR"

--- a/cardano_node_tests/cluster_scripts/alonzo/run_dbsync.sh
+++ b/cardano_node_tests/cluster_scripts/alonzo/run_dbsync.sh
@@ -13,4 +13,4 @@ export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-exec "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"
+exec "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"

--- a/cardano_node_tests/cluster_scripts/alonzo/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/alonzo/start-cluster-hfc
@@ -56,8 +56,8 @@ cp "$SCRIPT_DIR/genesis.spec.json" "$STATE_CLUSTER/shelley/genesis.spec.json"
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   "$SCRIPT_DIR/postgres-setup.sh"

--- a/cardano_node_tests/cluster_scripts/alonzo_pv5/run_dbsync.sh
+++ b/cardano_node_tests/cluster_scripts/alonzo_pv5/run_dbsync.sh
@@ -13,4 +13,4 @@ export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-exec "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"
+exec "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"

--- a/cardano_node_tests/cluster_scripts/alonzo_pv5/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/alonzo_pv5/start-cluster-hfc
@@ -56,8 +56,8 @@ cp "$SCRIPT_DIR/genesis.spec.json" "$STATE_CLUSTER/shelley/genesis.spec.json"
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   "$SCRIPT_DIR/postgres-setup.sh"

--- a/cardano_node_tests/cluster_scripts/mary/run_dbsync.sh
+++ b/cardano_node_tests/cluster_scripts/mary/run_dbsync.sh
@@ -13,4 +13,4 @@ export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-exec "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"
+exec "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"

--- a/cardano_node_tests/cluster_scripts/mary/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/mary/start-cluster-hfc
@@ -56,8 +56,8 @@ cp "$SCRIPT_DIR/genesis.spec.json" "$STATE_CLUSTER/shelley/genesis.spec.json"
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   "$SCRIPT_DIR/postgres-setup.sh"

--- a/cardano_node_tests/cluster_scripts/testnets_nopools/run_dbsync.sh
+++ b/cardano_node_tests/cluster_scripts/testnets_nopools/run_dbsync.sh
@@ -18,4 +18,4 @@ export PGPASSFILE="$STATE_CLUSTER/pgpass"
 echo "${PGHOST}:${PGPORT}:${DATABASE_NAME}:${PGUSER}:secret" > "$PGPASSFILE"
 chmod 600 "$PGPASSFILE"
 
-exec "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"
+exec "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"

--- a/cardano_node_tests/cluster_scripts/testnets_nopools/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets_nopools/start-cluster
@@ -52,8 +52,8 @@ chmod u+w "$STATE_CLUSTER"/config-*.json
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node-extended/bin/cardano-db-sync-extended\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # copy db-sync config file
   cp "$TESTNET_CONF_DIR/dbsync-config.yaml" "$STATE_CLUSTER/dbsync-config.yaml"


### PR DESCRIPTION
cardano-db-sync and cardano-db-sync-extended were merged.
Target db-sync-extended does not exists on master anymore.

Details here:
https://github.com/input-output-hk/cardano-db-sync/pull/904