### PR TITLE
Fix CI error about missing db-sync-extended

### DIFF
--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -26,10 +26,7 @@ NOPOOLS = bool(os.environ.get("NOPOOLS"))
 HAS_DBSYNC = bool(os.environ.get("DBSYNC_REPO"))
 if HAS_DBSYNC:
     DBSYNC_BIN = (
-        Path(os.environ["DBSYNC_REPO"])
-        / "db-sync-node-extended"
-        / "bin"
-        / "cardano-db-sync-extended"
+        Path(os.environ["DBSYNC_REPO"]) / "db-sync-node" / "bin" / "cardano-db-sync"
     ).resolve()
 else:
     DBSYNC_BIN = Path("nonexistent")


### PR DESCRIPTION
Missing changes during db-sync scripts update for config file caused CI
error:
```
E   FileNotFoundError: [Errno 2] No such file or directory: '/scratch/workdir/cardano-db-sync/db-sync-node-extended/bin/cardano-db-sync-extended'
```