### PR TITLE
Better metrics skip

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -50,8 +50,6 @@ def pytest_addoption(parser: Any) -> None:
 
 
 def pytest_configure(config: Any) -> None:
-    # for detecting if code is running in pytest, or imported while e.g. building documentation
-    configuration._called_from_test = True  # type: ignore
     config._metadata["cardano-node"] = str(VERSIONS.node)
     config._metadata["cardano-node rev"] = VERSIONS.git_rev
     config._metadata["ghc"] = VERSIONS.ghc

--- a/cardano_node_tests/tests/test_metrics.py
+++ b/cardano_node_tests/tests/test_metrics.py
@@ -9,15 +9,11 @@ from _pytest.tmpdir import TempdirFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import cluster_nodes
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import model_ekg
 from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
-
-if getattr(configuration, "_called_from_test", None):
-    pytest.skip("metrics data are not stable yet", allow_module_level=True)
 
 
 @pytest.fixture(scope="module")
@@ -35,65 +31,10 @@ def temp_dir(create_temp_dir: Path):
         yield create_temp_dir
 
 
-# use the "temp_dir" fixture for all tests automatically
-pytestmark = pytest.mark.usefixtures("temp_dir")
-
-
-EXPECTED_METRICS = [
-    "cardano_node_metrics_Forge_adopted_int",
-    "cardano_node_metrics_Forge_forge_about_to_lead_int",
-    "cardano_node_metrics_Forge_forged_int",
-    "cardano_node_metrics_Forge_node_is_leader_int",
-    "cardano_node_metrics_Forge_node_not_leader_int",
-    "cardano_node_metrics_Mem_resident_int",
-    "cardano_node_metrics_RTS_gcLiveBytes_int",
-    "cardano_node_metrics_RTS_gcMajorNum_int",
-    "cardano_node_metrics_RTS_gcMinorNum_int",
-    "cardano_node_metrics_RTS_gcticks_int",
-    "cardano_node_metrics_RTS_mutticks_int",
-    "cardano_node_metrics_Stat_cputicks_int",
-    "cardano_node_metrics_Stat_threads_int",
-    "cardano_node_metrics_blockNum_int",
-    "cardano_node_metrics_blocksForgedNum_int",
-    "cardano_node_metrics_currentKESPeriod_int",
-    "cardano_node_metrics_delegMapSize_int",
-    "cardano_node_metrics_density_real",
-    "cardano_node_metrics_epoch_int",
-    "cardano_node_metrics_mempoolBytes_int",
-    "cardano_node_metrics_myBlocksUncoupled_int",
-    "cardano_node_metrics_nodeIsLeaderNum_int",
-    "cardano_node_metrics_nodeStartTime_int",
-    "cardano_node_metrics_operationalCertificateExpiryKESPeriod_int",
-    "cardano_node_metrics_operationalCertificateStartKESPeriod_int",
-    "cardano_node_metrics_remainingKESPeriods_int",
-    "cardano_node_metrics_served_header_counter_int",
-    "cardano_node_metrics_slotInEpoch_int",
-    "cardano_node_metrics_slotNum_int",
-    "cardano_node_metrics_txsInMempool_int",
-    "cardano_node_metrics_txsProcessedNum_int",
-    "cardano_node_metrics_utxoSize_int",
-    "ekg_server_timestamp_ms",
-    "rts_gc_bytes_allocated",
-    "rts_gc_bytes_copied",
-    "rts_gc_cpu_ms",
-    "rts_gc_cumulative_bytes_used",
-    "rts_gc_current_bytes_slop",
-    "rts_gc_current_bytes_used",
-    "rts_gc_gc_cpu_ms",
-    "rts_gc_gc_wall_ms",
-    "rts_gc_init_cpu_ms",
-    "rts_gc_init_wall_ms",
-    "rts_gc_max_bytes_slop",
-    "rts_gc_max_bytes_used",
-    "rts_gc_mutator_cpu_ms",
-    "rts_gc_mutator_wall_ms",
-    "rts_gc_num_bytes_usage_samples",
-    "rts_gc_num_gcs",
-    "rts_gc_par_avg_bytes_copied",
-    "rts_gc_par_max_bytes_copied",
-    "rts_gc_par_tot_bytes_copied",
-    "rts_gc_peak_megabytes_allocated",
-    "rts_gc_wall_ms",
+# use the "temp_dir" fixture for all tests automatically; skip all tests for now
+pytestmark = [
+    pytest.mark.skip(reason="metrics data are not stable yet"),
+    pytest.mark.usefixtures("temp_dir"),
 ]
 
 
@@ -127,6 +68,63 @@ def get_ekg_metrics(port: int) -> requests.Response:
 class TestPrometheus:
     """Prometheus metrics tests."""
 
+    EXPECTED_METRICS = [
+        "cardano_node_metrics_Forge_adopted_int",
+        "cardano_node_metrics_Forge_forge_about_to_lead_int",
+        "cardano_node_metrics_Forge_forged_int",
+        "cardano_node_metrics_Forge_node_is_leader_int",
+        "cardano_node_metrics_Forge_node_not_leader_int",
+        "cardano_node_metrics_Mem_resident_int",
+        "cardano_node_metrics_RTS_gcLiveBytes_int",
+        "cardano_node_metrics_RTS_gcMajorNum_int",
+        "cardano_node_metrics_RTS_gcMinorNum_int",
+        "cardano_node_metrics_RTS_gcticks_int",
+        "cardano_node_metrics_RTS_mutticks_int",
+        "cardano_node_metrics_Stat_cputicks_int",
+        "cardano_node_metrics_Stat_threads_int",
+        "cardano_node_metrics_blockNum_int",
+        "cardano_node_metrics_blocksForgedNum_int",
+        "cardano_node_metrics_currentKESPeriod_int",
+        "cardano_node_metrics_delegMapSize_int",
+        "cardano_node_metrics_density_real",
+        "cardano_node_metrics_epoch_int",
+        "cardano_node_metrics_mempoolBytes_int",
+        "cardano_node_metrics_myBlocksUncoupled_int",
+        "cardano_node_metrics_nodeIsLeaderNum_int",
+        "cardano_node_metrics_nodeStartTime_int",
+        "cardano_node_metrics_operationalCertificateExpiryKESPeriod_int",
+        "cardano_node_metrics_operationalCertificateStartKESPeriod_int",
+        "cardano_node_metrics_remainingKESPeriods_int",
+        "cardano_node_metrics_served_header_counter_int",
+        "cardano_node_metrics_slotInEpoch_int",
+        "cardano_node_metrics_slotNum_int",
+        "cardano_node_metrics_txsInMempool_int",
+        "cardano_node_metrics_txsProcessedNum_int",
+        "cardano_node_metrics_utxoSize_int",
+        "ekg_server_timestamp_ms",
+        "rts_gc_bytes_allocated",
+        "rts_gc_bytes_copied",
+        "rts_gc_cpu_ms",
+        "rts_gc_cumulative_bytes_used",
+        "rts_gc_current_bytes_slop",
+        "rts_gc_current_bytes_used",
+        "rts_gc_gc_cpu_ms",
+        "rts_gc_gc_wall_ms",
+        "rts_gc_init_cpu_ms",
+        "rts_gc_init_wall_ms",
+        "rts_gc_max_bytes_slop",
+        "rts_gc_max_bytes_used",
+        "rts_gc_mutator_cpu_ms",
+        "rts_gc_mutator_wall_ms",
+        "rts_gc_num_bytes_usage_samples",
+        "rts_gc_num_gcs",
+        "rts_gc_par_avg_bytes_copied",
+        "rts_gc_par_max_bytes_copied",
+        "rts_gc_par_tot_bytes_copied",
+        "rts_gc_peak_megabytes_allocated",
+        "rts_gc_wall_ms",
+    ]
+
     @allure.link(helpers.get_vcs_link())
     def test_available_metrics(
         self,
@@ -144,7 +142,7 @@ class TestPrometheus:
 
         metrics = response.text.strip().split("\n")
         metrics_keys = sorted(m.split(" ")[0] for m in metrics)
-        assert metrics_keys == EXPECTED_METRICS, "Metrics differ"
+        assert metrics_keys == self.EXPECTED_METRICS, "Metrics differ"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This way tests will be skipped only when they were selected to run, not everytime the test file is imported.