### PR TITLE
Reorder tests

### DIFF
--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -134,7 +134,7 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
     assert epoch + 1 == cluster_obj.get_epoch()
 
 
-@pytest.mark.order(3)
+@pytest.mark.order(5)
 @pytest.mark.skipif(
     VERSIONS.transaction_era != VERSIONS.DEFAULT_TX_ERA,
     reason="different TX eras doesn't affect this test, pointless to run",
@@ -153,7 +153,6 @@ class TestBasic:
         check_epoch_length(cluster)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(2)
     def test_slot_length(self, cluster_slot_length: clusterlib.ClusterLib):
         """Test the *slotLength* configuration."""
         cluster = cluster_slot_length

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -92,7 +92,7 @@ def pool_users_disposable(
 
 
 @pytest.mark.testnets
-@pytest.mark.order(3)
+@pytest.mark.order(8)
 class TestDelegateAddr:
     """Tests for address delegation to stake pools."""
 
@@ -207,7 +207,7 @@ class TestDelegateAddr:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(2)
+    @pytest.mark.order(7)
     @pytest.mark.dbsync
     @pytest.mark.long
     def test_deregister(
@@ -329,7 +329,7 @@ class TestDelegateAddr:
             assert delegation_out.pool_user.stake.address in tx_db_dereg.stake_deregistration
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(2)
+    @pytest.mark.order(7)
     @pytest.mark.dbsync
     @pytest.mark.long
     def test_undelegate(

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -108,7 +108,7 @@ class TestKES:
     """Basic tests for KES period."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(3)
+    @pytest.mark.order(5)
     @pytest.mark.skipif(
         not (VERSIONS.cluster_era == VERSIONS.transaction_era == VERSIONS.LAST_KNOWN_ERA),
         reason="meant to run only with the latest cluster era and the latest transaction era",
@@ -142,7 +142,7 @@ class TestKES:
         assert cluster.get_slot_no() == init_slot, "Unexpected new slots"
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(1)
+    @pytest.mark.order(6)
     def test_opcert_future_kes_period(
         self,
         cluster_lock_pool2: clusterlib.ClusterLib,
@@ -258,7 +258,7 @@ class TestKES:
             )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(2)
+    @pytest.mark.order(7)
     def test_update_valid_opcert(
         self,
         cluster_lock_pool2: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -629,7 +629,7 @@ def _create_register_pool_tx_delegate_stake_tx(
     return pool_creation_out
 
 
-@pytest.mark.order(2)
+@pytest.mark.order(7)
 @pytest.mark.testnets
 @pytest.mark.long
 @pytest.mark.dbsync
@@ -1767,7 +1767,7 @@ class TestStakePool:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.order(2)
+@pytest.mark.order(5)
 class TestPoolCost:
     """Tests for stake pool cost."""
 

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -324,7 +324,7 @@ def _get_reward_type_for_key_hash(key_hash: str, rec: list) -> List[str]:
     return rew_types
 
 
-@pytest.mark.order(1)
+@pytest.mark.order(6)
 @pytest.mark.long
 class TestRewards:
     """Tests for checking expected rewards."""

--- a/cardano_node_tests/tests/test_update_proposals.py
+++ b/cardano_node_tests/tests/test_update_proposals.py
@@ -36,7 +36,7 @@ def temp_dir(create_temp_dir: Path):
 pytestmark = pytest.mark.usefixtures("temp_dir")
 
 
-@pytest.mark.order(3)
+@pytest.mark.order(8)
 class TestUpdateProposals:
     """Tests for update proposals."""
 


### PR DESCRIPTION
The full testrun execution should now be quicker. Highest priority is
now 5 (instead of former 1), so we have buffer for even more priority tests in
the future without the need to re-number everything.