### PR TITLE
Fix failure when some of the items of tuple is None

### DIFF
--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -96,7 +96,7 @@ class TestDBSync:
         assert self.DBSYNC_TABLES.issubset(dbsync_queries.query_table_names())
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.order(-1)
+    @pytest.mark.order(-10)
     @pytest.mark.testnets
     def test_blocks(self, cluster):  # noqa: C901
         """Check expected values in the `block` table in db-sync."""
@@ -135,13 +135,13 @@ class TestDBSync:
                     f"Expected: positive int vs Returned: {rec.epoch_no}"
                 )
 
-            if rec.epoch_no < prev_rec.epoch_no:
+            if rec.epoch_no and prev_rec.epoch_no and rec.epoch_no < prev_rec.epoch_no:
                 errors.append(
                     "'epoch_no' value is different than expected; "
                     f"Expected: value >= {prev_rec.epoch_no} vs Returned: {rec.epoch_no}"
                 )
 
-            if rec.epoch_no > prev_rec.epoch_no + 1:
+            if rec.epoch_no and prev_rec.epoch_no and rec.epoch_no > prev_rec.epoch_no + 1:
                 errors.append(
                     "'epoch_no' value is different than expected; "
                     f"Expected: {prev_rec.epoch_no} or {prev_rec.epoch_no + 1}"
@@ -154,7 +154,7 @@ class TestDBSync:
                     f"Expected: positive int vs Returned: {rec.slot_no}"
                 )
 
-            if rec.slot_no < prev_rec.slot_no:
+            if rec.slot_no and prev_rec.slot_no and rec.slot_no < prev_rec.slot_no:
                 errors.append(
                     "'slot_no' value is different than expected; "
                     f"Expected: value >= {prev_rec.slot_no} vs Returned: {rec.slot_no}"
@@ -166,19 +166,26 @@ class TestDBSync:
                     f"Expected: positive int vs Returned: {rec.epoch_slot_no}"
                 )
 
-            if rec.epoch_slot_no <= prev_rec.epoch_slot_no and rec.epoch_no == prev_rec.epoch_no:
+            if (
+                rec.epoch_slot_no
+                and prev_rec.epoch_slot_no
+                and rec.epoch_slot_no <= prev_rec.epoch_slot_no
+                and rec.epoch_no == prev_rec.epoch_no
+            ):
                 errors.append(
                     "'epoch_slot_no' value is different than expected; "
                     f"Expected: value > {prev_rec.epoch_slot_no} vs Returned: {rec.epoch_slot_no}"
                 )
 
-            if rec.block_no is None or rec.block_no != prev_rec.block_no + 1:
+            if rec.block_no is None or (
+                prev_rec.block_no and rec.block_no != prev_rec.block_no + 1
+            ):
                 errors.append(
                     "'block_no' value is different than expected; "
                     f"Expected: {prev_rec.block_no + 1} vs Returned: {rec.block_no}"
                 )
 
-            if rec.previous_id is None or rec.previous_id != prev_rec.id:
+            if rec.previous_id is None or (prev_rec.id and rec.previous_id != prev_rec.id):
                 errors.append(
                     "'previous_id' value is different than expected; "
                     f"Expected: {prev_rec.id} vs Returned: {rec.previous_id}"


### PR DESCRIPTION
It can result in failures like
```
>           if rec.slot_no < prev_rec.slot_no:
E           TypeError: '<' not supported between instances of 'int' and 'NoneType'
```