### PR TITLE
Restart cluster instance when any service fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ tests: .dirs .run_tests
 
 
 # run all enabled tests on testnet, generate allure report
-testnets: export DbSyncAbortOnPanic=1
 testnets: export NOPOOLS=1
 testnets: export CLUSTERS_COUNT=1
 testnets: export FORBID_RESTART=1

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -46,8 +46,7 @@ def save_cluster_artifacts(save_dir: Path, state_dir: Path) -> None:
     destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{helpers.get_rand_str(8)}"
     destdir.mkdir(parents=True)
 
-    files_list = list(state_dir.glob("*.std*"))
-    files_list.extend(list(state_dir.glob("*.json")))
+    files_list = [*state_dir.glob("*.std*"), *state_dir.glob("*.json"), *state_dir.glob("*.log")]
     dirs_to_copy = ("nodes", "shelley")
 
     for fpath in files_list:

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -87,7 +87,12 @@ def environ(env: dict) -> Iterator[None]:
                 os.environ[key] = value
 
 
-def run_command(command: Union[str, list], workdir: FileType = "", shell: bool = False) -> bytes:
+def run_command(
+    command: Union[str, list],
+    workdir: FileType = "",
+    ignore_fail: bool = False,
+    shell: bool = False,
+) -> bytes:
     """Run command."""
     cmd: Union[str, list]
     if isinstance(command, str):
@@ -103,7 +108,7 @@ def run_command(command: Union[str, list], workdir: FileType = "", shell: bool =
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
     stdout, stderr = p.communicate()
 
-    if p.returncode != 0:
+    if not ignore_fail and p.returncode != 0:
         err_dec = stderr.decode()
         err_dec = err_dec or stdout.decode()
         raise AssertionError(f"An error occurred while running `{command}`: {err_dec}")


### PR DESCRIPTION
We now run db-sync tests with `DbSyncAbortOnPanic=1`. That means db-sync service fails on serious errors and keeps failing after restart. While it is desirable to not test on db-sync that is no longer in reliable state, it affects all remaining tests as there's no longer a working db-sync service.
This PR adds checks that all cluster instance services are healthy. If that's not the case, a fresh cluster instance is started.