### PR TITLE
Change supervisor.conf

### DIFF
--- a/cardano_node_tests/cluster_scripts/alonzo/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/alonzo/start-cluster-hfc
@@ -115,6 +115,8 @@ command=$SCRIPT_DIR/run_dbsync.sh
 stderr_logfile=./$STATE_CLUSTER_NAME/dbsync.stderr
 stdout_logfile=./$STATE_CLUSTER_NAME/dbsync.stdout
 autostart=false
+autorestart=false
+startsecs=3
 EoF
 fi
 

--- a/cardano_node_tests/cluster_scripts/alonzo/supervisor.conf
+++ b/cardano_node_tests/cluster_scripts/alonzo/supervisor.conf
@@ -5,21 +5,25 @@ port=127.0.0.1:9001
 command=./state-cluster/cardano-node-bft1
 stderr_logfile=./state-cluster/bft1.stderr
 stdout_logfile=./state-cluster/bft1.stdout
+startsecs=3
 
 [program:pool1]
 command=./state-cluster/cardano-node-pool1
 stderr_logfile=./state-cluster/pool1.stderr
 stdout_logfile=./state-cluster/pool1.stdout
+startsecs=3
 
 [program:pool2]
 command=./state-cluster/cardano-node-pool2
 stderr_logfile=./state-cluster/pool2.stderr
 stdout_logfile=./state-cluster/pool2.stdout
+startsecs=3
 
 [program:pool3]
 command=./state-cluster/cardano-node-pool3
 stderr_logfile=./state-cluster/pool3.stderr
 stdout_logfile=./state-cluster/pool3.stdout
+startsecs=3
 
 [group:nodes]
 programs=bft1,pool1,pool2,pool3

--- a/cardano_node_tests/cluster_scripts/alonzo_p2p/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/alonzo_p2p/start-cluster-hfc
@@ -115,6 +115,8 @@ command=$SCRIPT_DIR/run_dbsync.sh
 stderr_logfile=./$STATE_CLUSTER_NAME/dbsync.stderr
 stdout_logfile=./$STATE_CLUSTER_NAME/dbsync.stdout
 autostart=false
+autorestart=false
+startsecs=3
 EoF
 fi
 

--- a/cardano_node_tests/cluster_scripts/alonzo_p2p/supervisor.conf
+++ b/cardano_node_tests/cluster_scripts/alonzo_p2p/supervisor.conf
@@ -5,21 +5,25 @@ port=127.0.0.1:9001
 command=./state-cluster/cardano-node-bft1
 stderr_logfile=./state-cluster/bft1.stderr
 stdout_logfile=./state-cluster/bft1.stdout
+startsecs=3
 
 [program:pool1]
 command=./state-cluster/cardano-node-pool1
 stderr_logfile=./state-cluster/pool1.stderr
 stdout_logfile=./state-cluster/pool1.stdout
+startsecs=3
 
 [program:pool2]
 command=./state-cluster/cardano-node-pool2
 stderr_logfile=./state-cluster/pool2.stderr
 stdout_logfile=./state-cluster/pool2.stdout
+startsecs=3
 
 [program:pool3]
 command=./state-cluster/cardano-node-pool3
 stderr_logfile=./state-cluster/pool3.stderr
 stdout_logfile=./state-cluster/pool3.stdout
+startsecs=3
 
 [group:nodes]
 programs=bft1,pool1,pool2,pool3

--- a/cardano_node_tests/cluster_scripts/testnets/supervisor.conf
+++ b/cardano_node_tests/cluster_scripts/testnets/supervisor.conf
@@ -5,16 +5,19 @@ port=127.0.0.1:9001
 command=./state-cluster/cardano-node-relay1
 stderr_logfile=./state-cluster/relay1.stderr
 stdout_logfile=./state-cluster/relay1.stdout
+startsecs=3
 
 [program:pool1]
 command=./state-cluster/cardano-node-pool1
 stderr_logfile=./state-cluster/pool1.stderr
 stdout_logfile=./state-cluster/pool1.stdout
+startsecs=3
 
 [program:pool2]
 command=./state-cluster/cardano-node-pool2
 stderr_logfile=./state-cluster/pool2.stderr
 stdout_logfile=./state-cluster/pool2.stdout
+startsecs=3
 
 [program:webserver]
 command=python -m http.server 30000

--- a/cardano_node_tests/cluster_scripts/testnets_nopools/supervisor.conf
+++ b/cardano_node_tests/cluster_scripts/testnets_nopools/supervisor.conf
@@ -5,6 +5,7 @@ port=127.0.0.1:9001
 command=./state-cluster/cardano-node-relay1
 stderr_logfile=./state-cluster/relay1.stderr
 stdout_logfile=./state-cluster/relay1.stdout
+startsecs=3
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
Don't automatically restart db-sync on local network. Db-sync is expected to exit on important errors and there's no point in restarting it.

Increase time after which a service is considered to be started from 1s to 3s.