### PR TITLE
Use generic `Iterable` type

### DIFF
--- a/cardano_node_tests/cardano_cli_coverage.py
+++ b/cardano_node_tests/cardano_cli_coverage.py
@@ -7,13 +7,13 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable
 from typing import List
 from typing import Tuple
 
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import helpers
-from cardano_node_tests.utils.types import UnpackableSequence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -103,8 +103,9 @@ def merge_coverage(dict_a: dict, dict_b: dict) -> dict:
     return dict_a
 
 
-def cli(cli_args: UnpackableSequence) -> str:
+def cli(cli_args: Iterable[str]) -> str:
     """Run the `cardano-cli` command."""
+    assert not isinstance(cli_args, str), "`cli_args` must be sequence of strings"
     with subprocess.Popen(list(cli_args), stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
         __, stderr = p.communicate()
     return stderr.decode()
@@ -134,7 +135,7 @@ def parse_cmd_output(output: str) -> List[str]:
     return cli_args
 
 
-def get_available_commands(cli_args: UnpackableSequence, ignore_skips: bool = False) -> dict:
+def get_available_commands(cli_args: Iterable[str], ignore_skips: bool = False) -> dict:
     """Get all available cardano-cli sub-commands and options."""
     cli_out = cli(cli_args)
     new_cli_args = parse_cmd_output(cli_out)

--- a/cardano_node_tests/utils/cluster_management.py
+++ b/cardano_node_tests/utils/cluster_management.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import Iterable
 from typing import Iterator
 from typing import Optional
 
@@ -28,7 +29,6 @@ from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
 from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils import temptools
-from cardano_node_tests.utils.types import UnpackableSequence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -130,8 +130,8 @@ class MarkedTestsStatus:
 @dataclasses.dataclass
 class ClusterGetStatus:
     mark: str
-    lock_resources: UnpackableSequence
-    use_resources: UnpackableSequence
+    lock_resources: Iterable[str]
+    use_resources: Iterable[str]
     cleanup: bool
     start_cmd: str
     selected_instance: int = -1
@@ -141,9 +141,9 @@ class ClusterGetStatus:
     restart_ready: bool = False
     first_iteration: bool = True
     instance_dir: Path = Path("nonexistent")
-    started_tests: UnpackableSequence = ()
-    marked_starting: UnpackableSequence = ()
-    marked_running: UnpackableSequence = ()
+    started_tests: Iterable[Path] = ()
+    marked_starting: Iterable[Path] = ()
+    marked_running: Iterable[Path] = ()
 
 
 class ClusterManager:
@@ -336,8 +336,8 @@ class ClusterManager:
     def get(
         self,
         mark: str = "",
-        lock_resources: UnpackableSequence = (),
-        use_resources: UnpackableSequence = (),
+        lock_resources: Iterable[str] = (),
+        use_resources: Iterable[str] = (),
         cleanup: bool = False,
         start_cmd: str = "",
     ) -> clusterlib.ClusterLib:
@@ -574,7 +574,7 @@ class _ClusterGetter:
             self._on_marked_test_stop(instance_num)
 
     def _are_resources_usable(
-        self, resources: UnpackableSequence, instance_dir: Path, instance_num: int
+        self, resources: Iterable[str], instance_dir: Path, instance_num: int
     ) -> bool:
         """Check if resources are locked or in use."""
         for res in resources:
@@ -595,7 +595,7 @@ class _ClusterGetter:
         return False
 
     def _are_resources_locked(
-        self, resources: UnpackableSequence, instance_dir: Path, instance_num: int
+        self, resources: Iterable[str], instance_dir: Path, instance_num: int
     ) -> bool:
         """Check if resources are locked."""
         res_locked = []
@@ -869,8 +869,8 @@ class _ClusterGetter:
     def get(  # noqa: C901
         self,
         mark: str = "",
-        lock_resources: UnpackableSequence = (),
-        use_resources: UnpackableSequence = (),
+        lock_resources: Iterable[str] = (),
+        use_resources: Iterable[str] = (),
         cleanup: bool = False,
         start_cmd: str = "",
     ) -> clusterlib.ClusterLib:
@@ -880,6 +880,9 @@ class _ClusterGetter:
         right away.
         """
         # pylint: disable=too-many-statements,too-many-branches
+        assert not isinstance(lock_resources, str), "`lock_resources` must be sequence of strings"
+        assert not isinstance(use_resources, str), "`use_resources` must be sequence of strings"
+
         if configuration.DEV_CLUSTER_RUNNING:
             if start_cmd:
                 LOGGER.warning(

--- a/cardano_node_tests/utils/types.py
+++ b/cardano_node_tests/utils/types.py
@@ -6,6 +6,5 @@ from typing import Union
 
 FileType = Union[str, Path]
 FileTypeList = Union[List[str], List[Path], Set[str], Set[Path]]
-UnpackableSequence = Union[list, tuple, set]
 # list of `FileType`s, empty list, or empty tuple
 OptionalFiles = Union[FileTypeList, Tuple[()]]


### PR DESCRIPTION
Use asserts to ensure `Iterable[str]` means sequence of strings.