### PR TITLE
Optional checks using pytype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install_doc:
 # run linters
 lint:
 	pre-commit run -a
+	if type pytype >/dev/null 2>&1; then pytype cardano_node_tests; fi
 
 
 # generate sphinx documentation

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import List
 from typing import NamedTuple
 from typing import Optional
+from typing import Union
 
 from cardano_clusterlib import clusterlib
 
@@ -172,7 +173,9 @@ class TestnetCluster(ClusterType):
     def __init__(self) -> None:
         super().__init__()
         self.type = ClusterType.TESTNET
-        self.cluster_scripts: cluster_scripts.TestnetScripts = cluster_scripts.TestnetScripts()
+        self.cluster_scripts: Union[
+            cluster_scripts.ScriptsTypes, cluster_scripts.TestnetScripts
+        ] = cluster_scripts.TestnetScripts()
 
         # cached values
         self._testnet_type = ""

--- a/cardano_node_tests/utils/dbsync_queries.py
+++ b/cardano_node_tests/utils/dbsync_queries.py
@@ -201,6 +201,7 @@ class SchemaVersionStages(NamedTuple):
 @contextlib.contextmanager
 def execute(query: str, vars: Sequence = ()) -> Iterator[psycopg2.extensions.cursor]:
     # pylint: disable=redefined-builtin
+    cur = None
     try:
         cur = dbsync_conn.conn().cursor()
 
@@ -216,7 +217,8 @@ def execute(query: str, vars: Sequence = ()) -> Iterator[psycopg2.extensions.cur
 
         yield cur
     finally:
-        cur.close()
+        if cur is not None:
+            cur.close()
 
 
 class SchemaVersion:

--- a/cardano_node_tests/utils/model_ekg.py
+++ b/cardano_node_tests/utils/model_ekg.py
@@ -3,7 +3,7 @@
 #   timestamp: 2021-03-10T11:38:36+00:00
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel  # pytype: disable=import-error
 from pydantic import Field
 
 


### PR DESCRIPTION
Add option to run pytype during `make lint` when available.
Fix / warkaround issues found by pytype.