### PR TITLE
Skips for plutus delegate test

### DIFF
--- a/cardano_node_tests/tests/test_plutus_delegation.py
+++ b/cardano_node_tests/tests/test_plutus_delegation.py
@@ -21,6 +21,7 @@ from cardano_node_tests.utils import cluster_management
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -240,6 +241,11 @@ def deregister_stake_addr(
 # don't run these tests on testnets as a stake address corresponding to the Plutus script
 # might be already in use
 @pytest.mark.order(8)
+@pytest.mark.skipif(
+    VERSIONS.transaction_era < VERSIONS.ALONZO,
+    reason="runs only with Alonzo+ TX",
+)
+@pytest.mark.skipif(not common.BUILD_USABLE, reason=common.BUILD_SKIP_MSG)
 class TestDelegateAddr:
     """Tests for address delegation to stake pools."""
 


### PR DESCRIPTION
Skip the test when `transaction buid` cannot be used or Tx era < Alonzo.