### PR TITLE
Merge `test_expired_kes` and `test_op_cert_with_expired_kes`

### DIFF
--- a/cardano_node_tests/tests/kes.py
+++ b/cardano_node_tests/tests/kes.py
@@ -42,6 +42,8 @@ def check_kes_period_info_result(kes_output: dict, expected_scenario: str):
     elif kes_output.get("valid_counters") and not kes_output.get("valid_kes_period"):
         output_scenario = KesScenarios.INVALID_KES_PERIOD
 
-    assert (
-        expected_scenario == output_scenario
-    ), "The kes-period-command is not returning the expected results"
+    assert expected_scenario == output_scenario, (
+        "The kes-period-info command is not returning the expected results. "
+        f"Expected: '{expected_scenario}'; Returned: '{output_scenario}'\n"
+        f"Full output:\n{kes_output}"
+    )


### PR DESCRIPTION
Change `test_expired_kes` so that blocks are still being minted and so the `query kes-period-info` command can be used in the test.