### PR TITLE
Ignore error in log file when node is shutting down

### DIFF
--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -37,6 +37,8 @@ ERRORS_IGNORED = [
     "db-sync-node:.*could not serialize access",
     # can happen on p2p when local roots are not up yet
     r"PeerSelection:Info:.* TracePromoteColdFailed .* Network\.Socket\.connect:",
+    # can happen on p2p when node is shutting down
+    "TrInboundGovernorError AsyncCancelled",
     # harmless when whole network is shutting down
     "SubscriberWorkerCancelled, .*SubscriptionWorker exiting",
 ]


### PR DESCRIPTION
This error can happen when p2p is on.