### PR TITLE
Change defauts for `wait_for_epoch_interval`

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -68,7 +68,6 @@ class TestLeadershipSchedule:
                 cluster_obj=cluster,
                 start=-int(300 * cluster.slot_length),
                 stop=-10,
-                force_epoch=False,
             )
             queried_epoch = cluster.get_epoch() + 1
 
@@ -149,7 +148,6 @@ class TestLeadershipSchedule:
             cluster_obj=cluster,
             start=5,
             stop=-int(300 * cluster.slot_length + 5),
-            force_epoch=False,
         )
 
         # it should NOT be possible to query leadership schedule

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -103,9 +103,7 @@ class TestDelegateAddr:
         cluster, pool_id = cluster_and_pool
         temp_template = f"{common.get_test_id(cluster)}_{use_build_cmd}"
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -160,9 +158,7 @@ class TestDelegateAddr:
         cluster = cluster_use_pool1
         temp_template = f"{common.get_test_id(cluster)}_{use_build_cmd}"
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -229,9 +225,7 @@ class TestDelegateAddr:
 
         pool_user = clusterlib.PoolUser(payment=payment_addr_recs[1], stake=stake_addr_rec)
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -278,9 +272,7 @@ class TestDelegateAddr:
             pytest.skip(f"User of pool '{pool_id}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # files for deregistering stake address
         stake_addr_dereg_cert = cluster.gen_stake_addr_deregistration_cert(
@@ -373,9 +365,7 @@ class TestDelegateAddr:
         cluster, pool_id = cluster_and_pool
         temp_template = common.get_test_id(cluster)
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -411,9 +401,7 @@ class TestDelegateAddr:
             pytest.skip(f"User of pool '{pool_id}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # files for deregistering / re-registering stake address
         stake_addr_dereg_cert_file = cluster.gen_stake_addr_deregistration_cert(
@@ -642,9 +630,7 @@ class TestDelegateAddr:
             stake_pool_id=pool_id,
         )
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # delegate and deregister stake address in single TX

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -93,9 +93,7 @@ def _wait_epoch_chores(cluster_obj: clusterlib.ClusterLib, temp_template: str, t
         cluster_obj.wait_for_new_epoch()
 
     LOGGER.info(f"{datetime.datetime.now()}: Waiting for the end of current epoch.")
-    clusterlib_utils.wait_for_epoch_interval(
-        cluster_obj=cluster_obj, start=-19, stop=-15, force_epoch=False, check_slot=False
-    )
+    clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster_obj, start=-19, stop=-15)
 
     # save ledger state
     clusterlib_utils.save_ledger_state(
@@ -388,9 +386,7 @@ class TestKES:
 
             # make sure we are not at the very end of an epoch so we still have time for
             # the first block production check
-            clusterlib_utils.wait_for_epoch_interval(
-                cluster_obj=cluster, start=5, stop=-18, force_epoch=False, check_slot=False
-            )
+            clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-18)
 
             LOGGER.info("Checking blocks production for 5 epochs.")
             blocks_made_db = []
@@ -403,7 +399,7 @@ class TestKES:
 
                 # wait for the end of the epoch
                 clusterlib_utils.wait_for_epoch_interval(
-                    cluster_obj=cluster, start=-19, stop=-15, check_slot=False
+                    cluster_obj=cluster, start=-19, stop=-15, force_epoch=True
                 )
                 this_epoch = cluster.get_epoch()
 

--- a/cardano_node_tests/tests/test_ledger_state.py
+++ b/cardano_node_tests/tests/test_ledger_state.py
@@ -48,9 +48,7 @@ class TestLedgerState:
         stop = (
             20 if cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.LOCAL else 200
         )
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-stop, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-stop)
 
         stake_pool_ids = cluster.get_stake_pools()
         if not stake_pool_ids:

--- a/cardano_node_tests/tests/test_plutus_delegation.py
+++ b/cardano_node_tests/tests/test_plutus_delegation.py
@@ -351,9 +351,7 @@ class TestDelegateAddr:
 
         # Step 2: register and delegate
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -391,9 +389,7 @@ class TestDelegateAddr:
             reward_error = f"User of pool '{pool_id}' hasn't received any rewards."
 
         # make sure we have enough time to finish deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # submit deregistration certificate and withdraw rewards
         tx_raw_delegation_out = deregister_stake_addr(

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -919,7 +919,7 @@ class TestStakePool:
 
         # deregister stake pool
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC
         )
         depoch = cluster.get_epoch() + 1
         if use_build_cmd:
@@ -1035,7 +1035,7 @@ class TestStakePool:
 
         # deregister stake pool
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC
         )
         depoch = cluster.get_epoch() + 1
         cluster.deregister_stake_pool(
@@ -1191,7 +1191,7 @@ class TestStakePool:
 
         # deregister stake pool in epoch + 2
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC
         )
         depoch = cluster.get_epoch() + 2
         cluster.deregister_stake_pool(
@@ -1359,7 +1359,7 @@ class TestStakePool:
 
         # make sure the update doesn't happen close to epoch boundary
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=10, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=10, stop=-DEREG_BUFFER_SEC
         )
 
         # update the pool metadata by resubmitting the pool registration certificate
@@ -1483,7 +1483,7 @@ class TestStakePool:
 
         # make sure the update doesn't happen close to epoch boundary
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=10, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=10, stop=-DEREG_BUFFER_SEC
         )
 
         # update the pool parameters by resubmitting the pool registration certificate
@@ -1715,7 +1715,7 @@ class TestStakePool:
 
         # create pool deregistration cert
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC, force_epoch=False
+            cluster_obj=cluster, start=5, stop=-DEREG_BUFFER_SEC
         )
         pool_dereg_cert_file = cluster.gen_pool_deregistration_cert(
             pool_name=pool_data.pool_name,

--- a/cardano_node_tests/tests/test_staking.py
+++ b/cardano_node_tests/tests/test_staking.py
@@ -342,9 +342,7 @@ class TestRewards:
         )
 
         # make sure we have enough time to finish the registration/delegation in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-300, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-300)
         init_epoch = cluster.get_epoch()
 
         if check_pool_rewards:
@@ -385,9 +383,7 @@ class TestRewards:
 
         # withdraw rewards to payment address, make sure we have enough time to finish
         # the withdrawal in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-300, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-300)
         cluster.withdraw_reward(
             stake_addr_record=delegation_out.pool_user.stake,
             dst_addr_record=delegation_out.pool_user.payment,
@@ -452,9 +448,7 @@ class TestRewards:
         pool_user = clusterlib.PoolUser(payment=payment_addr_recs[1], stake=stake_addr_rec)
 
         # make sure we have enough time to finish the registration/delegation in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         init_epoch = cluster.get_epoch()
 
@@ -615,7 +609,7 @@ class TestRewards:
 
             # sleep till the end of epoch
             clusterlib_utils.wait_for_epoch_interval(
-                cluster_obj=cluster, start=-19, stop=-15, check_slot=False
+                cluster_obj=cluster, start=-19, stop=-15, force_epoch=True
             )
             this_epoch = cluster.get_epoch()
 
@@ -769,9 +763,7 @@ class TestRewards:
         )
 
         # make sure we have enough time to finish delegation in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         init_epoch = cluster.get_epoch()
 
@@ -1045,7 +1037,7 @@ class TestRewards:
 
                 # sleep till the end of epoch
                 clusterlib_utils.wait_for_epoch_interval(
-                    cluster_obj=cluster, start=-19, stop=-15, check_slot=False
+                    cluster_obj=cluster, start=-19, stop=-15, force_epoch=True
                 )
 
                 _check_ledger_state(this_epoch=this_epoch)
@@ -1117,9 +1109,7 @@ class TestRewards:
 
         temp_template = common.get_test_id(cluster)
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -1157,9 +1147,7 @@ class TestRewards:
         )
 
         # make sure we have enough time to finish the transfer in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # transfer all funds from payment address back to faucet, so no funds are staked
         clusterlib_utils.return_funds_to_faucet(
@@ -1237,9 +1225,7 @@ class TestRewards:
             cluster_obj=cluster, addrs_data=cluster_manager.cache.addrs_data, pool_name=pool_name
         )
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -1262,9 +1248,7 @@ class TestRewards:
             pytest.skip(f"User of pool '{pool_name}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish the pool update in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # load and update original pool data
         loaded_data = clusterlib_utils.load_registered_pool_data(
@@ -1380,9 +1364,7 @@ class TestRewards:
             cluster_obj=cluster, addrs_data=cluster_manager.cache.addrs_data, pool_name=pool_name
         )
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -1405,9 +1387,7 @@ class TestRewards:
             pytest.skip(f"User of pool '{pool_name}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to withdraw the pledge in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # load pool data
         loaded_data = clusterlib_utils.load_registered_pool_data(
@@ -1542,9 +1522,7 @@ class TestRewards:
             cluster_obj=cluster, addrs_data=cluster_manager.cache.addrs_data, pool_name=pool_name
         )
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -1567,9 +1545,7 @@ class TestRewards:
             pytest.skip(f"User of pool '{pool_name}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # deregister stake address - owner's stake is lower than pledge
         stake_addr_dereg_cert = cluster.gen_stake_addr_deregistration_cert(
@@ -1715,9 +1691,7 @@ class TestRewards:
             cluster_obj=cluster, addrs_data=cluster_manager.cache.addrs_data, pool_name=pool_name
         )
 
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool
@@ -1740,9 +1714,7 @@ class TestRewards:
             pytest.skip(f"User of pool '{pool_name}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # withdraw pool rewards to payment address
         # use `transaction build` if possible
@@ -1901,9 +1873,7 @@ class TestRewards:
             pytest.skip(f"Pool '{pool_name}' hasn't received any rewards, cannot continue.")
 
         # make sure we have enough time to finish reward address deregistration in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
         # withdraw pool rewards to payment address
         cluster.withdraw_reward(
@@ -1958,9 +1928,7 @@ class TestRewards:
             )
 
             # make sure we have enough time to finish pool deregistration in one epoch
-            clusterlib_utils.wait_for_epoch_interval(
-                cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-            )
+            clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
 
             src_dereg_balance = cluster.get_address_balance(pool_owner.payment.address)
             stake_acount_balance = cluster.get_stake_addr_info(
@@ -2147,9 +2115,7 @@ class TestRewards:
             pytest.skip("Pools haven't received any rewards, cannot continue.")
 
         # make sure we have enough time to submit pool registration cert in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-20, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-20)
         init_epoch = cluster.get_epoch()
 
         # fund source address so the pledge is still met after TX fees are deducted
@@ -2364,9 +2330,7 @@ class TestRewards:
         )
 
         # make sure we have enough time to finish the registration/delegation in one epoch
-        clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=-40, force_epoch=False
-        )
+        clusterlib_utils.wait_for_epoch_interval(cluster_obj=cluster, start=5, stop=-40)
         init_epoch = cluster.get_epoch()
 
         # submit registration certificate and delegate to pool1
@@ -2534,7 +2498,7 @@ class TestRewards:
                 )
                 # wait for second half of an epoch
                 clusterlib_utils.wait_for_epoch_interval(
-                    cluster_obj=cluster, start=-60, stop=-40, check_slot=False
+                    cluster_obj=cluster, start=-60, stop=-40, force_epoch=True
                 )
                 # re-register, delegate to pool1
                 delegation_out_ep4 = delegation.delegate_stake_addr(
@@ -2555,7 +2519,7 @@ class TestRewards:
 
             # sleep till the end of epoch
             clusterlib_utils.wait_for_epoch_interval(
-                cluster_obj=cluster, start=-19, stop=-15, check_slot=False
+                cluster_obj=cluster, start=-19, stop=-15, force_epoch=True
             )
 
             # store collected rewards info

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -778,8 +778,8 @@ def wait_for_epoch_interval(
     cluster_obj: clusterlib.ClusterLib,
     start: int,
     stop: int,
-    force_epoch: bool = True,
-    check_slot: bool = True,
+    force_epoch: bool = False,
+    check_slot: bool = False,
 ) -> None:
     """Wait for time interval within an epoch.
 
@@ -790,9 +790,9 @@ def wait_for_epoch_interval(
         stop: An end of the interval, in seconds. Negative number for counting from the
             end of an epoch.
         force_epoch: A bool indicating whether the interval must be in current epoch
-            (True by default).
-        check_slot: A bool indicating whether current slot number must match the time interval
-            (True by default).
+            (False by default).
+        check_slot: A bool indicating whether to check if slot number matches time interval
+            after waiting (False by default).
     """
     start_abs = start if start >= 0 else cluster_obj.epoch_length_sec + start
     stop_abs = stop if stop >= 0 else cluster_obj.epoch_length_sec + stop


### PR DESCRIPTION
Don't check if slot number after waiting matches the specified interval (i.e. no need to wait for new tip by default).
The interval doesn't need to be in current epoch by default.