### PR TITLE
Remove the need to lock Plutus spending tests

### DIFF
--- a/cardano_node_tests/tests/test_plutus_delegation.py
+++ b/cardano_node_tests/tests/test_plutus_delegation.py
@@ -25,7 +25,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
-# skip tests if is not alonzo era
+# skip all tests if Tx era < alonzo
 pytestmark = pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
     reason="runs only with Alonzo+ TX",
@@ -48,7 +48,7 @@ def cluster_lock_42stake(
     pool_id = delegation.get_pool_id(
         cluster_obj=cluster_obj,
         addrs_data=cluster_manager.cache.addrs_data,
-        pool_name="node-pool3",
+        pool_name=cluster_management.Resources.POOL3,
     )
     return cluster_obj, pool_id
 

--- a/cardano_node_tests/tests/test_plutus_mint_build.py
+++ b/cardano_node_tests/tests/test_plutus_mint_build.py
@@ -20,7 +20,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
-# skip tests if is not alonzo era
+# skip all tests if Tx era < alonzo
 pytestmark = pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
     reason="runs only with Alonzo+ TX",

--- a/cardano_node_tests/tests/test_plutus_mint_raw.py
+++ b/cardano_node_tests/tests/test_plutus_mint_raw.py
@@ -20,7 +20,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
-# skip tests if is not alonzo era
+# skip all tests if Tx era < alonzo
 pytestmark = pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
     reason="runs only with Alonzo+ TX",

--- a/cardano_node_tests/tests/test_plutus_spend_raw.py
+++ b/cardano_node_tests/tests/test_plutus_spend_raw.py
@@ -25,7 +25,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
 
-# skip tests if is not alonzo era
+# skip all tests if Tx era < alonzo
 pytestmark = pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
     reason="runs only with Alonzo+ TX",
@@ -33,33 +33,17 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def cluster_lock_always_suceeds(
+def payment_addrs(
     cluster_manager: cluster_management.ClusterManager,
-) -> clusterlib.ClusterLib:
-    """Make sure just one txin plutus test run at a time.
-
-    Plutus script always has the same address. When one script is used in multiple
-    tests that are running in parallel, the blanaces etc. don't add up.
-    """
-    return cluster_manager.get(lock_resources=[str(plutus_common.ALWAYS_SUCCEEDS_PLUTUS.stem)])
-
-
-@pytest.fixture
-def payment_addrs_lock_always_suceeds(
-    cluster_manager: cluster_management.ClusterManager,
-    cluster_lock_always_suceeds: clusterlib.ClusterLib,
+    cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.AddressRecord]:
-    """Create new payment address while using the `cluster_lock_always_suceeds` fixture."""
-    cluster = cluster_lock_always_suceeds
+    """Create new payment addresses."""
     with cluster_manager.cache_fixture() as fixture_cache:
         if fixture_cache.value:
             return fixture_cache.value  # type: ignore
 
         addrs = clusterlib_utils.create_payment_addr_records(
-            *[
-                f"plutus_payment_lock_allsucceeds_ci{cluster_manager.cluster_instance_num}_{i}"
-                for i in range(4)
-            ],
+            *[f"payment_addrs_ci{cluster_manager.cluster_instance_num}_{i}" for i in range(4)],
             cluster_obj=cluster,
         )
         fixture_cache.value = addrs
@@ -77,75 +61,18 @@ def payment_addrs_lock_always_suceeds(
 
 
 @pytest.fixture
-def cluster_lock_guessing_game(
+def pool_users(
     cluster_manager: cluster_management.ClusterManager,
-) -> clusterlib.ClusterLib:
-    """Make sure just one guessing game plutus test run at a time.
-
-    Plutus script always has the same address. When one script is used in multiple
-    tests that are running in parallel, the balances etc. don't add up.
-    """
-    return cluster_manager.get(lock_resources=[str(plutus_common.GUESSING_GAME_PLUTUS.stem)])
-
-
-@pytest.fixture
-def payment_addrs_lock_guessing_game(
-    cluster_manager: cluster_management.ClusterManager,
-    cluster_lock_guessing_game: clusterlib.ClusterLib,
-) -> List[clusterlib.AddressRecord]:
-    """Create new payment address while using the `cluster_lock_guessing_game` fixture."""
-    cluster = cluster_lock_guessing_game
-    with cluster_manager.cache_fixture() as fixture_cache:
-        if fixture_cache.value:
-            return fixture_cache.value  # type: ignore
-
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[
-                f"plutus_payment_lock_ggame_ci{cluster_manager.cluster_instance_num}_{i}"
-                for i in range(2)
-            ],
-            cluster_obj=cluster,
-        )
-        fixture_cache.value = addrs
-
-    # fund source address
-    clusterlib_utils.fund_from_faucet(
-        addrs[0],
-        cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
-        amount=20_000_000_000,
-    )
-
-    return addrs
-
-
-@pytest.fixture
-def cluster_lock_context_eq(
-    cluster_manager: cluster_management.ClusterManager,
-) -> clusterlib.ClusterLib:
-    """Make sure just one guessing game plutus test run at a time.
-
-    Plutus script always has the same address. When one script is used in multiple
-    tests that are running in parallel, the blanaces etc. don't add up.
-    """
-    return cluster_manager.get(lock_resources=[str(plutus_common.CONTEXT_EQUIVALENCE_PLUTUS.stem)])
-
-
-@pytest.fixture
-def pool_users_lock_context_eq(
-    cluster_manager: cluster_management.ClusterManager,
-    cluster_lock_context_eq: clusterlib.ClusterLib,
+    cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.PoolUser]:
-    """Create new pool users while using the `cluster_lock_context_eq` fixture."""
-    cluster = cluster_lock_context_eq
+    """Create new pool users."""
     with cluster_manager.cache_fixture() as fixture_cache:
         if fixture_cache.value:
             return fixture_cache.value  # type: ignore
 
         created_users = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
-            name_template="plutus_payment_lock_context_eq_ci"
-            f"{cluster_manager.cluster_instance_num}",
+            name_template=f"pool_users_ci{cluster_manager.cluster_instance_num}",
             no_of_addr=2,
         )
         fixture_cache.value = created_users
@@ -159,49 +86,6 @@ def pool_users_lock_context_eq(
     )
 
     return created_users
-
-
-@pytest.fixture
-def cluster_lock_always_fails(
-    cluster_manager: cluster_management.ClusterManager,
-) -> clusterlib.ClusterLib:
-    """Make sure just one txin plutus test run at a time.
-
-    Plutus script always has the same address. When one script is used in multiple
-    tests that are running in parallel, the blanaces etc. don't add up.
-    """
-    return cluster_manager.get(lock_resources=[str(plutus_common.ALWAYS_FAILS_PLUTUS.stem)])
-
-
-@pytest.fixture
-def payment_addrs_lock_always_fails(
-    cluster_manager: cluster_management.ClusterManager,
-    cluster_lock_always_fails: clusterlib.ClusterLib,
-) -> List[clusterlib.AddressRecord]:
-    """Create new payment address while using the `cluster_lock_always_fails` fixture."""
-    cluster = cluster_lock_always_fails
-    with cluster_manager.cache_fixture() as fixture_cache:
-        if fixture_cache.value:
-            return fixture_cache.value  # type: ignore
-
-        addrs = clusterlib_utils.create_payment_addr_records(
-            *[
-                f"plutus_payment_lock_allfails_ci{cluster_manager.cluster_instance_num}_{i}"
-                for i in range(2)
-            ],
-            cluster_obj=cluster,
-        )
-        fixture_cache.value = addrs
-
-    # fund source address
-    clusterlib_utils.fund_from_faucet(
-        addrs[0],
-        cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
-        amount=20_000_000_000,
-    )
-
-    return addrs
 
 
 def _fund_script(
@@ -232,8 +116,6 @@ def _fund_script(
     fee_redeem = int(plutusrequiredtime + plutusrequiredspace) + 10_000_000
     collateral_fraction = cluster_obj.get_protocol_params()["collateralPercentage"] / 100
     collateral_amount = int(fee_redeem * collateral_fraction * collateral_fraction_offset)
-
-    script_init_balance = cluster_obj.get_address_balance(script_address)
 
     # create a Tx output with a datum hash at the script address
 
@@ -296,19 +178,26 @@ def _fund_script(
 
     cluster_obj.submit_tx(tx_file=tx_signed, txins=tx_raw_output.txins)
 
-    script_balance = cluster_obj.get_address_balance(script_address)
+    txid = cluster_obj.get_txid(tx_body_file=tx_raw_output.out_file)
+
+    script_utxos = cluster_obj.get_utxo(txin=f"{txid}#0", coins=[clusterlib.DEFAULT_COIN])
+    assert script_utxos, "No script UTxO"
+
+    script_balance = script_utxos[0].amount
     assert (
-        script_balance == script_init_balance + amount + fee_redeem + deposit_amount
+        script_balance == amount + fee_redeem + deposit_amount
     ), f"Incorrect balance for script address `{script_address}`"
 
     for token in stokens:
+        token_balance = cluster_obj.get_utxo(txin=f"{txid}#0", coins=[token.coin])[0].amount
         assert (
-            cluster_obj.get_address_balance(script_address, coin=token.coin) == token.amount
+            token_balance == token.amount
         ), f"Incorrect token balance for script address `{script_address}`"
 
     for token in ctokens:
+        token_balance = cluster_obj.get_utxo(txin=f"{txid}#1", coins=[token.coin])[0].amount
         assert (
-            cluster_obj.get_address_balance(dst_addr.address, coin=token.coin) == token.amount
+            token_balance == token.amount
         ), f"Incorrect token balance for address `{dst_addr.address}`"
 
     dbsync_utils.check_tx(cluster_obj=cluster_obj, tx_raw_output=tx_raw_output)
@@ -324,7 +213,6 @@ def _spend_locked_txin(
     collateral_utxos: List[clusterlib.UTXOData],
     plutus_op: plutus_common.PlutusOp,
     amount: int,
-    deposit_amount: int = 0,
     tx_files: Optional[clusterlib.TxFiles] = None,
     invalid_hereafter: Optional[int] = None,
     invalid_before: Optional[int] = None,
@@ -343,9 +231,6 @@ def _spend_locked_txin(
 
     script_address = script_utxos[0].address
     fee_redeem = int(plutusrequiredtime + plutusrequiredspace) + 10_000_000
-
-    script_init_balance = cluster_obj.get_address_balance(script_address)
-    dst_init_balance = cluster_obj.get_address_balance(dst_addr.address)
 
     # spend the "locked" UTxO
 
@@ -392,6 +277,10 @@ def _spend_locked_txin(
     if not submit_tx:
         return "", tx_raw_output
 
+    dst_init_balance = cluster_obj.get_address_balance(dst_addr.address)
+
+    script_utxos_lovelace = [u for u in script_utxos if u.coin == clusterlib.DEFAULT_COIN]
+
     if not script_valid:
         cluster_obj.submit_tx(tx_file=tx_signed, txins=collateral_utxos)
 
@@ -400,9 +289,10 @@ def _spend_locked_txin(
             == dst_init_balance - collateral_utxos[0].amount
         ), f"Collateral was NOT spent from `{dst_addr.address}`"
 
-        assert (
-            cluster_obj.get_address_balance(script_address) == script_init_balance
-        ), f"Incorrect balance for script address `{script_address}`"
+        for u in script_utxos_lovelace:
+            assert cluster_obj.get_utxo(
+                txin=f"{u.utxo_hash}#{u.utxo_ix}", coins=[clusterlib.DEFAULT_COIN]
+            ), f"Inputs were unexpectedly spent for `{script_address}`"
 
         return "", tx_raw_output
 
@@ -414,9 +304,10 @@ def _spend_locked_txin(
             cluster_obj.get_address_balance(dst_addr.address) == dst_init_balance
         ), f"Collateral was spent from `{dst_addr.address}`"
 
-        assert (
-            cluster_obj.get_address_balance(script_address) == script_init_balance
-        ), f"Incorrect balance for script address `{script_address}`"
+        for u in script_utxos_lovelace:
+            assert cluster_obj.get_utxo(
+                txin=f"{u.utxo_hash}#{u.utxo_ix}", coins=[clusterlib.DEFAULT_COIN]
+            ), f"Inputs were unexpectedly spent for `{script_address}`"
 
         return err, tx_raw_output
 
@@ -424,22 +315,24 @@ def _spend_locked_txin(
         tx_file=tx_signed, txins=[t.txins[0] for t in tx_raw_output.script_txins if t.txins]
     )
 
-    # check tx view
-    tx_view.check_tx_view(cluster_obj=cluster_obj, tx_raw_output=tx_raw_output)
-
     assert (
         cluster_obj.get_address_balance(dst_addr.address) == dst_init_balance + amount
     ), f"Incorrect balance for destination address `{dst_addr.address}`"
 
-    assert (
-        cluster_obj.get_address_balance(script_address)
-        == script_init_balance - amount - fee_redeem - deposit_amount
-    ), f"Incorrect balance for script address `{script_address}`"
+    for u in script_utxos_lovelace:
+        assert not cluster_obj.get_utxo(
+            txin=f"{u.utxo_hash}#{u.utxo_ix}", coins=[clusterlib.DEFAULT_COIN]
+        ), f"Inputs were NOT spent for `{script_address}`"
 
     for token in spent_tokens:
-        assert (
-            cluster_obj.get_address_balance(script_address, coin=token.coin) == 0
-        ), f"Incorrect token balance for script address `{script_address}`"
+        script_utxos_token = [u for u in script_utxos if u.coin == token.coin]
+        for u in script_utxos_token:
+            assert not cluster_obj.get_utxo(
+                txin=f"{u.utxo_hash}#{u.utxo_ix}", coins=[token.coin]
+            ), f"Token inputs were NOT spent for `{script_address}`"
+
+    # check tx view
+    tx_view.check_tx_view(cluster_obj=cluster_obj, tx_raw_output=tx_raw_output)
 
     dbsync_utils.check_tx(cluster_obj=cluster_obj, tx_raw_output=tx_raw_output)
 
@@ -496,8 +389,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_txin_locking(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Test locking a Tx output with a plutus script and spending the locked UTxO.
 
@@ -509,8 +402,8 @@ class TestLocking:
         * check that the expected amount was spent
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
+        amount = 50_000_000
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS_PLUTUS,
@@ -522,10 +415,10 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_suceeds[0],
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
-            amount=50_000_000,
+            amount=amount,
         )
 
         utxo_err = _check_pretty_utxo(cluster_obj=cluster, tx_raw_output=tx_output_fund)
@@ -536,11 +429,11 @@ class TestLocking:
         _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            dst_addr=payment_addrs[1],
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
-            amount=50_000_000,
+            amount=amount,
         )
 
         if utxo_err:
@@ -555,8 +448,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_context_equivalance(
         self,
-        cluster_lock_context_eq: clusterlib.ClusterLib,
-        pool_users_lock_context_eq: List[clusterlib.PoolUser],
+        cluster: clusterlib.ClusterLib,
+        pool_users: List[clusterlib.PoolUser],
     ):
         """Test context equivalence while spending a locked UTxO.
 
@@ -568,7 +461,6 @@ class TestLocking:
         * check that the expected amount was spent
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_context_eq
         temp_template = common.get_test_id(cluster)
         amount = 10_000_000
         deposit_amount = cluster.get_address_deposit()
@@ -576,7 +468,7 @@ class TestLocking:
         # create stake address registration cert
         stake_addr_reg_cert_file = cluster.gen_stake_addr_registration_cert(
             addr_name=f"{temp_template}_addr0",
-            stake_vkey_file=pool_users_lock_context_eq[0].stake.vkey_file,
+            stake_vkey_file=pool_users[0].stake.vkey_file,
         )
 
         tx_files = clusterlib.TxFiles(certificate_files=[stake_addr_reg_cert_file])
@@ -599,8 +491,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=pool_users_lock_context_eq[0].payment,
-            dst_addr=pool_users_lock_context_eq[1].payment,
+            payment_addr=pool_users[0].payment,
+            dst_addr=pool_users[1].payment,
             plutus_op=plutus_op_dummy,
             amount=amount,
             deposit_amount=deposit_amount,
@@ -614,12 +506,11 @@ class TestLocking:
         __, tx_output_dummy = _spend_locked_txin(
             temp_template=f"{temp_template}_dummy",
             cluster_obj=cluster,
-            dst_addr=pool_users_lock_context_eq[1].payment,
+            dst_addr=pool_users[1].payment,
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op_dummy,
             amount=amount,
-            deposit_amount=deposit_amount,
             tx_files=tx_files,
             invalid_before=1,
             invalid_hereafter=invalid_hereafter,
@@ -652,12 +543,11 @@ class TestLocking:
         _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=pool_users_lock_context_eq[1].payment,
+            dst_addr=pool_users[1].payment,
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
             amount=amount,
-            deposit_amount=deposit_amount,
             tx_files=tx_files,
             invalid_before=1,
             invalid_hereafter=invalid_hereafter,
@@ -677,8 +567,8 @@ class TestLocking:
     )
     def test_guessing_game(
         self,
-        cluster_lock_guessing_game: clusterlib.ClusterLib,
-        payment_addrs_lock_guessing_game: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
         worker_id: str,
         script: str,
     ):
@@ -695,7 +585,6 @@ class TestLocking:
           when failure is expected
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_guessing_game
         temp_template = f"{common.get_test_id(cluster)}_{script}"
 
         if script.endswith("game_42_43"):
@@ -732,8 +621,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_guessing_game[0],
-            dst_addr=payment_addrs_lock_guessing_game[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
         )
@@ -743,7 +632,7 @@ class TestLocking:
         err, __ = _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=payment_addrs_lock_guessing_game[1],
+            dst_addr=payment_addrs[1],
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
@@ -761,8 +650,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_always_fails(
         self,
-        cluster_lock_always_fails: clusterlib.ClusterLib,
-        payment_addrs_lock_always_fails: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
         worker_id: str,
     ):
         """Test locking a Tx output with a plutus script and spending the locked UTxO.
@@ -775,7 +664,6 @@ class TestLocking:
         * check that the amount was not transferred, collateral UTxO was not spent
           and the expected error was raised
         """
-        cluster = cluster_lock_always_fails
         temp_template = common.get_test_id(cluster)
 
         plutus_op = plutus_common.PlutusOp(
@@ -794,8 +682,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_fails[0],
-            dst_addr=payment_addrs_lock_always_fails[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
         )
@@ -805,7 +693,7 @@ class TestLocking:
         err, __ = _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=payment_addrs_lock_always_fails[1],
+            dst_addr=payment_addrs[1],
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
@@ -821,8 +709,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_script_invalid(
         self,
-        cluster_lock_always_fails: clusterlib.ClusterLib,
-        payment_addrs_lock_always_fails: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Test failing script together with the `--script-invalid` argument - collateral is taken.
 
@@ -833,7 +721,6 @@ class TestLocking:
         * try to spend the locked UTxO
         * check that the amount was not transferred and collateral UTxO was spent
         """
-        cluster = cluster_lock_always_fails
         temp_template = common.get_test_id(cluster)
 
         plutus_op = plutus_common.PlutusOp(
@@ -846,8 +733,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_fails[0],
-            dst_addr=payment_addrs_lock_always_fails[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
         )
@@ -857,7 +744,7 @@ class TestLocking:
         _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=payment_addrs_lock_always_fails[1],
+            dst_addr=payment_addrs[1],
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
@@ -870,10 +757,10 @@ class TestLocking:
     @pytest.mark.testnets
     def test_txin_token_locking(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
-        """Test locking a Tx output with a plutus script and spending the locked UTxO.
+        """Test locking a Tx output with native tokens and spending the locked UTxO.
 
         * create a Tx output that contains native tokens with a datum hash at the script address
         * check that the expected amount was locked at the script address
@@ -881,10 +768,9 @@ class TestLocking:
         * check that the expected amount was spent
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
         token_rand = clusterlib.get_rand_str(5)
-        payment_addr = payment_addrs_lock_always_suceeds[0]
+        payment_addr = payment_addrs[0]
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS_PLUTUS,
@@ -906,8 +792,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_suceeds[0],
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
             tokens=tokens_rec,
@@ -918,7 +804,7 @@ class TestLocking:
         _spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            dst_addr=payment_addrs[1],
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
@@ -931,8 +817,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_collateral_w_tokens(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Test spending the locked UTxO while collateral contains native tokens.
 
@@ -943,10 +829,9 @@ class TestLocking:
         * check that the expected error was raised
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
         token_rand = clusterlib.get_rand_str(5)
-        payment_addr = payment_addrs_lock_always_suceeds[0]
+        payment_addr = payment_addrs[0]
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS_PLUTUS,
@@ -968,8 +853,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_suceeds[0],
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
             tokens_collateral=tokens_rec,
@@ -982,7 +867,7 @@ class TestLocking:
             _spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
-                dst_addr=payment_addrs_lock_always_suceeds[1],
+                dst_addr=payment_addrs[1],
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op,
@@ -995,8 +880,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_same_collateral_txin(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Test spending the locked UTxO while using the same UTxO as collateral.
 
@@ -1008,7 +893,6 @@ class TestLocking:
         * check that the expected error was raised
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
 
         plutus_op = plutus_common.PlutusOp(
@@ -1021,8 +905,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_suceeds[0],
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
         )
@@ -1033,7 +917,7 @@ class TestLocking:
             _spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
-                dst_addr=payment_addrs_lock_always_suceeds[1],
+                dst_addr=payment_addrs[1],
                 script_utxos=script_utxos,
                 collateral_utxos=script_utxos,
                 plutus_op=plutus_op,
@@ -1045,8 +929,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_no_datum_txin(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Test using UTxO without datum hash in place of locked UTxO.
 
@@ -1057,11 +941,10 @@ class TestLocking:
         * check that the expected error was raised
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
 
-        payment_addr = payment_addrs_lock_always_suceeds[0]
-        dst_addr = payment_addrs_lock_always_suceeds[1]
+        payment_addr = payment_addrs[0]
+        dst_addr = payment_addrs[1]
 
         plutusrequiredtime, plutusrequiredspace = 700_000_000, 10_000_000
 
@@ -1111,8 +994,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_collaterals(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
         scenario: str,
     ):
         """Test dividing required collateral amount into multiple collateral UTxOs.
@@ -1131,7 +1014,6 @@ class TestLocking:
           when failure is expected
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
 
         max_collateral_ins = cluster.get_protocol_params()["maxCollateralInputs"]
@@ -1147,8 +1029,8 @@ class TestLocking:
             collateral_num = 0
             exp_err = "Transaction body has no collateral inputs"
 
-        payment_addr = payment_addrs_lock_always_suceeds[2]
-        dst_addr = payment_addrs_lock_always_suceeds[3]
+        payment_addr = payment_addrs[2]
+        dst_addr = payment_addrs[3]
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS_PLUTUS,
@@ -1219,8 +1101,8 @@ class TestLocking:
     @pytest.mark.testnets
     def test_collateral_percent(
         self,
-        cluster_lock_always_suceeds: clusterlib.ClusterLib,
-        payment_addrs_lock_always_suceeds: List[clusterlib.AddressRecord],
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: List[clusterlib.AddressRecord],
     ):
         """Try to spend locked UTxO while collateral is less than required by `collateralPercentage`.
 
@@ -1233,7 +1115,6 @@ class TestLocking:
         * check that the expected error was raised
         * (optional) check transactions in db-sync
         """
-        cluster = cluster_lock_always_suceeds
         temp_template = common.get_test_id(cluster)
 
         plutus_op = plutus_common.PlutusOp(
@@ -1246,8 +1127,8 @@ class TestLocking:
         tx_output_fund = _fund_script(
             temp_template=temp_template,
             cluster_obj=cluster,
-            payment_addr=payment_addrs_lock_always_suceeds[0],
-            dst_addr=payment_addrs_lock_always_suceeds[1],
+            payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
             amount=50_000_000,
             collateral_fraction_offset=0.9,
@@ -1260,7 +1141,7 @@ class TestLocking:
             _spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
-                dst_addr=payment_addrs_lock_always_suceeds[1],
+                dst_addr=payment_addrs[1],
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op,


### PR DESCRIPTION
It was necessary to allow just single test per Plutus script running at a time. Remove this limitation.