### PR TITLE
More efficient way to get test ID

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -1,5 +1,8 @@
-import inspect
+import os
+import re
+from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 
 from cardano_clusterlib import clusterlib
 
@@ -17,6 +20,18 @@ BUILD_SKIP_MSG = (
 )
 
 
+class PytestTest(NamedTuple):
+    test_function: str
+    test_file: Path
+    full: str
+    test_class: str = ""
+    test_params: str = ""
+    stage: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.test_function)
+
+
 @helpers.callonce
 def hypothesis_settings() -> Any:
     # pylint: disable=import-outside-toplevel
@@ -31,25 +46,41 @@ def hypothesis_settings() -> Any:
     )
 
 
+def get_current_test() -> PytestTest:
+    """Get components (test file, test name, etc.) of current pytest test."""
+    curr_test = os.environ.get("PYTEST_CURRENT_TEST") or ""
+    if not curr_test:
+        return PytestTest(test_function="", test_file=Path("/nonexistent"), full="")
+
+    reg = re.search(
+        r"(^.*/test_\w+\.py)(?:::)?(Test\w+)?::(test_\w+)(\[.+\])? *\(?(\w+)?", curr_test
+    )
+    if not reg:
+        raise AssertionError(f"Failed to match '{curr_test}'")
+
+    return PytestTest(
+        test_function=reg.group(3),
+        test_file=Path(reg.group(1)),
+        full=curr_test,
+        test_class=reg.group(2) or "",
+        test_params=reg.group(4) or "",
+        stage=reg.group(5) or "",
+    )
+
+
 def get_test_id(cluster_obj: clusterlib.ClusterLib) -> str:
     """Return unique test ID - function name + assigned cluster instance + random string.
 
     Log the test ID into cluster manager log file.
     """
-    calling_frame = inspect.currentframe().f_back  # type: ignore
-    func_name = calling_frame.f_code.co_name  # type: ignore
+    curr_test = get_current_test()
     rand_str = clusterlib.get_rand_str(3)
-    test_id = f"{func_name}_ci{cluster_obj.cluster_id}_{rand_str}"
+    test_id = f"{curr_test.test_function}_ci{cluster_obj.cluster_id}_{rand_str}"
 
     # log test ID to cluster manager log file - getting test ID happens early
     # after the start of a test, so the log entry can be used for determining
     # time of the test start
-    i_self = calling_frame.f_locals.get("self")  # type: ignore
-    if i_self:
-        code_id = f"{i_self.__class__.__module__}.{i_self.__class__.__qualname__}"
-    else:
-        code_id = calling_frame.f_globals["__name__"]  # type: ignore
     cm: cluster_management.ClusterManager = cluster_obj._cluster_manager  # type: ignore
-    cm._log(f"c{cm.cluster_instance_num}: got ID `{test_id}` for `{code_id}.{func_name}`")
+    cm._log(f"c{cm.cluster_instance_num}: got ID `{test_id}` for `{curr_test.full}`")
 
     return test_id

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -243,7 +243,7 @@ def testfile_temp_dir(tmp_path_factory: TempdirFactory) -> Path:
     """
     # get a dir path based on the test file running
     dir_path = (
-        (os.getenv("PYTEST_CURRENT_TEST") or "unknown")
+        (os.environ.get("PYTEST_CURRENT_TEST") or "unknown")
         .split("::")[0]
         .split("/")[-1]
         .replace(".", "_")

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -42,7 +42,7 @@ def pool_users(
 
         created_users = clusterlib_utils.create_pool_users(
             cluster_obj=cluster,
-            name_template=f"test_delegation_pool_users_ci{cluster_manager.cluster_instance_num}",
+            name_template=f"test_delegation_pool_user_ci{cluster_manager.cluster_instance_num}",
             no_of_addr=2,
         )
         fixture_cache.value = created_users
@@ -62,9 +62,10 @@ def pool_users_disposable(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.PoolUser]:
     """Create function scoped pool users."""
+    test_id = common.get_test_id(cluster)
     pool_users = clusterlib_utils.create_pool_users(
         cluster_obj=cluster,
-        name_template=f"test_delegation_pool_users_{clusterlib.get_rand_str(3)}",
+        name_template=f"{test_id}_pool_user",
         no_of_addr=2,
     )
     return pool_users

--- a/cardano_node_tests/tests/test_plutus_delegation.py
+++ b/cardano_node_tests/tests/test_plutus_delegation.py
@@ -60,13 +60,14 @@ def pool_user(
 ) -> delegation.PoolUserScript:
     """Create pool user."""
     cluster, *__ = cluster_lock_42stake
+    test_id = common.get_test_id(cluster)
 
     script_stake_address = cluster.gen_stake_addr(
-        addr_name=f"test_plutus_delegation_pool_user_ci{cluster_manager.cluster_instance_num}",
+        addr_name=f"{test_id}_pool_user",
         stake_script_file=plutus_common.STAKE_GUESS_42_PLUTUS,
     )
     payment_addr_rec = cluster.gen_payment_addr_and_keys(
-        name=f"test_plutus_delegation_pool_user_ci{cluster_manager.cluster_instance_num}",
+        name=f"{test_id}_pool_user",
         stake_script_file=plutus_common.STAKE_GUESS_42_PLUTUS,
     )
     pool_user = delegation.PoolUserScript(

--- a/cardano_node_tests/tests/test_plutus_mint_build.py
+++ b/cardano_node_tests/tests/test_plutus_mint_build.py
@@ -33,12 +33,9 @@ def payment_addrs(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.AddressRecord]:
     """Create new payment address."""
+    test_id = common.get_test_id(cluster)
     addrs = clusterlib_utils.create_payment_addr_records(
-        *[
-            f"plutus_payment_ci{cluster_manager.cluster_instance_num}_"
-            f"{clusterlib.get_rand_str(4)}_{i}"
-            for i in range(2)
-        ],
+        *[f"{test_id}_payment_addr_{i}" for i in range(2)],
         cluster_obj=cluster,
     )
 

--- a/cardano_node_tests/tests/test_plutus_mint_raw.py
+++ b/cardano_node_tests/tests/test_plutus_mint_raw.py
@@ -33,12 +33,9 @@ def payment_addrs(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.AddressRecord]:
     """Create new payment address."""
+    test_id = common.get_test_id(cluster)
     addrs = clusterlib_utils.create_payment_addr_records(
-        *[
-            f"plutus_payment_ci{cluster_manager.cluster_instance_num}_"
-            f"{clusterlib.get_rand_str(4)}_{i}"
-            for i in range(2)
-        ],
+        *[f"{test_id}_payment_addr_{i}" for i in range(2)],
         cluster_obj=cluster,
     )
 

--- a/cardano_node_tests/tests/test_plutus_spend_build.py
+++ b/cardano_node_tests/tests/test_plutus_spend_build.py
@@ -38,12 +38,9 @@ def payment_addrs(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.AddressRecord]:
     """Create new payment addresses."""
-    rand_str = clusterlib.get_rand_str(4)
+    test_id = common.get_test_id(cluster)
     addrs = clusterlib_utils.create_payment_addr_records(
-        *[
-            f"payment_addrs_ci{cluster_manager.cluster_instance_num}_{rand_str}_{i}"
-            for i in range(2)
-        ],
+        *[f"{test_id}_payment_addr_{i}" for i in range(2)],
         cluster_obj=cluster,
     )
 
@@ -64,10 +61,10 @@ def pool_users(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.PoolUser]:
     """Create new pool users."""
-    rand_str = clusterlib.get_rand_str(4)
+    test_id = common.get_test_id(cluster)
     created_users = clusterlib_utils.create_pool_users(
         cluster_obj=cluster,
-        name_template=f"pool_users_ci{cluster_manager.cluster_instance_num}_{rand_str}",
+        name_template=f"{test_id}_pool_users",
         no_of_addr=2,
     )
 

--- a/cardano_node_tests/tests/test_plutus_spend_raw.py
+++ b/cardano_node_tests/tests/test_plutus_spend_raw.py
@@ -38,12 +38,9 @@ def payment_addrs(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.AddressRecord]:
     """Create new payment addresses."""
-    rand_str = clusterlib.get_rand_str(4)
+    test_id = common.get_test_id(cluster)
     addrs = clusterlib_utils.create_payment_addr_records(
-        *[
-            f"payment_addrs_ci{cluster_manager.cluster_instance_num}_{rand_str}_{i}"
-            for i in range(2)
-        ],
+        *[f"{test_id}_payment_addr_{i}" for i in range(2)],
         cluster_obj=cluster,
     )
 
@@ -64,10 +61,10 @@ def pool_users(
     cluster: clusterlib.ClusterLib,
 ) -> List[clusterlib.PoolUser]:
     """Create new pool users."""
-    rand_str = clusterlib.get_rand_str(4)
+    test_id = common.get_test_id(cluster)
     created_users = clusterlib_utils.create_pool_users(
         cluster_obj=cluster,
-        name_template=f"pool_users_ci{cluster_manager.cluster_instance_num}_{rand_str}",
+        name_template=f"{test_id}_pool_users",
         no_of_addr=2,
     )
 

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1932,12 +1932,13 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
         testfile_temp_dir: Path,
     ) -> Tuple[str, str, clusterlib.KeyPair, clusterlib.ColdKeyPair]:
-        pool_name = f"pool_{clusterlib.get_rand_str(4)}"
+        rand_str = clusterlib.get_rand_str(3)
+        pool_name = f"pool_{rand_str}"
 
         pool_metadata = {
             "name": pool_name,
             "description": "cardano-node-tests E2E tests",
-            "ticker": "IOG2",
+            "ticker": f"IO{rand_str}",
             "homepage": "https://github.com/input-output-hk/cardano-node-tests",
         }
         pool_metadata_file = helpers.write_json(

--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -138,9 +138,10 @@ class TestBasic:
         cluster: clusterlib.ClusterLib,
     ) -> List[clusterlib.AddressRecord]:
         """Create 2 new payment addresses for `test_build_no_change`."""
+        test_id = common.get_test_id(cluster)
         addrs = clusterlib_utils.create_payment_addr_records(
-            f"addr_no_change_ci{cluster_manager.cluster_instance_num}_0",
-            f"addr_no_change_ci{cluster_manager.cluster_instance_num}_1",
+            f"{test_id}_addr_no_change_0",
+            f"{test_id}_addr_no_change_1",
             cluster_obj=cluster,
         )
 


### PR DESCRIPTION
Uses `PYTEST_CURRENT_TEST` env variable instead of expensive `inspect`.