### PR TITLE
Fix value ranges

### DIFF
--- a/cardano_node_tests/tests/test_plutus_spend_build.py
+++ b/cardano_node_tests/tests/test_plutus_spend_build.py
@@ -964,7 +964,9 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
-    @hypothesis.given(redeemer_number=st.integers(min_value=-2 ^ 64, max_value=2 ^ 64))
+    @hypothesis.given(
+        redeemer_number=st.integers(min_value=-(2**64) - 1, max_value=(2**64) - 1)
+    )
     @common.hypothesis_settings()
     def test_guessing_game_pbt(
         self,


### PR DESCRIPTION
In Python the `**` is exponentiation operator, the `^` is bitwise XOR.
`2 ^ 64 == 66` and `2 ** 64 == 18446744073709551616` (that's the number we want)