### PR TITLE
Test both typed and untyped redeemers and datum

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -44,6 +44,7 @@ class PlutusOp(NamedTuple):
     script_file: Path
     datum_file: Optional[Path] = None
     datum_cbor_file: Optional[Path] = None
+    datum_value: Optional[str] = None
     redeemer_file: Optional[Path] = None
     redeemer_cbor_file: Optional[Path] = None
     redeemer_value: Optional[str] = None


### PR DESCRIPTION
Split negative and valid scenarios into separate tests.