### PR TITLE
Wait for 2 new blocks on submit

### DIFF
--- a/cardano_node_tests/tests/test_transactions.py
+++ b/cardano_node_tests/tests/test_transactions.py
@@ -1852,7 +1852,7 @@ class TestNegative:
         # it should NOT be possible to submit a transaction with ttl far in the future
         err_str = ""
         try:
-            cluster.submit_tx_bare(out_file_signed)
+            cluster.submit_tx(out_file_signed, txins=tx_raw_output.txins)
         except clusterlib.CLIError as err:
             err_str = str(err)
 


### PR DESCRIPTION
Even though it should not be possible to submit the Tx, in reality the Tx is going through. Therefore we need to wait for two new blocks after submitting the Tx so we are sure that the input UTxO is really spent. Otherwise some other test may attempt to use the same UTxO and fail because of `BadInputsUTxO`.