### PR TITLE
Wait up to 50s in new epoch

### DIFF
--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -898,7 +898,7 @@ class TestRewards:
 
                 # wait before recording reward
                 clusterlib_utils.wait_for_epoch_interval(
-                    cluster_obj=cluster, start=10, stop=30, force_epoch=True
+                    cluster_obj=cluster, start=10, stop=50, force_epoch=True
                 )
                 this_epoch = cluster.get_epoch()
 
@@ -1539,7 +1539,7 @@ class TestRewards:
 
             # wait before recording reward
             clusterlib_utils.wait_for_epoch_interval(
-                cluster_obj=cluster, start=5, stop=35, force_epoch=True
+                cluster_obj=cluster, start=10, stop=50, force_epoch=True
             )
             this_epoch = cluster.get_epoch()
 


### PR DESCRIPTION
It can rarely happen that the tip is not updated for longer than 35s. The `wait_for_new_epoch` depends on info from current tip. When `wait_for_new_epoch` gets the information that we are in next epoch, we can already be past the 35s.