### PR TITLE
Attempt to fix context equivalence tests

### DIFF
--- a/cardano_node_tests/tests/test_plutus_mint_build.py
+++ b/cardano_node_tests/tests/test_plutus_mint_build.py
@@ -701,7 +701,7 @@ class TestBuildMinting:
 
         # Step 2: mint the "qacoin"
 
-        invalid_hereafter = cluster.get_slot_no() + 1_000
+        invalid_hereafter = cluster.get_slot_no() + 200
 
         policyid = cluster.get_policyid(plutus_common.MINTING_CONTEXT_EQUIVALENCE_PLUTUS_V1)
         asset_name = f"qacoin{clusterlib.get_rand_str(4)}".encode("utf-8").hex()
@@ -722,7 +722,7 @@ class TestBuildMinting:
         # we can generate a tx and then derive the correct redeemer
         redeemer_file_dummy = Path(f"{temp_template}_dummy_script_context.redeemer")
         clusterlib_utils.create_script_context(
-            cluster_obj=cluster, redeemer_file=redeemer_file_dummy
+            cluster_obj=cluster, plutus_version=1, redeemer_file=redeemer_file_dummy
         )
 
         plutus_mint_data_dummy = [
@@ -759,7 +759,10 @@ class TestBuildMinting:
 
         try:
             clusterlib_utils.create_script_context(
-                cluster_obj=cluster, redeemer_file=redeemer_file, tx_file=tx_file_dummy
+                cluster_obj=cluster,
+                plutus_version=1,
+                redeemer_file=redeemer_file,
+                tx_file=tx_file_dummy,
             )
         except AssertionError as err:
             err_msg = str(err)

--- a/cardano_node_tests/tests/test_plutus_mint_raw.py
+++ b/cardano_node_tests/tests/test_plutus_mint_raw.py
@@ -1097,7 +1097,7 @@ class TestMinting:
 
         # Step 2: mint the "qacoin"
 
-        invalid_hereafter = cluster.get_slot_no() + 1_000
+        invalid_hereafter = cluster.get_slot_no() + 200
 
         policyid = cluster.get_policyid(plutus_common.MINTING_CONTEXT_EQUIVALENCE_PLUTUS_V1)
         asset_name = f"qacoin{clusterlib.get_rand_str(4)}".encode("utf-8").hex()
@@ -1118,7 +1118,7 @@ class TestMinting:
         # we can generate a tx and then derive the correct redeemer
         redeemer_file_dummy = Path(f"{temp_template}_dummy_script_context.redeemer")
         clusterlib_utils.create_script_context(
-            cluster_obj=cluster, redeemer_file=redeemer_file_dummy
+            cluster_obj=cluster, plutus_version=1, redeemer_file=redeemer_file_dummy
         )
 
         plutus_mint_data_dummy = [
@@ -1159,7 +1159,10 @@ class TestMinting:
 
         try:
             clusterlib_utils.create_script_context(
-                cluster_obj=cluster, redeemer_file=redeemer_file, tx_file=tx_file_dummy
+                cluster_obj=cluster,
+                plutus_version=1,
+                redeemer_file=redeemer_file,
+                tx_file=tx_file_dummy,
             )
         except AssertionError as err:
             err_msg = str(err)

--- a/cardano_node_tests/tests/test_plutus_spend_build.py
+++ b/cardano_node_tests/tests/test_plutus_spend_build.py
@@ -502,7 +502,7 @@ class TestBuildLocking:
         # we can generate a tx and then derive the correct redeemer
         redeemer_file_dummy = Path(f"{temp_template}_dummy_script_context.redeemer")
         clusterlib_utils.create_script_context(
-            cluster_obj=cluster, redeemer_file=redeemer_file_dummy
+            cluster_obj=cluster, plutus_version=1, redeemer_file=redeemer_file_dummy
         )
 
         plutus_op_dummy = plutus_common.PlutusOp(
@@ -521,7 +521,7 @@ class TestBuildLocking:
             plutus_op=plutus_op_dummy,
         )
 
-        invalid_hereafter = cluster.get_slot_no() + 1_000
+        invalid_hereafter = cluster.get_slot_no() + 200
 
         __, tx_output_dummy, __ = _build_spend_locked_txin(
             temp_template=f"{temp_template}_dummy",
@@ -547,7 +547,10 @@ class TestBuildLocking:
 
         try:
             clusterlib_utils.create_script_context(
-                cluster_obj=cluster, redeemer_file=redeemer_file, tx_file=tx_file_dummy
+                cluster_obj=cluster,
+                plutus_version=1,
+                redeemer_file=redeemer_file,
+                tx_file=tx_file_dummy,
             )
         except AssertionError as err:
             err_msg = str(err)

--- a/cardano_node_tests/tests/test_plutus_spend_raw.py
+++ b/cardano_node_tests/tests/test_plutus_spend_raw.py
@@ -524,7 +524,7 @@ class TestLocking:
         # we can generate a tx and then derive the correct redeemer
         redeemer_file_dummy = Path(f"{temp_template}_dummy_script_context.redeemer")
         clusterlib_utils.create_script_context(
-            cluster_obj=cluster, redeemer_file=redeemer_file_dummy
+            cluster_obj=cluster, plutus_version=1, redeemer_file=redeemer_file_dummy
         )
 
         plutus_op_dummy = plutus_common.PlutusOp(
@@ -545,7 +545,7 @@ class TestLocking:
             deposit_amount=deposit_amount,
         )
 
-        invalid_hereafter = cluster.get_slot_no() + 1_000
+        invalid_hereafter = cluster.get_slot_no() + 200
 
         __, tx_output_dummy = _spend_locked_txin(
             temp_template=f"{temp_template}_dummy",
@@ -569,7 +569,10 @@ class TestLocking:
 
         try:
             clusterlib_utils.create_script_context(
-                cluster_obj=cluster, redeemer_file=redeemer_file, tx_file=tx_file_dummy
+                cluster_obj=cluster,
+                plutus_version=1,
+                redeemer_file=redeemer_file,
+                tx_file=tx_file_dummy,
             )
         except AssertionError as err:
             err_msg = str(err)


### PR DESCRIPTION
The `create-script-context` tool is still broken though. At least we are ready once the tool is eventually fixed.