### PR TITLE
Update clusterlib to 0.3.0rc11 to fix getting pool-params on node 1.35.1+

### DIFF
--- a/nix/cardano-clusterlib.nix
+++ b/nix/cardano-clusterlib.nix
@@ -2,10 +2,10 @@
 
 buildPythonPackage rec {
   pname = "cardano-clusterlib";
-  version = "0.3.0rc10";
+  version = "0.3.0rc11";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "GFSxRL6uZ91WXHtdu3T78+t+cXPbnwi5Q38CbMpQTkw=";
+    sha256 = "KHinOtlo02XHHVsJabWU7zjvsqjf6PMGXmbaEg9dzkw=";
   };
   doCheck = false;
   nativeBuildInputs = [ setuptools_scm ];

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     allure-pytest
-    cardano-clusterlib >= 0.3.0rc10,<0.4.0
+    cardano-clusterlib >= 0.3.0rc11,<0.4.0
     cbor2
     filelock
     hypothesis


### PR DESCRIPTION
Change introduced in https://github.com/input-output-hk/cardano-node/pull/4170/commits/f0475c99ca6dcc495884d4e159f2516fecdcd939. The data is now nested.