### PR TITLE
Add `dst_addr`s that were removed by mistake

### DIFF
--- a/cardano_node_tests/tests/test_plutus_v2_spend_build.py
+++ b/cardano_node_tests/tests/test_plutus_v2_spend_build.py
@@ -2027,6 +2027,7 @@ class TestNegativeReadonlyReferenceInputs:
             temp_template=temp_template,
             cluster=cluster,
             payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             amount=reference_input_amount,
         )
 

--- a/cardano_node_tests/tests/test_plutus_v2_spend_raw.py
+++ b/cardano_node_tests/tests/test_plutus_v2_spend_raw.py
@@ -1946,6 +1946,7 @@ class TestNegativeReadonlyReferenceInputs:
             temp_template=temp_template,
             cluster=cluster,
             payment_addr=payment_addrs[0],
+            dst_addr=payment_addrs[1],
             amount=amount,
         )
 


### PR DESCRIPTION
This was broken by https://github.com/input-output-hk/cardano-node-tests/pull/1317