### PR TITLE
CTD-54 changes to conform to IOG style guide

### DIFF
--- a/doc/mir_cert_test_example_manual_steps.md
+++ b/doc/mir_cert_test_example_manual_steps.md
@@ -185,12 +185,13 @@ cardano-cli transaction submit \
 --testnet-magic 42
 ```
 
-### Our stake address has id=13 and is registered 
-See the table below:  
+### Our stake address has id=13 and is registered
+
+See the table below:
 The stake address is `stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns`.
 
 ```sql
-dbsync0=# select * from stake_address;   
+select * from stake_address;
 ```
 
 | id |                           hash_raw                           |                               view                               | registered_tx_id | script_hash |
@@ -203,13 +204,10 @@ dbsync0=# select * from stake_address;
 | 3  | \xe07940665a5f25116ac467b1d0fdc514b86cad61786c59d1a52fcce9da | stake_test1upu5qej6tuj3z6kyv7caplw9zjuxettp0pk9n5d99lxwnksl99hux |                5 |  |
 | 13 | \xe027f58eedab972a15283c85aabf6670bf472394163f0329b9965bd69d | stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns |                9 |  |
 
-(7 rows)
-
 
 ```sql
-dbsync0=# select * from stake_registration;
 select * from stake_registration;
-```  
+```
 
 | id | addr_id | cert_index | tx_id | epoch_no |
 | -- | ------- | ---------- | ----- | --------- |
@@ -221,10 +219,9 @@ select * from stake_registration;
 | 6 |      11 |          9 |     5 |        1 |
 | 7 |      13 |          0 |    10 |       34 |
 
-(7 rows)
 
+## Deregistering an 'empty' stake address
 
-## Deregistering an 'empty' stake address  
  This address has no rewards because its stake was not delegated.
 
 ```sh
@@ -285,31 +282,28 @@ cardano-cli transaction sign \
 #### Submit txDeregistration event was registered in `db-sync`
 
 ```sql
-dbsync0=# select * from stake_deregistration;
 select * from stake_deregistration;
-```  
+```
+
  id | addr_id | cert_index | tx_id | epoch_no | redeemer_id
  -- | ------- | ---------- | ----- | -------- | ------------
-  1 |      13 |          0 |    11 |       39 |  
-
-(1 row)
-
+  1 |      13 |          0 |    11 |       39 |
 
 
 **RESERVES** and **TREASURY** table state before MIR cert submission:
 
 ```sql
-dbsync0=# select * from reserve;
 select * from reserve;
 ```
+
 | id | addr_id | cert_index | amount | tx_id
 | -- | ------- | ---------- | ------ | ------
 (0 rows)
 
 ```sql
-dbsync0=# select * from treasury;
 select * from treasury;
 ```
+
 | id | addr_id | cert_index | amount | tx_id
 | -- | ------- | ---------- | ------ | ------
 (0 rows)
@@ -373,18 +367,17 @@ cardano-cli transaction submit \
 ## State of tables after MIR cert tx submission
 
 ```sql
-dbsync0=# select * from reserve;
 select * from reserve;
 ```
+
  | id | addr_id | cert_index |    amount    | tx_id
  | -- | ------ | ---------- | ------------ | ------
   |  1 |      13 |          0 | 500000000000 |    12
-(1 row)
 
 ```sql
-dbsync0=# select * from treasury;
 select * from treasury;
 ```
+
  | id | addr_id | cert_index | amount | tx_id
  | -- | ------ | ---------- | ------ | ------
 (0 rows)
@@ -403,18 +396,16 @@ We can see that currently there are some issues:
 ```
 
 ```sql
-dbsync0=# select * from epoch_reward_total_received order by id DESC LIMIT 5;
 select * from epoch_reward_total_received order by id DESC LIMIT 5;
 ```
+
  | id | earned_epoch |    amount
  | -- | ----------- | -------------
  | 57 |           56 | 501065150011
  | 56 |           55 |   1196962304
  | 55 |           54 |   1197126868
  | 54 |           53 |   1197291461
- | 53 |           52 |   1197456077  
-
-(5 rows)
+ | 53 |           52 |   1197456077
 
 ```sql
 select reward.earned_epoch, pool_hash.view as delegated_pool, reward.amount as lovelace
@@ -422,6 +413,6 @@ select reward.earned_epoch, pool_hash.view as delegated_pool, reward.amount as l
     inner join pool_hash on reward.pool_id = pool_hash.id
     where stake_address.view = 'stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns'
     order by earned_epoch asc ;
-``` 
+```
 
-(NOTHING)
+`(NOTHING)`

--- a/doc/mir_cert_test_example_manual_steps.md
+++ b/doc/mir_cert_test_example_manual_steps.md
@@ -1,11 +1,9 @@
-# Test MIR certificate submission with local cluster
+# Test MIR certificate submission with a local cluster
 
-Some node network operations require access to genesis keys and this in other hand requires proper access to
-machines where those nodes are running. This is more of a `dev-ops` thing and in order
-to test things much faster and safer (in worst case test can only break your local cluster which you can easily respin) `local-cluster` is perfect fot investigating such cases.
+Some node network operations require access to genesis keys, and this requires proper access to the
+machines where those nodes are running. To run these tests more quickly and more safely (in the worst case, the test can only break your local cluster, which you can easily respin), `local-cluster` is just what you need.
 
-
-Below is an example of such case for running manual test for checking MIR certificate transfer to stake address that was registered and then deregistered before submission of MIR cert transaction. This is a practical example of interacting with `local cluster` - `cardano-node` and `db-sync` which also presents how easily you can use `local cluster` for examining cardano fautures.
+Below is an example of such a case of running a manual test for checking the MIR certificate transfer to a stake address that was registered and then deregistered before the MIR cert transaction was submitted. This is a practical example of interacting with `local-cluster` - `cardano-node` and `db-sync`, which also shows how easily you can use `local-cluster` for examining Cardano features.
 
 This assumes that you have a running local cluster.
 Instructions on how to start a local cluster can be found here:
@@ -59,9 +57,9 @@ stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns
 ```
 
 
-## Let's transfer funds from "faucet" address to our own Shelley address `payment.addr`
+## Let's transfer funds from the 'faucet' address to our own Shelley address `payment.addr`
 
-First query address that holds funds:
+First query an address that holds funds:
 
 ```sh
 cardano-cli query utxo --address $(cat /home/artur/Projects/cardano-node/state-cluster0/byron/address-000-converted) --testnet-magic 42
@@ -70,8 +68,8 @@ cardano-cli query utxo --address $(cat /home/artur/Projects/cardano-node/state-c
 3409ede3ea6665b175c5a56e41187f9e62b4f02901b1437a935b90ad60042249     0        35996998496920237 lovelace + TxOutDatumHashNone
 ```
 
-We will use arbitrary fee = 1 ADA
-and send 2 mln ADA from "faucet" address (address-000-converted) to payment.addr:
+We will assume an arbitrary fee = 1 ADA
+and send 2 mln ADA from the 'faucet' address (address-000-converted) to payment.addr:
 
 ```sh
 expr 35996998496920237 - 2000000000000 - 1000000
@@ -125,7 +123,7 @@ cardano-cli stake-address registration-certificate \
 --out-file stake.cert
 ```
 
-There is a deposit required for `stake address`. Let's check it's value:
+There is a deposit required for `stake address`. Let's check its value:
 
 ```sh
 cardano-cli query protocol-parameters --testnet-magic 42 | grep Deposit
@@ -145,7 +143,7 @@ cardano-cli query utxo --address $(cat /home/artur/Projects/payment.addr) --test
 ece90464d725625a1d7d5f484b24199f067d6bddb3df9b05a67c6cc8dba6944e     0        2000000000000 lovelace + TxOutDatumHashNone
 ```
 
-Calculate the change to send back to payment address after including the deposit:
+Calculate the change to send back to the payment address after including the deposit:
 
 ```sh
 fee = 1 ADA = 1000000 lovelaces
@@ -187,40 +185,46 @@ cardano-cli transaction submit \
 --testnet-magic 42
 ```
 
-### Our stake address has id=13 and is registered -> see in table below
-
-Stake address is `stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns`.
+### Our stake address has id=13 and is registered 
+See the table below:  
+The stake address is `stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns`.
 
 ```sql
-dbsync0=# select * from stake_address;
- id |                           hash_raw                           |                               view                               | registered_tx_id | script_hash
-----+--------------------------------------------------------------+------------------------------------------------------------------+------------------+-------------
-  5 | \xe0568028c22bdf100e83979696540db02ec6a4eb1f1c8e9d5b91b77487 | stake_test1uptgq2xz9003qr5rj7tfv4qdkqhvdf8truwga82mjxmhfpcxv3p46 |                5 |
-  1 | \xe0e50e564992e494d163c310af81d858168286e6acdff5bf15d887ed19 | stake_test1urjsu4jfjtjff5trcvg2lqwctqtg9phx4n0lt0c4mzr76xgfd5c7u |                5 |
-  8 | \xe0c4e0c1c243bcb0ff38e835d8e35f29c1f7d277587d602d713cf1933e | stake_test1urzwpswzgw7tplecaq6a3c6l98ql05nhtp7kqtt38ncex0stcmuyj |                5 |
-  2 | \xe054ddf4c30186b9154afe55b42ba175d903794ecd66b785c68bd2e7c1 | stake_test1up2dmaxrqxrtj922le2mg2apwhvsx72we4nt0pwx30fw0sg607vyz |                5 |
- 11 | \xe01c60761146bc394d9fb4e47f9ffbd3fd53256ca52b88dc040f6be406 | stake_test1uqwxqas3g67rjnvlknj8l8lm6074xftv554c3hqypa47gpstqfku4 |                5 |
-  3 | \xe07940665a5f25116ac467b1d0fdc514b86cad61786c59d1a52fcce9da | stake_test1upu5qej6tuj3z6kyv7caplw9zjuxettp0pk9n5d99lxwnksl99hux |                5 |
- 13 | \xe027f58eedab972a15283c85aabf6670bf472394163f0329b9965bd69d | stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns |                9 |
-(7 rows)
+dbsync0=# select * from stake_address;   
 ```
+
+| id |                           hash_raw                           |                               view                               | registered_tx_id | script_hash |
+| -- | ------------------------------------------------------------ | ---------------------------------------------------------------- | ---------------- | ----------- |
+| 5  | \xe0568028c22bdf100e83979696540db02ec6a4eb1f1c8e9d5b91b77487 | stake_test1uptgq2xz9003qr5rj7tfv4qdkqhvdf8truwga82mjxmhfpcxv3p46 |                5 |  |
+| 1  | \xe0e50e564992e494d163c310af81d858168286e6acdff5bf15d887ed19 | stake_test1urjsu4jfjtjff5trcvg2lqwctqtg9phx4n0lt0c4mzr76xgfd5c7u |                5 |  |
+| 8  | \xe0c4e0c1c243bcb0ff38e835d8e35f29c1f7d277587d602d713cf1933e | stake_test1urzwpswzgw7tplecaq6a3c6l98ql05nhtp7kqtt38ncex0stcmuyj |                5 |  |
+| 2  | \xe054ddf4c30186b9154afe55b42ba175d903794ecd66b785c68bd2e7c1 | stake_test1up2dmaxrqxrtj922le2mg2apwhvsx72we4nt0pwx30fw0sg607vyz |                5 |  |
+| 11 | \xe01c60761146bc394d9fb4e47f9ffbd3fd53256ca52b88dc040f6be406 | stake_test1uqwxqas3g67rjnvlknj8l8lm6074xftv554c3hqypa47gpstqfku4 |                5 |  |
+| 3  | \xe07940665a5f25116ac467b1d0fdc514b86cad61786c59d1a52fcce9da | stake_test1upu5qej6tuj3z6kyv7caplw9zjuxettp0pk9n5d99lxwnksl99hux |                5 |  |
+| 13 | \xe027f58eedab972a15283c85aabf6670bf472394163f0329b9965bd69d | stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns |                9 |  |
+
+(7 rows)
+
 
 ```sql
 dbsync0=# select * from stake_registration;
 select * from stake_registration;
- id | addr_id | cert_index | tx_id | epoch_no
-----+---------+------------+-------+----------
-  1 |       1 |          0 |     5 |        1
-  2 |       5 |          1 |     5 |        1
-  3 |       2 |          4 |     5 |        1
-  4 |       8 |          5 |     5 |        1
-  5 |       3 |          8 |     5 |        1
-  6 |      11 |          9 |     5 |        1
-  7 |      13 |          0 |    10 |       34
-(7 rows)
-```
+```  
 
-## Deregister "empty" stake address (no rewards on stake address as it was no delegated)
+| id | addr_id | cert_index | tx_id | epoch_no |
+| -- | ------- | ---------- | ----- | --------- |
+| 1 |       1 |          0 |     5 |        1 |
+| 2 |       5 |          1 |     5 |        1 |
+| 3 |       2 |          4 |     5 |        1 |
+| 4 |       8 |          5 |     5 |        1 |
+| 5 |       3 |          8 |     5 |        1 |
+| 6 |      11 |          9 |     5 |        1 |
+| 7 |      13 |          0 |    10 |       34 |
+
+(7 rows)
+
+
+## Deregister 'empty' stake address (no rewards on the stake address as it was not delegated)
 
 ```sh
 cardano-cli query stake-address-info --address stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns --testnet-magic 42
@@ -248,7 +252,7 @@ cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 42
 a4c141cfae907aa1c4b418f65f384a6d860d52786b412481bc63733acfab1541     0        1999998600000 lovelace + TxOutDatumHashNone
 ```
 
-#### Add +400000 from Key Deposit the will be returned
+#### Add +400000 from Key Deposit that will be returned
 
 ```sh
 expr 1999998600000 + 400000 - 1000000
@@ -283,18 +287,20 @@ cardano-cli transaction sign \
 cardano-cli transaction submit \
 --tx-file tx-deregister-stake-addr.signed \
 --testnet-magic 42
-```
+```  
 
 #### Deregistartion event was registered in `db-sync`
 
 ```sql
 dbsync0=# select * from stake_deregistration;
 select * from stake_deregistration;
- id | addr_id | cert_index | tx_id | epoch_no | redeemer_id
-----+---------+------------+-------+----------+-------------
-  1 |      13 |          0 |    11 |       39 |
+```  
+| id | addr_id | cert_index | tx_id | epoch_no | redeemer_id
+| -- | ------- | ---------- | ----- | -------- | ------------
+|  1 |      13 |          0 |    11 |       39 |  
+
 (1 row)
-```
+
 
 
 **RESERVES** and **TREASURY** table state before MIR cert submission:
@@ -302,18 +308,18 @@ select * from stake_deregistration;
 ```sql
 dbsync0=# select * from reserve;
 select * from reserve;
- id | addr_id | cert_index | amount | tx_id
-----+---------+------------+--------+-------
-(0 rows)
 ```
+| id | addr_id | cert_index | amount | tx_id
+| -- | ------- | ---------- | ------ | ------
+(0 rows)
 
 ```sql
 dbsync0=# select * from treasury;
 select * from treasury;
- id | addr_id | cert_index | amount | tx_id
-----+---------+------------+--------+-------
-(0 rows)
 ```
+| id | addr_id | cert_index | amount | tx_id
+| -- | ------- | ---------- | ------ | ------
+(0 rows)
 
 
 ## Generate MIR cert to send funds from reserves to unregistered stake address
@@ -328,9 +334,9 @@ cardano-cli governance create-mir-certificate \
 
 ```sh
 cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 42
-                           TxHash                                 TxIx        Amount
---------------------------------------------------------------------------------------
-277cab33552f06331af9dbf0d05635464a769dab05335511df7c7d4d70f41b61     0        1999998000000 lovelace + TxOutDatumHashNone
+                            TxHash                               | TxIx |    Amount
+ -----------------------------------------------------------------------------------
+ 277cab33552f06331af9dbf0d05635464a769dab05335511df7c7d4d70f41b61  0      1999998000000 lovelace + TxOutDatumHashNone
 ```
 
 ```sh
@@ -376,19 +382,19 @@ cardano-cli transaction submit \
 ```sql
 dbsync0=# select * from reserve;
 select * from reserve;
- id | addr_id | cert_index |    amount    | tx_id
-----+---------+------------+--------------+-------
-  1 |      13 |          0 | 500000000000 |    12
-(1 row)
 ```
+ | id | addr_id | cert_index |    amount    | tx_id
+ | -- | ------ | ---------- | ------------ | ------
+  |  1 |      13 |          0 | 500000000000 |    12
+(1 row)
 
 ```sql
 dbsync0=# select * from treasury;
 select * from treasury;
- id | addr_id | cert_index | amount | tx_id
-----+---------+------------+--------+-------
-(0 rows)
 ```
+ | id | addr_id | cert_index | amount | tx_id
+ | -- | ------ | ---------- | ------ | ------
+(0 rows)
 
 
 ## Logs
@@ -406,15 +412,16 @@ We can see that currently there are some issues:
 ```sql
 dbsync0=# select * from epoch_reward_total_received order by id DESC LIMIT 5;
 select * from epoch_reward_total_received order by id DESC LIMIT 5;
- id | earned_epoch |    amount
-----+--------------+--------------
- 57 |           56 | 501065150011
- 56 |           55 |   1196962304
- 55 |           54 |   1197126868
- 54 |           53 |   1197291461
- 53 |           52 |   1197456077
-(5 rows)
 ```
+ | id | earned_epoch |    amount
+ | -- | ----------- | -------------
+ | 57 |           56 | 501065150011
+ | 56 |           55 |   1196962304
+ | 55 |           54 |   1197126868
+ | 54 |           53 |   1197291461
+ | 53 |           52 |   1197456077  
+
+(5 rows)
 
 ```sql
 select reward.earned_epoch, pool_hash.view as delegated_pool, reward.amount as lovelace
@@ -422,6 +429,6 @@ select reward.earned_epoch, pool_hash.view as delegated_pool, reward.amount as l
     inner join pool_hash on reward.pool_id = pool_hash.id
     where stake_address.view = 'stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns'
     order by earned_epoch asc ;
+``` 
 
-<NOTHING>
-```
+(NOTHING)

--- a/doc/mir_cert_test_example_manual_steps.md
+++ b/doc/mir_cert_test_example_manual_steps.md
@@ -1,4 +1,4 @@
-# Test MIR certificate submission with a local cluster
+# Testing MIR certificate submission with a local cluster
 
 Some node network operations require access to genesis keys, and this requires proper access to the
 machines where those nodes are running. To run these tests more quickly and more safely (in the worst case, the test can only break your local cluster, which you can easily respin), `local-cluster` is just what you need.
@@ -9,7 +9,7 @@ This assumes that you have a running local cluster.
 Instructions on how to start a local cluster can be found here:
 <https://input-output-hk.github.io/cardano-node-tests/how-tos/300_running_local_cluster.html>
 
-## Create key pairs
+## Creating key pairs
 
 ### Payment key pair
 
@@ -57,7 +57,7 @@ stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns
 ```
 
 
-## Let's transfer funds from the 'faucet' address to our own Shelley address `payment.addr`
+## Transferring funds from the 'faucet' address to our own Shelley address `payment.addr`
 
 First query an address that holds funds:
 
@@ -115,7 +115,7 @@ cardano-cli query utxo --address $(cat /home/artur/Projects/payment.addr) --test
 ece90464d725625a1d7d5f484b24199f067d6bddb3df9b05a67c6cc8dba6944e     0        2000000000000 lovelace + TxOutDatumHashNone
 ```
 
-## Create a stake registration certificate
+## Creating a stake registration certificate
 
 ```sh
 cardano-cli stake-address registration-certificate \
@@ -153,7 +153,7 @@ expr 2000000000000 - 1000000 - 400000
 1999994000000
 ```
 
-### Submit the certificate with a transaction
+### Submitting the certificate with a transaction
 
 #### Build tx
 
@@ -224,7 +224,8 @@ select * from stake_registration;
 (7 rows)
 
 
-## Deregister 'empty' stake address (no rewards on the stake address as it was not delegated)
+## Deregistering an 'empty' stake address  
+ This address has no rewards because its stake was not delegated.
 
 ```sh
 cardano-cli query stake-address-info --address stake_test1uqnltrhd4wtj59fg8jz640mxwzl5wgu5zclsx2dejedad8gmxw2ns --testnet-magic 42
@@ -237,7 +238,7 @@ cardano-cli query stake-address-info --address stake_test1uqnltrhd4wtj59fg8jz640
 ]
 ```
 
-### Create deregistration certificate
+### Creating a deregistration certificate
 
 ```sh
 cardano-cli stake-address deregistration-certificate \
@@ -252,7 +253,7 @@ cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 42
 a4c141cfae907aa1c4b418f65f384a6d860d52786b412481bc63733acfab1541     0        1999998600000 lovelace + TxOutDatumHashNone
 ```
 
-#### Add +400000 from Key Deposit that will be returned
+#### Adding +400000 from a key deposit that will be returned
 
 ```sh
 expr 1999998600000 + 400000 - 1000000
@@ -281,23 +282,15 @@ cardano-cli transaction sign \
 --out-file tx-deregister-stake-addr.signed
 ```
 
-#### Submit tx
-
-```sh
-cardano-cli transaction submit \
---tx-file tx-deregister-stake-addr.signed \
---testnet-magic 42
-```  
-
-#### Deregistartion event was registered in `db-sync`
+#### Submit txDeregistration event was registered in `db-sync`
 
 ```sql
 dbsync0=# select * from stake_deregistration;
 select * from stake_deregistration;
 ```  
-| id | addr_id | cert_index | tx_id | epoch_no | redeemer_id
-| -- | ------- | ---------- | ----- | -------- | ------------
-|  1 |      13 |          0 |    11 |       39 |  
+ id | addr_id | cert_index | tx_id | epoch_no | redeemer_id
+ -- | ------- | ---------- | ----- | -------- | ------------
+  1 |      13 |          0 |    11 |       39 |  
 
 (1 row)
 
@@ -322,7 +315,7 @@ select * from treasury;
 (0 rows)
 
 
-## Generate MIR cert to send funds from reserves to unregistered stake address
+## Generating MIR cert to send funds from reserves to unregistered stake address
 
 ```sh
 cardano-cli governance create-mir-certificate \
@@ -377,7 +370,7 @@ cardano-cli transaction submit \
 ```
 
 
-## STATE of tables after MIR cert tx submission
+## State of tables after MIR cert tx submission
 
 ```sql
 dbsync0=# select * from reserve;

--- a/doc/running_local_cluster.md
+++ b/doc/running_local_cluster.md
@@ -127,7 +127,7 @@ Now you are ready to run the preparation script (which is described in detail in
 
 Inside `cardano-node-tests/cardano_node_tests/cluster_scripts` there are folders with all the data and scripts necessary for starting the cluster in various eras and setups:
 
-- `alonzo` - prepare files to start the cluster in `Byron` era and transition it through update proposals to `Alonzo` era. Once the cluster is ready it will be in `Alonzo` era and the decentralization parameter is set to: `d = 0`.
+- `Alonzo` - prepare files to start the cluster in `Byron` era and transition it through update proposals to `Alonzo` era. Once the cluster is ready it will be in `Alonzo` era and the decentralization parameter is set to: `d = 0`.
 
 - `testnets_nopools` - prepare files so the cluster will run on the real network but without setting up our own pool there.
 
@@ -493,7 +493,7 @@ When you run tests with:
 
 `pytest ... --log-level=debug`
 
-you can see what Cardano-CLI commands are executed.
+you can see what Cardano CLI commands are executed.
 
 
 ## Logs for `cardano-node` and `db-sync`
@@ -516,7 +516,7 @@ db-sync:
 - `cardano-node/state-cluster0/dbsync.stderr`
 
 
-## Accessing the `DB-sync` database
+## Accessing the `db-sync` database
 
 - If you did not change **PGPORT** and **PGUSER**:
 `psql -h /path/to/your/data -U postgres -e dbsync0` </br>

--- a/doc/running_local_cluster.md
+++ b/doc/running_local_cluster.md
@@ -1,15 +1,15 @@
-# How to start local cluster
+# How to start a local cluster
 
 ## What is a local cluster
 
-A **local cluster** is a local Cardano blockchain that consists of 3 stake pools and 1 BFT node. The chain is started in Byron era and it is moved in the desired era, similarly to Mainnet, using Update Proposals. The default `testnet-magic` value is 42.
+A **local cluster** is a local Cardano blockchain that consists of 3 stake pools and 1 BFT node. The chain is started in Byron era and it is moved to the desired era, similarly to Mainnet, using Update Proposals. The default `testnet-magic` value is 42.
 
-Using a local cluster you can test/play/interact with all the Cardano blockchain functionalities - from block creation, to rewards generation based on the stake delegated to each of the stake pool, generating and sending all kinds of transactions, to interacting with Plutus scripts.
+Using a local cluster, you can test/play/interact with all the Cardano blockchain functionalities - from block creation to rewards generation - based on the stake delegated to each of the stake pools, generating and sending all kinds of transactions, to interact with Plutus scripts.
 
-**Local cluster parameters**:
+**Local cluster parameters**
 
 - slotLength: 200ms
-- epochLenght: 1000 slots per epoch (that is 200sec)
+- epochLength: 1000 slots per epoch (that is 200sec)
 - activeSlotsCoeff: 0.1 (that means there will be ~ 100 blocks per epoch)
 
 ## Requirements
@@ -17,13 +17,11 @@ Using a local cluster you can test/play/interact with all the Cardano blockchain
 - Python 3.8 or newer
 - python3-pip
 - virtualenv
-- nix
+- nix For instructions on how to install `nix` and how to add IOHK binary cache, see <https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md>
 
-For instrucions on how to install `nix` and how to add IOHK binary cache, see <https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md>
+## Initial setup for all Cardano components
 
-## Initial setup for all cardano components
-
-Create directory for storing the cardano components repos:
+Create a directory for storing the Cardano components repositories:
 
 ```sh
 mkdir Projects
@@ -44,13 +42,13 @@ Clone the Cardano projects:
 
 `git clone git@github.com:input-output-hk/cardano-node-tests.git`
 
-Checkout the `db-sync` version that you want to use. `cardano-node-tests` requires `db-sync` executable file so we need to build db-sync.
+Checkout the `db-sync` version that you want to use. `cardano-node-tests` requires the `db-sync` executable file so we need to build db-sync.
 
 ```sh
 cd cardano-db-sync
 git checkout tags/11.0.4
 nix-build -A cardano-db-sync -o db-sync-node
-<<< wait for build to complete - it may take a while >>>
+<< wait for build to complete - it may take a while >>
 ```
 
 Go to `cardano-node-tests`, start the virtual environment and install all dependencies:
@@ -58,7 +56,7 @@ Go to `cardano-node-tests`, start the virtual environment and install all depend
 ```sh
 cd ../cardano-node-tests
 ./setup_venv.sh
-<<< it may take a while >>>
+<< it may take a while >>
 ```
 
 For debug purposes, at this point it might be beneficial to also install `ipython`:
@@ -81,69 +79,68 @@ and start nix devops shell:
 
 `nix-shell -A devops`
 
-Go back to tests repo and activate virtual environment:
+Go back to the tests repo and activate the virtual environment:
 
 ```sh
 cd ../cardano-node-tests
 . .env/bin/activate
 ```
 
-> **Note:** All the remaining steps from the below sections should be performed from `cardano-node-tests` directory
+> **Note:** All the remaining steps from the sections below should be performed from the `cardano-node-tests` directory
 
 
-### Starting postgres test database
+### Starting Postgres test database  
 
-**Usage of separate postgres database for testing is not mandatory.**
+**Usage of a separate Postgres database for testing is not mandatory.**
 
 There is a script for creating test database: `cardano-node-tests/scripts/postgres-start.sh`
 
-**Option 1:** If you want to start script that will use default values for postgres
-port/username and you already have a running postgres instance on your machine
+**Option 1:** If you want to start a script that will use default values for Postgres
+port/username and you already have a running Postgres instance on your machine
 then you need to stop it first:
 
 `sudo service postgresql stop`
 
-Then you can start a separate postgres instance that will be used for creating test database **dbsync0**.
+Then you can start a separate Postgres instance that will be used for creating test database **dbsync0**.
 
 `./scripts/postgres-start.sh "/home/username/Projects/tmp/postgres-qa" -k`
 
-As a first argument pass a directory where you would like to have your db data to be stored.
-After script ended `postgres-qa` directory should be created with `data` directory inside it under specified path.
+As a first argument, pass a directory where you would like to have your DB data to be stored.  After the script ends, `postgres-qa` directory should be created with `data` directory inside it under the specified path.
 
-"k" switch will kill already running postgres process (assuming it belongs to regular user, not root) and remove `data` directory (if you already used that directory in other test sessions).
+The "k" switch will kill any already running Postgres process (assuming it belongs to a regular user, not root) and remove the `data` directory (if you already used that directory in other test sessions).
 
 
-**Option 2**: If you don't want to stop your local postgres instance that is already running on port **5432** then you can simply export environment variables with values that will not collide with your default postgres setup, like:
+**Option 2**: If you don't want to stop your local Postgres instance that is already running on port **5432** then you can simply export environment variables with values that will not collide with your default Postgres setup, like:
 
 `export PGHOST=localhost PGPORT=5434 PGUSER=postgres_dbsync`
 
-and then run script:
+and then run this script:
 
 `./scripts/postgres-start.sh "/home/username/Projects/tmp/postgres-qa" -k`
 
-that will start a separate postgres database for testing.
+that will start a separate Postgres database for testing.
 
-Now you are ready to run preparation script (which is described in detail in next section **Preparing local cluster scripts**)
+Now you are ready to run the preparation script (which is described in detail in the next section).
 
 
 ### Preparing local cluster scripts
 
 Inside `cardano-node-tests/cardano_node_tests/cluster_scripts` there are folders with all the data and scripts necessary for starting the cluster in various eras and setups:
 
-- `alonzo` - prepare files to start cluster in `Byron` era and transition it through update proposals to `Alonzo` era. Once the cluster is ready it will be in `Alonzo` era and decentralisation parameter is set to: `d = 0`.
+- `alonzo` - prepare files to start the cluster in `Byron` era and transition it through update proposals to `Alonzo` era. Once the cluster is ready it will be in `Alonzo` era and the decentralization parameter is set to: `d = 0`.
 
-- `testnets_nopools` - prepare files so the cluster will run on real network but without setting up our own pool there.
+- `testnets_nopools` - prepare files so the cluster will run on the real network but without setting up our own pool there.
 
-- `testnets` - prepare files so the cluster will run on real network and will also have stake pool configured there. The tests that require pool presence will be run there.
+- `testnets` - prepare files so the cluster will run on the real network and will also have a stake pool configured there. The tests that require pool presence will be run there.
 
-**The procedure for setting up a local cluster on real network will be described in a separate document and link will be added here later.**
+**The procedure for setting up a local cluster on a real network will be described in a separate document and a link will be added here later.**
 
 
-If you want to prepare teh local cluster for running in **alonzo** era, use:
+If you want to prepare the local cluster for running in the `Alonzo` era, use:
 
 `prepare-cluster-scripts -d scripts/destination/dir -s cardano_node_tests/cluster_scripts/alonzo`
 
-Once you run this preparation script you will notice a new directory with template files and scripts located in:
+Once you run this preparation script, you will notice a new directory with template files and scripts located in:
 `cardano-node-tests/scripts/destination/dir`
 
 Those files will be used by the script that will start our local cluster.
@@ -153,13 +150,13 @@ Those files will be used by the script that will start our local cluster.
 
 > **Note:** This step is optional.
 
-As it was mentioned, after running the preparation script, a new directory with template files and scripts will be created:
+After running the preparation script, a new directory with template files and scripts will be created:
 `cardano-node-tests/scripts/destination/dir`
 
 You can find there a `start-cluster-hfc` script that contains all the code that starts the local cluster.
 
 If you want, for example, to change the value of the decentralization parameter, just search for that keyword
-in the code of `start-cluster-hfc` and after finding proper chunk edit it:
+in the code of `start-cluster-hfc` and after finding the right place edit it:
 
 ```sh
 MARY_HF_PROPOSAL="$STATE_CLUSTER/shelley/update-proposal-mary.proposal"
@@ -173,8 +170,8 @@ cardano_cli_log governance create-update-proposal \
   --protocol-minor-version 0
 ```
 
-If you would like to adjust some Alonzo specific parameters like `maxCollateralInputs`, the  procedure
-would be the same - use the search option in your editor, find the proper place and edit it accordingly to your needs:
+If you would like to adjust some Alonzo-specific parameters like `maxCollateralInputs`, the  procedure
+would be the same - use the search option in your editor, find the proper place and edit it according to your needs:
 
 ```sh
 jq -r '
@@ -257,15 +254,14 @@ Cluster started. Run `/home/artur/Projects/cardano-node-tests/scripts/destinatio
 
 ### Stop the local cluster
 
-To stop cluster run the exact command that last line suggests in the above log:
+To stop the cluster, run the exact command that the last line suggests in the above log:
 
 `<scripts/destination/dir>/stop-cluster-hfc`
 
 ### Set the TX_Era
 
-You can even create and send different era transactions (for example the local cluster can be in
-Alonzo era and you can create and send Shelley era transactions).
-You can control the transaction_era dynamically, while the cluster is running, through usage of
+You can even create and send different era transactions (for example the local cluster can be in the Alonzo era and you can create and send Shelley-era transactions).
+You can control the transaction era dynamically, while the cluster is running, using the
 following environment variable:
 
 ```sh
@@ -280,7 +276,7 @@ Available options for `TX_ERA`:
 - `alonzo`
 - `babbage`
 
-You can find the available options inside this file:
+You can find the available options in this file:
  `cardano-node-tests/cardano_node_tests/utils/configuration.py`
 
 You can now start the test (in the same shell and from `cardano-node-tests` directory)
@@ -298,9 +294,9 @@ You can run an entire test suite (tests covering an entire area of functionaliti
 pytest cardano_node_tests/tests/test_native_tokens.py
 ```
 
-### Run single test
+### Run a single test
 
-Open test file, find name of test you would like to run e.g. `test_minting_unicode_asset_name`
+Open the test file, find the name of the test you would like to run eg `test_minting_unicode_asset_name`
 
 ```sh
 pytest -k "test_minting_unicode_asset_name"
@@ -308,7 +304,7 @@ pytest -k "test_minting_unicode_asset_name"
 pytest -k "MyClass and not method"
 ```
 
-This will run tests which contain names that match the given string expression (case-insensitive),
+This will run tests that contain names that match the given string expression (case-insensitive),
 which can include Python operators that use filenames, class names and function names as variables.
 The example above will run TestMyClass.test_something but not TestMyClass.test_method_simple.
 
@@ -317,8 +313,8 @@ For more info on how to invoke tests, see <https://docs.pytest.org/en/6.2.x/usag
 
 ## Interact with the node
 
-Once the local cluster is running you can interact with its nodes. You can open a new shell and export
-`CARDANO_NODE_SOCKET_PATH` with the same value you used before to start cluster:
+Once the local cluster is running, you can interact with its nodes. You can open a new shell and export
+`CARDANO_NODE_SOCKET_PATH` with the same value you used before to start the cluster:
 
 `export CARDANO_NODE_SOCKET_PATH=/home/username/Projects/cardano-node/state-cluster0/bft1.socket`
 
@@ -378,16 +374,16 @@ cardano-cli query protocol-parameters --testnet-magic 42
 
 ### Transfer funds to your address
 
-During cluster startup,a Byron address will be created and the funds are moved out of the genesis UTxO into a regular address.
+During cluster startup, a Byron address will be created and the funds will be moved out of the genesis UTXO into a regular address.
 
 Inside `cardano-node/state-cluster0/byron`
 
 you can find:
 
-- `payment-keys.000.key` - byron payment signing key
-- `address-000` - printed address of a byron payment signing key (above) where funds from genesis were moved
-- `genesis-address-000` - genesis address with funds that will be transferred from to byron address-000
-- `payment-keys.000-converted.skey` - this is a byron payment signing key (payment-keys.000.key) converted to a corresponding Shelley-format key
+- `payment-keys.000.key` - Byron payment signing key
+- `address-000` - printed address of a Byron payment signing key (above) where funds from genesis were moved
+- `genesis-address-000` - genesis address with funds that will be transferred to a Byron address-000
+- `payment-keys.000-converted.skey` - this is a Byron payment signing key (payment-keys.000.key) converted to a corresponding Shelley-format key
 - `payment-keys.000-converted.vkey` - this is a verification key that was obtained from signing key `payment-keys.000-converted.skey`
 - `address-000-converted` - `address-000` converted to a corresponding Shelley-format key
 
@@ -402,12 +398,14 @@ and query it:
 
 ```sh
 cardano-cli query utxo --address 2657WMsDfac7Mx1ew6MVfxGqLGwvkkExEFyuWRxDGk4rPQB86uAfrD8BGqjh6ToRj --testnet-magic 42
-                           TxHash                                 TxIx        Amount
---------------------------------------------------------------------------------------
-30bfdafa359d0258e54c80de8d00b0556572fef93ec6171ac16572f3994132c7     0        35996998496920237 lovelace + TxOutDatumHashNone
-```
 
-You can use `address-000-converted` as a faucet to transfer funds to your manually created addresses. Signing key file that you need to use during transaction sign process is located here:
+``` 
+ |                          TxHash                                    | TxIx |  Amount  
+ | ----------------------------------------------------------------- | ---- | ------------
+ | 30bfdafa359d0258e54c80de8d00b0556572fef93ec6171ac16572f3994132c7  |   0  |      35996998496920237  lovelace + TxOutDatumHashNone
+
+
+You can use `address-000-converted` as a faucet to transfer funds to your manually created addresses. The signing key file that you need to use during the transaction sign process is located here:
 `cardano-node/state-cluster0/byron/payment-keys.000-converted.skey`
 
 **Example**:
@@ -447,7 +445,7 @@ Transaction successfully submitted.
 
 ## Debugging with IPython
 
-- If you have not already installed `ipython` package earlier, then do it in a shell that is not a `nix-shell` and where the virtual environment is activated
+- If you have not already installed the `ipython` package earlier, then do it in a shell that is not a `nix-shell` and where the virtual environment is activated
 
 ```sh
 pip install ipython
@@ -459,7 +457,7 @@ pip install ipython
 from IPython import embed; embed()
 ```
 
-on the line above the one where test code fails or where you want to simply investigate code:
+on the line above the one where the test code fails or where you want to simply investigate code:
 
 ```python
 def test_minting_unicode_asset_name(
@@ -478,7 +476,7 @@ def test_minting_unicode_asset_name(
 ```
 
 - run with `pytest -s ...` and inspect the runtime state once it gives you the `ipython` shell.
-Now you can enter variable names in `IPython` console in order to check their values/state.
+Now you can enter variable names in the `IPython` console to check their values/state.
 
 ```sh
 pytest -s cardano_node_tests/tests/test_native_tokens.py -k "test_minting_unicode_asset_name"
@@ -495,7 +493,7 @@ When you run tests with:
 
 `pytest ... --log-level=debug`
 
-you can see what cardano-cli commands are executed.
+you can see what Cardano-CLI commands are executed.
 
 
 ## Logs for `cardano-node` and `db-sync`
@@ -518,7 +516,7 @@ db-sync:
 - `cardano-node/state-cluster0/dbsync.stderr`
 
 
-## Accessing `db-sync` database
+## Accessing the `DB-sync` database
 
 - If you did not change **PGPORT** and **PGUSER**:
 `psql -h /path/to/your/data -U postgres -e dbsync0` </br>
@@ -534,39 +532,43 @@ Use `\dt` for listing all tables:
 
 ```sql
 dbsync0=# \dt
+```
                     List of relations
  Schema |            Name             | Type  |  Owner
---------+-----------------------------+-------+----------
+------- | --------------------------- | ----- | ---------
  public | ada_pots                    | table | postgres
  public | admin_user                  | table | postgres
  public | block                       | table | postgres
  public | collateral_tx_in            | table | postgres
- public | cost_models                 | table | postgres
+ public | cost_models                 | table | postgres  
+
 ... < skipped >
 (42 rows)
-```
+
 
 Use `\d table_name` for checking table details:
 
 
 ```sql
 dbsync0=# \d collateral_tx_in
-                               Table "public.collateral_tx_in"
-    Column    |  Type   | Collation | Nullable |                   Default
---------------+---------+-----------+----------+----------------------------------------------
+```
+                               Table "public.collateral_tx_in"  
+|    Column    |  Type   | Collation | Nullable |                   Default
+|  ----------- | ------- | --------- | -------- | ---------------------------------------------
  id           | bigint  |           | not null | nextval('collateral_tx_in_id_seq'::regclass)
  tx_in_id     | bigint  |           | not null |
  tx_out_id    | bigint  |           | not null |
- tx_out_index | txindex |           | not null |
+ tx_out_index | txindex |           | not null |  
+
 Indexes:
     "collateral_tx_in_pkey" PRIMARY KEY, btree (id)
     "unique_col_txin" UNIQUE CONSTRAINT, btree (tx_in_id, tx_out_id, tx_out_index)
 Foreign-key constraints:
     "collateral_tx_in_tx_in_id_fkey" FOREIGN KEY (tx_in_id) REFERENCES tx(id) ON UPDATE RESTRICT ON DELETE CASCADE
     "collateral_tx_in_tx_out_id_fkey" FOREIGN KEY (tx_out_id) REFERENCES tx(id) ON UPDATE RESTRICT ON DELETE CASCADE
-```
 
-and `\q` for leaving database.
+
+and `\q` for leaving the database.
 
 
 ### Useful queries

--- a/doc/running_local_cluster.md
+++ b/doc/running_local_cluster.md
@@ -6,7 +6,7 @@ A **local cluster** is a local Cardano blockchain that consists of 3 stake pools
 
 Using a local cluster, you can test/play/interact with all the Cardano blockchain functionalities - from block creation to rewards generation - based on the stake delegated to each of the stake pools, generating and sending all kinds of transactions, to interact with Plutus scripts.
 
-**Local cluster parameters**
+### Local cluster parameters
 
 - slotLength: 200ms
 - epochLength: 1000 slots per epoch (that is 200sec)
@@ -89,7 +89,7 @@ cd ../cardano-node-tests
 > **Note:** All the remaining steps from the sections below should be performed from the `cardano-node-tests` directory
 
 
-### Starting Postgres test database  
+### Starting Postgres test database
 
 **Usage of a separate Postgres database for testing is not mandatory.**
 
@@ -398,9 +398,9 @@ and query it:
 
 ```sh
 cardano-cli query utxo --address 2657WMsDfac7Mx1ew6MVfxGqLGwvkkExEFyuWRxDGk4rPQB86uAfrD8BGqjh6ToRj --testnet-magic 42
+```
 
-``` 
- |                          TxHash                                    | TxIx |  Amount  
+ |                          TxHash                                    | TxIx |  Amount
  | ----------------------------------------------------------------- | ---- | ------------
  | 30bfdafa359d0258e54c80de8d00b0556572fef93ec6171ac16572f3994132c7  |   0  |      35996998496920237  lovelace + TxOutDatumHashNone
 
@@ -530,43 +530,42 @@ for values used in examples above it would be: </br>
 
 Use `\dt` for listing all tables:
 
-```sql
+```text
 dbsync0=# \dt
 ```
-                    List of relations
+
  Schema |            Name             | Type  |  Owner
 ------- | --------------------------- | ----- | ---------
  public | ada_pots                    | table | postgres
  public | admin_user                  | table | postgres
  public | block                       | table | postgres
  public | collateral_tx_in            | table | postgres
- public | cost_models                 | table | postgres  
-
-... < skipped >
-(42 rows)
+ public | cost_models                 | table | postgres
+ ...
 
 
 Use `\d table_name` for checking table details:
 
 
-```sql
+```text
 dbsync0=# \d collateral_tx_in
 ```
-                               Table "public.collateral_tx_in"  
+
 |    Column    |  Type   | Collation | Nullable |                   Default
 |  ----------- | ------- | --------- | -------- | ---------------------------------------------
  id           | bigint  |           | not null | nextval('collateral_tx_in_id_seq'::regclass)
  tx_in_id     | bigint  |           | not null |
  tx_out_id    | bigint  |           | not null |
- tx_out_index | txindex |           | not null |  
+ tx_out_index | txindex |           | not null |
 
+ ```text
 Indexes:
     "collateral_tx_in_pkey" PRIMARY KEY, btree (id)
     "unique_col_txin" UNIQUE CONSTRAINT, btree (tx_in_id, tx_out_id, tx_out_index)
 Foreign-key constraints:
     "collateral_tx_in_tx_in_id_fkey" FOREIGN KEY (tx_in_id) REFERENCES tx(id) ON UPDATE RESTRICT ON DELETE CASCADE
     "collateral_tx_in_tx_out_id_fkey" FOREIGN KEY (tx_out_id) REFERENCES tx(id) ON UPDATE RESTRICT ON DELETE CASCADE
-
+```
 
 and `\q` for leaving the database.
 

--- a/doc/smash/smash_faq.md
+++ b/doc/smash/smash_faq.md
@@ -3,13 +3,13 @@
 Q: I can see that one pool has many reserved tickers. Is this a valid behavior?
 
 ```sql
-testnet_v12_6=# select * from reserved_pool_ticker where pool_hash='\x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f';
+select * from reserved_pool_ticker where pool_hash='\x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f';
 ```
+
 | id | name |                         pool_hash
 | -- | ---- | -----------------------------------------------------------
 |   4 | QA_3 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f
-|   5 | QA_4 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f  
-(2 rows)
+|   5 | QA_4 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f
 
 
 A: Yes, this should be allowed. Reserved ticker functionality has never been used and how to use it is still under discussion.
@@ -23,12 +23,12 @@ Q: I can delist pools that do not exist. Is this a valid behavior?
 ```sh
 curl -X GET -v http://localhost:3101/api/v1/metadata/8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66/4b2221a0ac0b0197308323080ba97e3e453f8625393d30f96eebe0fca4cb7335 | jq .
 
-```
 (NOTHING)
+```
 
 1. Delist it:
 
-```shell
+```sh
 curl --verbose -u username:password --header "Content-Type: application/json" --request PATCH --data '{"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}' http://localhost:3101/api/v1/delist
 
 {"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}
@@ -37,14 +37,14 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 1. Check DB: the last record with that pool_id added:
 
 ```sql
-testnet_v12_6=# select * from delisted_pool;
+select * from delisted_pool;
 ```
+
   id |                          hash_raw
  --- | -----------------------------------------------------------
    1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41
    2 | \x3a57885c1e896a939c0b71c8e070eaf742fbcdb214f62cede8b79b10
    5 | \x8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66
-
 
 
 A: Yes, this is a valid behavior, for example, someone could start syncing and delist the pool either manually or using the fetch policies endpoint before they appear in the Blockchain. Keeping them separate means we don't impose any order.
@@ -73,7 +73,10 @@ jq length retired_pools.json
 VS
 
 ```sql
-testnet_v12_6=# select count (*) from pool_retire;
+select count (*) from pool_retire;
+```
+
+```text
 count
 -------
   346

--- a/doc/smash/smash_faq.md
+++ b/doc/smash/smash_faq.md
@@ -1,28 +1,30 @@
 # SMASH FAQ
 
-Q: I can see that one pool has many reserved tickers. Is this a valid behavior ?
+Q: I can see that one pool has many reserved tickers. Is this a valid behavior?
 
 ```sql
 testnet_v12_6=# select * from reserved_pool_ticker where pool_hash='\x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f';
- id | name |                         pool_hash
-----+------+------------------------------------------------------------
-  4 | QA_3 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f
-  5 | QA_4 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f
-(2 rows)
 ```
+| id | name |                         pool_hash
+| -- | ---- | -----------------------------------------------------------
+|   4 | QA_3 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f
+|   5 | QA_4 | \x1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f  
+(2 rows)
 
-A: Yes, this should be allowed. Reserved ticker functionality has never been used and it's still under discussion how to use it.
+
+A: Yes, this should be allowed. Reserved ticker functionality has never been used and how to use it is still under discussion.
 
 
-Q: I can delist pools that do not exist. Is this a valid behavior ?
+Q: I can delist pools that do not exist. Is this a valid behavior?
 
 
 1. Query some fake pool:
 
 ```sh
 curl -X GET -v http://localhost:3101/api/v1/metadata/8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66/4b2221a0ac0b0197308323080ba97e3e453f8625393d30f96eebe0fca4cb7335 | jq .
-< NOTHING >
+
 ```
+(NOTHING)
 
 1. Delist it:
 
@@ -32,22 +34,23 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 {"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}
 ```
 
-1. Check DB: last record with that pool_id added:
+1. Check DB: the last record with that pool_id added:
 
 ```sql
 testnet_v12_6=# select * from delisted_pool;
- id |                          hash_raw
-----+------------------------------------------------------------
-  1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41
-  2 | \x3a57885c1e896a939c0b71c8e070eaf742fbcdb214f62cede8b79b10
-  5 | \x8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66
 ```
+  id |                          hash_raw
+ --- | -----------------------------------------------------------
+   1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41
+   2 | \x3a57885c1e896a939c0b71c8e070eaf742fbcdb214f62cede8b79b10
+   5 | \x8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66
 
 
-A: Yes, this is a valid behavior, for example someone could start syncing and delist the pool either manually or using the fetch policies endpoint before they appear in the Blockchain. Keeping them separate means we don't impose any order.
+
+A: Yes, this is a valid behavior, for example, someone could start syncing and delist the pool either manually or using the fetch policies endpoint before they appear in the Blockchain. Keeping them separate means we don't impose any order.
 
 
-Q: What happened to `testing-flag`:
+Q: What happened to `testing-flag`?
 
 ```sh
 flag testing-mode
@@ -56,10 +59,10 @@ flag testing-mode
 ```
 
 A: The flag was removed completely. `testing-mode` was supposed to enable manual insert endpoints like the POST metadata endpoint.
-One can directly use the db to insert entries for testing so we are not missing any functionality by removing it.
+One can directly use the database to insert entries for testing, so we are not missing any functionality by removing it.
 
 
-Q: Can the count of results returned by **SMASH** retire endpoint differ from results count in **pool_retire** table ?
+Q: Can the count of results returned by the **SMASH** retire endpoint differ from the results count in the **pool_retire** table?
 
 ```sh
 curl --header "Content-Type: application/json" http://localhost:3100/api/v1/retired | jq . > retired_pools.json
@@ -77,4 +80,4 @@ count
 (1 row)
 ```
 
-A: Yes, if the pools re-registers. There has to be an entry in **pool_update** which is after the **announced_tx_id**
+A: Yes, if the pools re-register. There has to be an entry in **pool_update** which is after the **announced_tx_id**

--- a/doc/smash/smash_tests_and_debugging_examples.md
+++ b/doc/smash/smash_tests_and_debugging_examples.md
@@ -1,8 +1,8 @@
 # SMASH - tests and debugging examples
 
 
-These examples come from the `testnet` network.  
-  
+These examples come from the `testnet` network.
+
 **SMASH** can be built with:
 
 `cabal build cardano-smash-server`
@@ -66,13 +66,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 ```
 
 ```sql
-testnet_v12_6=# select * from delisted_pool;
+select * from delisted_pool;
 ```
+
 | id |                          hash_raw
 | -- | -----------------------------------------------------------
-| 1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41  
-(1 row)
-
+| 1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41
 
 
 ## Reserving a ticker
@@ -99,13 +98,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 ```
 
 ```sql
-testnet_v12_6=# select * from reserved_pool_ticker;
+select * from reserved_pool_ticker;
 ```
+
 | id | name |                         pool_hash
 | -- | ---- | -----------------------------------------------------------
-|  1 | ART  | \x1c443cd9c14c85e6b541be0c2bd98c9f11be25185a15636c33c4cd8f  
-(1 row)
-
+|  1 | ART  | \x1c443cd9c14c85e6b541be0c2bd98c9f11be25185a15636c33c4cd8f
 
 
 ## Whitelisting
@@ -132,12 +130,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 ```
 
 ```sql
-testnet_v12_6=# select * from delisted_pool;
+select * from delisted_pool;
 ```
+
  id |                          hash_raw
  -- | -----------------------------------------------------------
  1 | \x81e84003f3d2f65315b479dc3cdbe4aa8c8595a3d76818e284b29f27
-(1 row)
 
 
 b) Query pool after it was delisted ==> no results
@@ -159,12 +157,12 @@ curl -u username:password -X PATCH -v http://localhost:3100/api/v1/enlist -H 'co
 ```
 
 ```sql
-testnet_v12_6=# select * from delisted_pool;
+select * from delisted_pool;
 ```
+
 | id |                          hash_raw
 | -- | -----------------------------------------------------------
-                        << NOTHING >>
-```
+(0 rows)
 
 d) Query pool again:
 
@@ -331,8 +329,9 @@ cat smash_imported_policies.json | jq -r '.delistedPools | length'
 VS
 
 ```sql
-testnet_v12_6=# select * from delisted_pool;
+select * from delisted_pool;
 ```
+
  id  |                          hash_raw
 ---- | -----------------------------------------------------------
  382 | \xce2e5bbae0caa514670d63cfdad3123a5d32cf7c37df87add5a0f75f
@@ -352,9 +351,7 @@ testnet_v12_6=# select * from delisted_pool;
  396 | \x0e76c44520b9d7f2e211eccd82de49350288368802c7aaa72a13c3fa
  397 | \xd471e981d54a7f60496f9239d2d706db7a71df8517025f478c112e3e
  398 | \xf537b3a5ac2ecdc854a535a15f7732632375a0bf2af17dccbe5b422d
- 399 | \x033fa1cdc17193fa3d549e795591999621e749fd7ef48f7380468d14  
-(18 rows)
-
+ 399 | \x033fa1cdc17193fa3d549e795591999621e749fd7ef48f7380468d14
 
 
 ## An example of debugging an issue with a pool
@@ -365,23 +362,22 @@ We have a pool `pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla` that c
 
 
 ```sql
-testnet_v12_6=# select * from pool_hash where view='pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla';
+select * from pool_hash where view='pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla';
 ```
+
  id  |                          hash_raw                          |                           view
 ---- | --------------------------------------------------------- | ----------------------------------------------------------
- 103 | \xbe329bbf0ee0f53d19f3b2808611779a49c7df43f330a8035eb9f853 | pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla  
-
-(1 row)
+ 103 | \xbe329bbf0ee0f53d19f3b2808611779a49c7df43f330a8035eb9f853 | pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla
 
 
 **pool_retire**:
 
 ```sql
-testnet_v12_6=# select * from pool_retire where hash_id=103;
+select * from pool_retire where hash_id=103;
 ```
- id | hash_id | cert_index | announced_tx_id | retiring_epoch
---- | ------- | ---------- | --------------- | ---------------  
 
+ id | hash_id | cert_index | announced_tx_id | retiring_epoch
+--- | ------- | ---------- | --------------- | ---------------
 (0 rows)
 
 
@@ -395,7 +391,7 @@ Let's check the last update for this pool
  103 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  100000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              85 |     101 |   0.04 |  340000000 |            25037
  118 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  250000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              87 |     116 |   0.01 |  340000000 |            34587
  292 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  250000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              90 |     290 |   0.04 |  430000000 |            55996
- 303 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 | 3495862056 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              91 |     301 | 0.0095 |  340000000 |            56543  
+ 303 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 | 3495862056 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              91 |     301 | 0.0095 |  340000000 |            56543
 
 (4 rows)
 
@@ -405,17 +401,15 @@ and metadata associated with it
 **pool_metadata_ref**:
 
 ```sql
-testnet_v12_6=# select * from pool_metadata_ref where pool_id=103;
+select * from pool_metadata_ref where pool_id=103;
 ```
+
  id  | pool_id |         url          |                                hash                                | registered_tx_id
 ---- | ------- | -------------------- | ------------------------------------------------------------------ | -----------------
- 301 |     103 | https://git.io/JTUAD | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543
- 101 |     103 | https://git.io/JU8gA | \x314699218763d2d0c1c2cc75d4405de67709a888f01a4ca4d2b0f290e285c6e1 |            25037
- 290 |     103 | https://git.io/JUNOy | \x94be57c392f721154c96bafbf9ebd80fe369b35ec8f177b292329ee21db25cbf |            55996
- 116 |     103 | https://LLCJ.com     | \x4001829c25b4af556d1a473dec4874a621899cf6a84c60156ec2411727f1a169 |            34587  
-
-(4 rows)
-
+ 301 |     103 | <https://git.io/JTUAD> | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543
+ 101 |     103 | <https://git.io/JU8gA> | \x314699218763d2d0c1c2cc75d4405de67709a888f01a4ca4d2b0f290e285c6e1 |            25037
+ 290 |     103 | <https://git.io/JUNOy> | \x94be57c392f721154c96bafbf9ebd80fe369b35ec8f177b292329ee21db25cbf |            55996
+ 116 |     103 | <https://LLCJ.com>     | \x4001829c25b4af556d1a473dec4874a621899cf6a84c60156ec2411727f1a169 |            34587
 
 
 So our pool is not visible in tools like wallet and it is also not present in **pool_retire** table.
@@ -425,13 +419,12 @@ Private pools are not listed by those tools however last records from **pool_upd
 Let's check the pool relay:
 
 ```sql
-testnet_v12_6=# select * from pool_relay where update_id=303;
+select * from pool_relay where update_id=303;
 ```
+
   id  | update_id |     ipv4     | ipv6 | dns_name | dns_srv_name | port
 ----- | --------- | ------------ | ---- | -------- | ------------ | -----
- 1426 |       303 | 72.184.59.65 |      |          |              | 3001  
-
-(1 row)
+ 1426 |       303 | 72.184.59.65 |      |          |              | 3001
 
 and try to ping it:
 
@@ -561,7 +554,7 @@ For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395`, the
 
  id  | pool_id |         url          |                                hash                                | registered_tx_id
 ---- | ------- | -------------------- | ------------------------------------------------------------------ | -----------------
- 301 |     103 | https://git.io/JTUAD | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543  
+ 301 |     103 | <https://git.io/JTUAD> | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543
 
 
 `https://git.io/JTUAD` opens correctly a GH page with the following JSON:
@@ -577,21 +570,20 @@ For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395`, the
 
 It seems that for this pool, 4 metadata references have been registered (from **pool_metadata_ref** table), but 3 of them failed and only one succeeded.
 
-The **pool_offline_data** table shows different metadata - the one that matches the record with `id=290`` in **pool_metadata_ref**
-(homepage `https://llcj.com/`differs from JSON presented above `https://git.io/JUNOy`)
+The **pool_offline_data** table shows different metadata - the one that matches the record with `id=290` in **pool_metadata_ref**
+(homepage <https://llcj.com/> differs from JSON presented above <https://git.io/JUNOy>)
 
 
 ```sql
-testnet_v12_6=# select id, pool_id, json from pool_offline_data where pool_id=103;
+select id, pool_id, json from pool_offline_data where pool_id=103;
 ```
+
  id  | pool_id |                                                json
 ---- | ------- | ----------------------------------------------------------------------------------------------------
- 138 |     103 | {"name": "Lpool", "ticker": "LPO", "homepage": "https://LLCJ.com", "description": "L pool is cool"}  
- 
-(1 row)
+ 138 |     103 | {"name": "Lpool", "ticker": "LPO", "homepage": "https://LLCJ.com", "description": "L pool is cool"}
 
 
-but this is not the last entry in **pool_metadata_ref** which has `id=301` and  `homepage=https://git.io/JTUAD`. 
+but this is not the last entry in **pool_metadata_ref** which has `id=301` and  `homepage=https://git.io/JTUAD`.
 
 The reason for this problem is mentioned in one of the error messages returned by **SMASH**:
 

--- a/doc/smash/smash_tests_and_debugging_examples.md
+++ b/doc/smash/smash_tests_and_debugging_examples.md
@@ -1,20 +1,19 @@
 # SMASH - Tests and debugging examples
 
 
-Examples come from `testnet` network.
-
-
-**SMASH** can be build with:
+These examples come from the `testnet` network.  
+  
+**SMASH** can be built with:
 
 `cabal build cardano-smash-server`
 
 
-Find and copy executable to your $PATH:
+Find and copy the executable to your $PATH:
 
 `cp $(find . -name cardano-smash-server -executable -type f) ~/.local/bin`
 
 
-Prepare `admins.txt` file which should have format:
+Prepare an `admins.txt` file which should have this format:
 
 ```text
 username, password
@@ -48,7 +47,7 @@ curl --verbose --header "Content-Type: application/json" --request GET http://lo
 ```
 
 
-## Delisting pool
+## Delisting pools
 
 a) Delisting a pool for the first time:
 
@@ -58,7 +57,7 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 {"poolId":"a5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41"}
 ```
 
-b) Delisting already delisted pool results in:
+b) Delisting an already delisted pool results in:
 
 ```sh
 curl --verbose -u username:password --header "Content-Type: application/json" --request PATCH --data '{"poolId":"a5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41"}' http://localhost:3100/api/v1/delist
@@ -68,11 +67,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 
 ```sql
 testnet_v12_6=# select * from delisted_pool;
- id |                          hash_raw
-----+------------------------------------------------------------
-  1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41
-(1 row)
 ```
+| id |                          hash_raw
+| -- | -----------------------------------------------------------
+| 1 | \xa5a3ce765f5162548181a44d1ff8c8f8c50018cca59acc0b70a85a41  
+(1 row)
+
 
 
 ## Reserving a ticker
@@ -85,7 +85,7 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 {"name":"ART"}
 ```
 
-b) Insert already a reserved ticker for a different pool:
+b) Insert an already reserved ticker for a different pool:
 
 ```sh
 curl --verbose -u username:password --header "Content-Type: application/json" --request POST --data '{"poolId":"1c443cd9c14c85e6b541be0c2bd98c9f11cd25185a15636c44c4cd3f"}' http://localhost:3100/api/v1/tickers/ART
@@ -100,11 +100,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 
 ```sql
 testnet_v12_6=# select * from reserved_pool_ticker;
- id | name |                         pool_hash
-----+------+------------------------------------------------------------
-  1 | ART  | \x1c443cd9c14c85e6b541be0c2bd98c9f11be25185a15636c33c4cd8f
-(1 row)
 ```
+| id | name |                         pool_hash
+| -- | ---- | -----------------------------------------------------------
+|  1 | ART  | \x1c443cd9c14c85e6b541be0c2bd98c9f11be25185a15636c33c4cd8f  
+(1 row)
+
 
 
 ## Whitelisting
@@ -132,11 +133,12 @@ curl --verbose -u username:password --header "Content-Type: application/json" --
 
 ```sql
 testnet_v12_6=# select * from delisted_pool;
- id |                          hash_raw
-----+------------------------------------------------------------
-  1 | \x81e84003f3d2f65315b479dc3cdbe4aa8c8595a3d76818e284b29f27
-(1 row)
 ```
+ id |                          hash_raw
+ -- | -----------------------------------------------------------
+ 1 | \x81e84003f3d2f65315b479dc3cdbe4aa8c8595a3d76818e284b29f27
+(1 row)
+
 
 b) Query pool after it was delisted ==> no results
 
@@ -158,8 +160,9 @@ curl -u username:password -X PATCH -v http://localhost:3100/api/v1/enlist -H 'co
 
 ```sql
 testnet_v12_6=# select * from delisted_pool;
- id |                          hash_raw
-----+------------------------------------------------------------
+```
+| id |                          hash_raw
+| -- | -----------------------------------------------------------
                         << NOTHING >>
 ```
 
@@ -234,9 +237,9 @@ curl --header "Content-Type: application/json" http://localhost:3100/api/v1/reti
 ```
 
 
-## Fetch policies from other SMASH service
+## Fetch policies from another SMASH service
 
-Fetch policies from other SMASH service:
+Fetch policies from another SMASH service:
 
 * mainnet
    <https://smash.cardano-mainnet.iohk.io>
@@ -329,8 +332,9 @@ VS
 
 ```sql
 testnet_v12_6=# select * from delisted_pool;
+```
  id  |                          hash_raw
------+------------------------------------------------------------
+---- | -----------------------------------------------------------
  382 | \xce2e5bbae0caa514670d63cfdad3123a5d32cf7c37df87add5a0f75f
  383 | \x2b830258888a09e846b63474c642ad4e18aecd08dafb1f2a4d653e80
  384 | \x027a08f49ad5ece08e3a1575fb9cd8e8d7cf3b7815807a20b1a715f1
@@ -348,50 +352,53 @@ testnet_v12_6=# select * from delisted_pool;
  396 | \x0e76c44520b9d7f2e211eccd82de49350288368802c7aaa72a13c3fa
  397 | \xd471e981d54a7f60496f9239d2d706db7a71df8517025f478c112e3e
  398 | \xf537b3a5ac2ecdc854a535a15f7732632375a0bf2af17dccbe5b422d
- 399 | \x033fa1cdc17193fa3d549e795591999621e749fd7ef48f7380468d14
+ 399 | \x033fa1cdc17193fa3d549e795591999621e749fd7ef48f7380468d14  
 (18 rows)
 
-```
 
 
 ## Debugging issue with pool - example
 
-Here is an example of unusual behavior of pool on `testnet` that could not be seen in any tool that tracks pools and at the same time it could not be found in retired pools.
+Here is an example of unusual behavior of a pool on `testnet` that could not be seen in any tool that tracks pools and at the same time, it could not be found in retired pools.
 
-We got pool `pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla` that can't be found in [Deadalus](https://buildkite.com/input-output-hk/daedalus/builds?branch=release%2F4.5.2) (version for `testnet`) nor on <https://pooltool.io/> (which is a web tool for listing pool details on both, `mainnet` and `testnet`) and it is also not listed in **pool_retire** table:
+We have a pool `pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla` that can't be found in [Daedalus](https://buildkite.com/input-output-hk/daedalus/builds?branch=release%2F4.5.2) (version for `testnet`) nor on <https://pooltool.io/> (which is a web tool for listing pool details on both `mainnet` and `testnet`) and it is also not listed in the **pool_retire** table:
 
 
 ```sql
 testnet_v12_6=# select * from pool_hash where view='pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla';
- id  |                          hash_raw                          |                           view
------+------------------------------------------------------------+----------------------------------------------------------
- 103 | \xbe329bbf0ee0f53d19f3b2808611779a49c7df43f330a8035eb9f853 | pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla
-(1 row)
 ```
+ id  |                          hash_raw                          |                           view
+---- | --------------------------------------------------------- | ----------------------------------------------------------
+ 103 | \xbe329bbf0ee0f53d19f3b2808611779a49c7df43f330a8035eb9f853 | pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla  
+
+(1 row)
 
 
 **pool_retire**:
 
 ```sql
 testnet_v12_6=# select * from pool_retire where hash_id=103;
- id | hash_id | cert_index | announced_tx_id | retiring_epoch
-----+---------+------------+-----------------+----------------
-(0 rows)
 ```
+ id | hash_id | cert_index | announced_tx_id | retiring_epoch
+--- | ------- | ---------- | --------------- | ---------------  
+
+(0 rows)
+
 
 Let's check the last update for this pool
 
 **pool_update**:
 
-```sql
+
  id  | hash_id | cert_index |                            vrf_key_hash                            |   pledge   |                         reward_addr                          | active_epoch_no | meta_id | margin | fixed_cost | registered_tx_id
------+---------+------------+--------------------------------------------------------------------+------------+--------------------------------------------------------------+-----------------+---------+--------+------------+------------------
+---- | ------- | ---------- | ------------------------------------------------------------------ | ---------- | ------------------------------------------------------------ | --------------- | ------- | ------ | ---------- | -----------------
  103 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  100000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              85 |     101 |   0.04 |  340000000 |            25037
  118 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  250000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              87 |     116 |   0.01 |  340000000 |            34587
  292 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 |  250000000 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              90 |     290 |   0.04 |  430000000 |            55996
- 303 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 | 3495862056 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              91 |     301 | 0.0095 |  340000000 |            56543
+ 303 |     103 |          0 | \xfdbcad682e1462b1a107fb204316e73b4791aba0691410bdb5a6c219a0a16fe6 | 3495862056 | \xe0d6de2014f77443a986d2ae9144fbcdcf08da0ddea1c0ce0f7e311d68 |              91 |     301 | 0.0095 |  340000000 |            56543  
+
 (4 rows)
-```
+
 
 and metadata associated with it
 
@@ -399,29 +406,32 @@ and metadata associated with it
 
 ```sql
 testnet_v12_6=# select * from pool_metadata_ref where pool_id=103;
+```
  id  | pool_id |         url          |                                hash                                | registered_tx_id
------+---------+----------------------+--------------------------------------------------------------------+------------------
+---- | ------- | -------------------- | ------------------------------------------------------------------ | -----------------
  301 |     103 | https://git.io/JTUAD | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543
  101 |     103 | https://git.io/JU8gA | \x314699218763d2d0c1c2cc75d4405de67709a888f01a4ca4d2b0f290e285c6e1 |            25037
  290 |     103 | https://git.io/JUNOy | \x94be57c392f721154c96bafbf9ebd80fe369b35ec8f177b292329ee21db25cbf |            55996
- 116 |     103 | https://LLCJ.com     | \x4001829c25b4af556d1a473dec4874a621899cf6a84c60156ec2411727f1a169 |            34587
+ 116 |     103 | https://LLCJ.com     | \x4001829c25b4af556d1a473dec4874a621899cf6a84c60156ec2411727f1a169 |            34587  
+
 (4 rows)
-```
+
 
 
 So our pool is not visible in tools like wallet and it is also not present in **pool_retire** table.
 Private pools are not listed by those tools however last records from **pool_update** table listed above show that this is not a private pool because it has a `margin < 100%`.
 
 
-Let's check pool relay:
+Let's check the pool relay:
 
 ```sql
 testnet_v12_6=# select * from pool_relay where update_id=303;
-  id  | update_id |     ipv4     | ipv6 | dns_name | dns_srv_name | port
-------+-----------+--------------+------+----------+--------------+------
- 1426 |       303 | 72.184.59.65 |      |          |              | 3001
-(1 row)
 ```
+  id  | update_id |     ipv4     | ipv6 | dns_name | dns_srv_name | port
+----- | --------- | ------------ | ---- | -------- | ------------ | -----
+ 1426 |       303 | 72.184.59.65 |      |          |              | 3001  
+
+(1 row)
 
 and try to ping it:
 
@@ -435,7 +445,7 @@ PING 72.184.59.65 (72.184.59.65) 56(84) bytes of data.
 We can see that it is up.
 
 
-Now let's check ledger state and see if the record for our pool is still present there:
+Now let's check the ledger state and see if the record for our pool is still present there:
 
 ```sh
 cardano-cli query stake-distribution --testnet-magic 1097911063 | grep pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7vc2sq67h8u9x8z2cla
@@ -546,15 +556,15 @@ curl http://localhost:3100/api/v1/errors/pool1hcefh0cwur6n6x0nk2qgvythnfyu0h6r7v
 ]
 ```
 
-For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395` url from **pool_metadata_ref** is:
+For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395`, the URL from **pool_metadata_ref** is:
 
-```sql
+
  id  | pool_id |         url          |                                hash                                | registered_tx_id
------+---------+----------------------+--------------------------------------------------------------------+------------------
- 301 |     103 | https://git.io/JTUAD | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543
-```
+---- | ------- | -------------------- | ------------------------------------------------------------------ | -----------------
+ 301 |     103 | https://git.io/JTUAD | \xf2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 |            56543  
 
-`https://git.io/JTUAD` opens correctly a GH page with following json:
+
+`https://git.io/JTUAD` opens correctly a GH page with the following JSON:
 
 ```json
 {
@@ -565,30 +575,31 @@ For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395` url 
 }
 ```
 
-It seems that for this pool 4 metadata references have been registered (from **pool_metadata_ref** table), but 3 of them failed and only one succeeded.
+It seems that for this pool, 4 metadata references have been registered (from **pool_metadata_ref** table), but 3 of them failed and only one succeeded.
 
-The **pool_offline_data** table shows different metadata - the one that matches record with `id=290` in **pool_metadata_ref**
-(homepage `https://llcj.com/`differs from json presented above `https://git.io/JUNOy`)
+The **pool_offline_data** table shows different metadata - the one that matches the record with `id=290`` in **pool_metadata_ref**
+(homepage `https://llcj.com/`differs from JSON presented above `https://git.io/JUNOy`)
 
 
 ```sql
 testnet_v12_6=# select id, pool_id, json from pool_offline_data where pool_id=103;
- id  | pool_id |                                                json
------+---------+-----------------------------------------------------------------------------------------------------
- 138 |     103 | {"name": "Lpool", "ticker": "LPO", "homepage": "https://LLCJ.com", "description": "L pool is cool"}
-(1 row)
 ```
+ id  | pool_id |                                                json
+---- | ------- | ----------------------------------------------------------------------------------------------------
+ 138 |     103 | {"name": "Lpool", "ticker": "LPO", "homepage": "https://LLCJ.com", "description": "L pool is cool"}  
+ 
+(1 row)
 
-but this is not the last entry in **pool_metadata_ref** which has `id=301` and  `homepage=https://git.io/JTUAD`.
 
+but this is not the last entry in **pool_metadata_ref** which has `id=301` and  `homepage=https://git.io/JTUAD`. 
 
-Reason of this problem is mentioned in one of errors returned by **SMASH**:
+The reason for this problem is mentioned in one of the error messages returned by **SMASH**:
 
 ```text
 "cause":"Hash mismatch from when fetching metadata from https://git.io/JTUAD. Expected f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395 but got 75848f572990cbc72a9efd62ed5aa0178e16d5164c6dcfbb040dcec47f13d8f4."
 ```
 
-If we download metadata file and check it's hash:
+If we download the metadata file and check its hash:
 
 ```sh
 wget https://git.io/JTUAD
@@ -596,6 +607,6 @@ cardano-cli stake-pool metadata-hash --pool-metadata-file JTUAD
 75848f572990cbc72a9efd62ed5aa0178e16d5164c6dcfbb040dcec47f13d8f4
 ```
 
-we can see in fact that it's hash is different than expected.
+we can see in fact that its hash is different from what was expected.
 
-It looks like someone decided to update the last succesful metadata for pool (`id=290` in **pool_metadata_ref**) but declared a wrong hash for a new metadata file and now pool can't be correctly listed by **SMASH**.
+It looks like someone decided to update the last successful metadata for the pool (`id=290` in **pool_metadata_ref**) but declared a wrong hash for a new metadata file and now the pool can't be correctly listed by **SMASH**.

--- a/doc/smash/smash_tests_and_debugging_examples.md
+++ b/doc/smash/smash_tests_and_debugging_examples.md
@@ -1,4 +1,4 @@
-# SMASH - Tests and debugging examples
+# SMASH - tests and debugging examples
 
 
 These examples come from the `testnet` network.  
@@ -357,7 +357,7 @@ testnet_v12_6=# select * from delisted_pool;
 
 
 
-## Debugging issue with pool - example
+## An example of debugging an issue with a pool
 
 Here is an example of unusual behavior of a pool on `testnet` that could not be seen in any tool that tracks pools and at the same time, it could not be found in retired pools.
 

--- a/doc/stake_credential_history_tool.md
+++ b/doc/stake_credential_history_tool.md
@@ -5,7 +5,8 @@ The stake credential history tool is a very useful utility that produces a linea
 It works with all blockchain networks including local testnets.
 
 
-## Documentation  
+## Documentation
+
 The stake credential history tool is located in the `cardano-node` repository.
 
 Full documentation for building, running, and description of event types is [in its description](https://github.com/input-output-hk/cardano-node/blob/master/cardano-client-demo/Stake-Credential-History.md).
@@ -16,7 +17,7 @@ Full documentation for building, running, and description of event types is [in 
 We will use a [local test cluster](https://github.com/input-output-hk/cardano-node-tests/blob/master/doc/running_local_cluster.md) to show the Stake Credential History Tool in action.
 
 
-Let's place a breakpoint...  
+Let's place a breakpoint...
 
 
 ```python

--- a/doc/stake_credential_history_tool.md
+++ b/doc/stake_credential_history_tool.md
@@ -1,12 +1,12 @@
-# Stake Credential History Tool
+# Stake credential history tool
 
 
-The Stake Credential History Tool is a very useful utility that produces a linear history of events for a given stake credential.
+The stake credential history tool is a very useful utility that produces a linear history of events for a given stake credential.
 It works with all blockchain networks including local testnets.
 
 
 ## Documentation  
-The Stake Credential History Tool is located in the `cardano-node` repository.
+The stake credential history tool is located in the `cardano-node` repository.
 
 Full documentation for building, running, and description of event types is [in its description](https://github.com/input-output-hk/cardano-node/blob/master/cardano-client-demo/Stake-Credential-History.md).
 

--- a/doc/stake_credential_history_tool.md
+++ b/doc/stake_credential_history_tool.md
@@ -1,30 +1,29 @@
 # Stake Credential History Tool
 
 
-Stake Credential History Tool is a very useful utility that produces a linear history of events for a given stake credential.
+The Stake Credential History Tool is a very useful utility that produces a linear history of events for a given stake credential.
 It works with all blockchain networks including local testnets.
 
 
-## Documentation
+## Documentation  
+The Stake Credential History Tool is located in the `cardano-node` repository.
 
-Stake Credential History Tool is located in `cardano-node` repository.
-
-Full documentation for building, running and description of event types is [here](https://github.com/input-output-hk/cardano-node/blob/master/cardano-client-demo/Stake-Credential-History.md).
+Full documentation for building, running, and description of event types is [in its description](https://github.com/input-output-hk/cardano-node/blob/master/cardano-client-demo/Stake-Credential-History.md).
 
 
 ## Example of usage
 
-We will use a [local test cluster](https://github.com/input-output-hk/cardano-node-tests/blob/master/doc/running_local_cluster.md) to present Stake Credential History Tool in action.
+We will use a [local test cluster](https://github.com/input-output-hk/cardano-node-tests/blob/master/doc/running_local_cluster.md) to show the Stake Credential History Tool in action.
 
 
-Let's place a breakpoint:
+Let's place a breakpoint...  
 
 
 ```python
 from IPython import embed; embed()
 ```
 
-in one of tests in `test_mir_certs.py` named `test_pay_stake_addr_from_both` that sends funds from the reserves and treasury pots to stake address and run it with:
+in one of the tests in `test_mir_certs.py` named `test_pay_stake_addr_from_both` that sends funds from the reserves and treasury pots to a stake address, and run it with:
 
 
 ```sh
@@ -37,7 +36,7 @@ Once the test stops we will get the stake address we are interested in by using:
 cluster.get_stake_addr_info(registered_user.stake.address)
 ```
 
-Here is a step by step example:
+Here is a step-by-step example:
 
 
 ```sh
@@ -96,7 +95,7 @@ BALANCE ----------- EpochNo 16, SlotNo 16010, balance: Lovelace 100000000
 BALANCE ----------- EpochNo 17, SlotNo 17070, balance: Lovelace 100000000
 ```
 
-With Stake Credential History Tool we can see events like registrations, de-registrations, delegations, instantaneous rewards, reward withdrawals, mentions inside pool parameter registrations, and also per-epoch active stake and rewards.
+With the Stake Credential History Tool, we can see events like registrations, de-registrations, delegations, instantaneous rewards, reward withdrawals, mentions inside pool parameter registrations, and also per-epoch active stake and rewards.
 
 
 ```sh


### PR DESCRIPTION
Several SQL responses were shown as text, but they did not format into tables. To show them as tables, I took them out of the scope of the ``` SQL block. The result is not the way they would be rendered in a terminal window, but IMO it is more readable than the way they were.