### PR TITLE
Update Buildkite agent queue

### DIFF
--- a/.buildkite/db_sync_full_sync.yml
+++ b/.buildkite/db_sync_full_sync.yml
@@ -11,4 +11,4 @@ steps:
     timeout_in_minutes: 43200
     agents:
       system: x86_64-linux
-      queue: benchmark_large
+      queue: benchmark

--- a/.buildkite/db_sync_snapshot_restoration.yml
+++ b/.buildkite/db_sync_snapshot_restoration.yml
@@ -9,4 +9,4 @@ steps:
     timeout_in_minutes: 14400
     agents:
       system: x86_64-linux
-      queue: benchmark_large
+      queue: benchmark


### PR DESCRIPTION
Update Buildkite queue from `benchmark_large` (obsolete and gone) to just `benchmark`