### PR TITLE
Short pools ticker so there is more space for pool number

### DIFF
--- a/cardano_node_tests/cluster_scripts/babbage/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/babbage/start-cluster-hfc
@@ -391,7 +391,7 @@ for i in $(seq 1 "$NUM_POOLS"); do
 
   POOL_NAME="TestPool$i"
   POOL_DESC="Test Pool $i"
-  POOL_TICKER="TEST$i"
+  POOL_TICKER="TP$i"
 
   cat > "$STATE_CLUSTER/webserver/pool$i.html" <<EoF
 <!DOCTYPE html>

--- a/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster-hfc
@@ -308,7 +308,7 @@ for i in $(seq 1 "$NUM_POOLS"); do
 
   POOL_NAME="TestPool$i"
   POOL_DESC="Test Pool $i"
-  POOL_TICKER="TEST$i"
+  POOL_TICKER="TP$i"
 
   cat > "$STATE_CLUSTER/webserver/pool$i.html" <<EoF
 <!DOCTYPE html>


### PR DESCRIPTION
The ticker can be max up to 5 characters long.