### PR TITLE
Rename to follow nightly tests naming convention

### DIFF
--- a/.github/workflows/nightly_upgrade.yaml
+++ b/.github/workflows/nightly_upgrade.yaml
@@ -1,4 +1,4 @@
-name: Nightly upgrade tests
+name: Nightly tests upgrade
 
 on:
   schedule:


### PR DESCRIPTION
Currently the results are not picked up by reports aggregator due to naming mismatch.