### PR TITLE
Skip all tests in `TestMIRCerts` when HF shortcut is used

### DIFF
--- a/cardano_node_tests/tests/test_mir_certs.py
+++ b/cardano_node_tests/tests/test_mir_certs.py
@@ -207,6 +207,7 @@ class TestMIRCerts:
     @common.SKIPIF_BUILD_UNUSABLE
     def test_build_transfer_to_treasury(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: List[clusterlib.PoolUser],
@@ -286,6 +287,7 @@ class TestMIRCerts:
     @pytest.mark.dbsync
     def test_transfer_to_reserves(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: List[clusterlib.PoolUser],
@@ -371,6 +373,7 @@ class TestMIRCerts:
     @common.SKIPIF_BUILD_UNUSABLE
     def test_build_transfer_to_reserves(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: List[clusterlib.PoolUser],
@@ -451,6 +454,7 @@ class TestMIRCerts:
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
     def test_pay_stake_addr_from(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: List[clusterlib.PoolUser],
@@ -541,6 +545,7 @@ class TestMIRCerts:
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
     def test_build_pay_stake_addr_from(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: List[clusterlib.PoolUser],
@@ -637,6 +642,7 @@ class TestMIRCerts:
     @pytest.mark.dbsync
     def test_pay_stake_addr_from_both(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: List[clusterlib.PoolUser],
@@ -769,6 +775,7 @@ class TestMIRCerts:
     @pytest.mark.dbsync
     def test_pay_multi_stake_addrs(
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: List[clusterlib.PoolUser],
@@ -913,6 +920,7 @@ class TestMIRCerts:
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
     def test_pay_unregistered_stake_addr_from(  # noqa: C901
         self,
+        skip_on_hf_shortcut: None,  # pylint: disable=unused-argument
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: List[clusterlib.PoolUser],


### PR DESCRIPTION
If local cluster is started in latest era instead of going from Byron, there might be insufficient funds in pots.