### PR TITLE
Use system nix in `base`

### DIFF
--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -3,6 +3,8 @@
 
 set -xeuo pipefail
 
+nix --version
+
 REPODIR="$(readlink -m "${0%/*}/..")"
 cd "$REPODIR"
 

--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -3,6 +3,8 @@
 
 set -xeuo pipefail
 
+nix --version
+
 REPODIR="$(readlink -m "${0%/*}/..")"
 cd "$REPODIR"
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
         {
           devShells = rec {
             base = pkgs.mkShell {
-              nativeBuildInputs = with pkgs; [ bash nix gnugrep gnumake gnutar coreutils git xz python3Packages.supervisor ];
+              nativeBuildInputs = with pkgs; [ bash gnugrep gnumake gnutar coreutils git xz python3Packages.supervisor ];
             };
             python = pkgs.mkShell {
               nativeBuildInputs = with pkgs; with python39Packages; [ python39Full virtualenv pip matplotlib pandas requests xmltodict psutil GitPython pymysql ];


### PR DESCRIPTION
We no longer use pure shell, so there's no need to install nix. Moreover it istalls old nix (2.7.x) that doesn't work with latest cardano-node.