### PR TITLE
Make reporting of log errors more readable

### DIFF
--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -208,6 +208,14 @@ class ClusterManager:
         if container.value != cached_value:
             self.cache.test_data[curline_hash] = container.value
 
+    def get_logfiles_errors(self) -> str:
+        """Get errors found in cluster artifacts."""
+        if self._cluster_instance_num == -1:
+            return ""
+
+        self.log(f"c{self._cluster_instance_num}: called `get_logfiles_errors`")
+        return logfiles.get_logfiles_errors()
+
     def on_test_stop(self) -> None:
         """Perform actions after a test is finished."""
         if self._cluster_instance_num == -1:
@@ -215,9 +223,6 @@ class ClusterManager:
 
         current_test = os.environ.get("PYTEST_CURRENT_TEST") or ""
         self.log(f"c{self._cluster_instance_num}: called `on_test_stop` for '{current_test}'")
-
-        # search for errors in cluster logfiles
-        errors = logfiles.search_cluster_artifacts()
 
         with locking.FileLockIfXdist(self.cluster_lock):
             # There's only one test running on a worker at a time. Deleting the corresponding rules
@@ -258,9 +263,6 @@ class ClusterManager:
                 for tf in self.instance_dir.glob(f"{common.TEST_RUNNING_GLOB}*")
             ]
             self.log(f"c{self._cluster_instance_num}: running tests: {tnames}")
-
-        if errors:
-            logfiles.report_artifacts_errors(errors)
 
     def _get_resources_by_glob(
         self,

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -214,8 +214,8 @@ def expect_errors(regex_pairs: List[Tuple[str, str]], ignore_file_id: str) -> It
         raise AssertionError(errors_joined) from None
 
 
-def search_cluster_artifacts() -> List[Tuple[Path, str]]:
-    """Search cluster artifacts for errors."""
+def search_cluster_logs() -> List[Tuple[Path, str]]:
+    """Search cluster logs for errors."""
     cluster_env = cluster_nodes.get_cluster_env()
     lock_file = temptools.get_basetemp() / f"search_artifacts_{cluster_env.instance_num}.lock"
 
@@ -279,8 +279,12 @@ def clean_ignore_rules(ignore_file_id: str) -> None:
         rules_file.unlink(missing_ok=True)
 
 
-def report_artifacts_errors(errors: List[Tuple[Path, str]]) -> None:
-    """Report errors found in artifacts."""
+def get_logfiles_errors() -> str:
+    """Get errors found in cluster artifacts."""
+    errors = search_cluster_logs()
+    if not errors:
+        return ""
+
     err = [f"{e[0]}: {e[1]}" for e in errors]
     err_joined = "\n".join(err)
-    raise AssertionError(f"Errors found in cluster log files:\n{err_joined}") from None
+    return err_joined


### PR DESCRIPTION
Hide excessive traceback; raise more descriptive exception.