### PR TITLE
update error message when use script v2 + shelley tx

### DIFF
--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -2882,7 +2882,10 @@ class TestCompatibility:
                 use_build_cmd=use_build_cmd,
             )
         err_str = str(excinfo.value)
-        assert "SimpleScriptV2 is not supported" in err_str, err_str
+        assert (
+            "SimpleScriptV2 is not supported" in err_str
+            or "Transaction validity lower bound not supported in Shelley" in err_str
+        ), err_str
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(


### PR DESCRIPTION
The error message will change again after the merge of cardano-node PR 3478/4956:
`The script language SimpleScriptLanguage SimpleScriptV2 is not supported in the Shelley era.`