### PR TITLE
Allow use of any instance number for local dev cluster

### DIFF
--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -12,7 +12,10 @@ def _check_cardano_node_socket_path() -> None:
 
     socket_path = Path(socket_env).expanduser().resolve()
     parts = socket_path.parts
-    if parts[-2] != "state-cluster0" or parts[-1] not in ("bft1.socket", "relay1.socket"):
+    if not parts[-2].startswith("state-cluster") or parts[-1] not in (
+        "bft1.socket",
+        "relay1.socket",
+    ):
         raise RuntimeError(
             "The `CARDANO_NODE_SOCKET_PATH` value is not valid for use by testing framework."
         )


### PR DESCRIPTION
The dev cluster no longer needs to be the "cluster0". This enables running multiple instances of local dev cluster at the same time.