### PR TITLE
Fix: expect KES expiration date in UTC tz

### DIFF
--- a/cardano_node_tests/tests/kes.py
+++ b/cardano_node_tests/tests/kes.py
@@ -59,7 +59,7 @@ def check_kes_period_info_result(  # noqa: C901
         errors.append(f"The kes expiration date is `null` in check '{check_id}'")
     else:
         expected_expiration_date = (
-            datetime.datetime.now()
+            datetime.datetime.now(tz=datetime.timezone.utc)
             + datetime.timedelta(
                 seconds=command_metrics["qKesRemainingSlotsInKesPeriod"] * cluster_obj.slot_length
             )

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -356,7 +356,7 @@ class TestKES:
             if xfails:
                 pytest.xfail(" ".join(xfails))
             else:
-                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}.")
+                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}")
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(6)
@@ -615,7 +615,7 @@ class TestKES:
             if xfails:
                 pytest.xfail("; ".join(xfails))
             else:
-                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}.")
+                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}")
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(7)
@@ -801,7 +801,7 @@ class TestKES:
             if xfails:
                 pytest.xfail(" ".join(xfails))
             else:
-                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}.")
+                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}")
 
     @allure.link(helpers.get_vcs_link())
     def test_no_kes_period_arg(

--- a/cardano_node_tests/tests/test_staking_no_rewards.py
+++ b/cardano_node_tests/tests/test_staking_no_rewards.py
@@ -1006,4 +1006,4 @@ class TestNoRewards:
             if xfails:
                 pytest.xfail(" ".join(xfails))
             else:
-                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}.")
+                raise AssertionError(f"Failed checks on `kes-period-info` command:\n{err_joined}")


### PR DESCRIPTION
KES expiration date is reported in UTC, however the expected expiration date is not calculated in UTC. Depending on time of the day when the test is ran and system timezone, the test can fail with errors like:

```
E               AssertionError: Failed checks on `kes-period-info` command:
E               The kes expiration date in check '1': 2023-05-27 vs 2023-05-28
E               The kes expiration date in check '2': 2023-05-27 vs 2023-05-28
E               The kes expiration date in check '3': 2023-05-27 vs 2023-05-28
E               The kes expiration date in check '4': 2023-05-27 vs 2023-05-28.
```