### PR TITLE
Add ability to override node and cli binaries

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -81,6 +81,7 @@ nix develop --accept-flake-config $(node_override) --command bash -c '
   printf "finish: %(%H:%M:%S)T\n" -1
   echo "::endgroup::"  # end group for "Nix env setup"
   echo "::group::Pytest run"
+  if [ -e ".bin" ]; then export PATH="${PWD}/.bin:${PATH}"; fi
   export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
   make "${MAKE_TARGET:-"tests"}"
   retval="$?"

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -65,6 +65,10 @@ def pytest_addoption(parser: Any) -> None:
 
 
 def pytest_configure(config: Any) -> None:
+    # don't bother collecting metadata if all tests are skipped
+    if config.getvalue("skipall"):
+        return
+
     config._metadata["cardano-node"] = str(VERSIONS.node)
     config._metadata["cardano-node rev"] = VERSIONS.git_rev
     config._metadata["CLUSTER_ERA"] = configuration.CLUSTER_ERA
@@ -107,7 +111,9 @@ def pytest_configure(config: Any) -> None:
         config._metadata["db-sync exe"] = str(configuration.DBSYNC_BIN)
 
     if "nix/store" not in config._metadata["cardano-cli exe"]:
-        LOGGER.warning("WARNING: Not using `cardano-cli` from nix!")
+        LOGGER.warning("WARNING: Not using `cardano-cli` from nix store!")
+    if "nix/store" not in config._metadata["cardano-node exe"]:
+        LOGGER.warning("WARNING: Not using `cardano-node` from nix store!")
 
 
 def _skip_all_tests(config: Any, items: list) -> bool:


### PR DESCRIPTION
When running tests using the `regression.sh` script, binaries can be overridden by placing them into a `.bin` directory in the root of the repo.