### PR TITLE
Make sure `noqa` is always applied on single argument

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -34,7 +34,9 @@ if configuration.IS_XDIST:
     _xdist_sleep = time.sleep
 else:
 
-    def _xdist_sleep(secs: float) -> None:  # noqa: ARG001
+    def _xdist_sleep(
+        secs: float,  # noqa: ARG001
+    ) -> None:
         """No need to sleep if tests are running on a single worker."""
         # pylint: disable=unused-argument,unnecessary-pass
         pass

--- a/cardano_node_tests/cluster_management/resources_management.py
+++ b/cardano_node_tests/cluster_management/resources_management.py
@@ -24,7 +24,11 @@ class BaseFilter:
 class OneOf(BaseFilter):
     """Filter that returns one usable resource out of list of resources."""
 
-    def filter(self, unavailable: Iterable[str], **kwargs: Any) -> List[str]:  # noqa: ARG002
+    def filter(
+        self,
+        unavailable: Iterable[str],
+        **kwargs: Any,  # noqa: ARG002
+    ) -> List[str]:
         assert not isinstance(unavailable, str), "`unavailable` can't be single string"
 
         usable = [r for r in self.resources if r not in unavailable]

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -276,7 +276,9 @@ def testenv_setup_teardown(
 
 @pytest.fixture(scope="session", autouse=True)
 def session_autouse(
-    change_dir: Any, close_dbconn: Any, testenv_setup_teardown: Any  # noqa: ARG001
+    change_dir: Any,  # noqa: ARG001
+    close_dbconn: Any,  # noqa: ARG001
+    testenv_setup_teardown: Any,  # noqa: ARG001
 ) -> None:
     """Autouse session fixtures that are required for session setup and teardown."""
     # pylint: disable=unused-argument,unnecessary-pass
@@ -312,7 +314,9 @@ def cd_testfile_temp_dir(testfile_temp_dir: Path) -> Generator[Path, None, None]
 
 
 @pytest.fixture(autouse=True)
-def function_autouse(cd_testfile_temp_dir: Generator[Path, None, None]) -> None:  # noqa: ARG001
+def function_autouse(
+    cd_testfile_temp_dir: Generator[Path, None, None],  # noqa: ARG001
+) -> None:
     """Autouse function fixtures that are required for each test setup and teardown."""
     # pylint: disable=unused-argument,unnecessary-pass
     pass

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -1186,7 +1186,9 @@ class TestPing:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
     def test_ping_localhost(
-        self, cluster: clusterlib.ClusterLib, ping_available: None  # noqa: ARG002
+        self,
+        cluster: clusterlib.ClusterLib,
+        ping_available: None,  # noqa: ARG002
     ):
         """Test `cardano-cli ping` on local node using host and port."""
         # pylint: disable=unused-argument

--- a/cardano_node_tests/tests/test_xdist_helper.py
+++ b/cardano_node_tests/tests/test_xdist_helper.py
@@ -18,6 +18,8 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.order(1)
 @pytest.mark.parametrize("for_worker", tuple(range(PYTEST_XDIST_WORKER_COUNT)))
-def test_dummy(for_worker: int) -> None:  # noqa: ARG001
+def test_dummy(
+    for_worker: int,  # noqa: ARG001
+) -> None:
     # pylint: disable=unused-argument
     pytest.skip("Dummy helper for `pytest-xdist` scheduling")

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -299,7 +299,9 @@ class TestnetCluster(ClusterType):
         return cluster_obj
 
     def create_addrs_data(
-        self, cluster_obj: clusterlib.ClusterLib, destination_dir: FileType = "."  # noqa: ARG002
+        self,
+        cluster_obj: clusterlib.ClusterLib,  # noqa: ARG002
+        destination_dir: FileType = ".",  # noqa: ARG002
     ) -> Dict[str, Dict[str, Any]]:
         """Create addresses and their keys for usage in tests."""
         shelley_dir = get_cluster_env().state_dir / "shelley"


### PR DESCRIPTION
and doesn't mask other unrelated arguments.