### PR TITLE
Update nix build command for db-sync 13.1.1.0

### DIFF
--- a/.github/source_dbsync.sh
+++ b/.github/source_dbsync.sh
@@ -44,7 +44,7 @@ fi
 git rev-parse HEAD
 
 # build db-sync
-nix-build -A cardano-db-sync -o db-sync-node
+nix build .#cardano-db-sync -o db-sync-node
 export DBSYNC_REPO="$PWD"
 
 pushd "$REPODIR" || exit 1

--- a/doc/running_local_cluster.md
+++ b/doc/running_local_cluster.md
@@ -46,8 +46,8 @@ Checkout the `db-sync` version that you want to use. `cardano-node-tests` requir
 
 ```sh
 cd cardano-db-sync
-git checkout tags/11.0.4
-nix-build -A cardano-db-sync -o db-sync-node
+git checkout tags/13.1.1.0
+nix build .#cardano-db-sync -o db-sync-node
 << wait for build to complete - it may take a while >>
 ```
 


### PR DESCRIPTION
`cardano-db-sync` regression tests are failing with:
```
  ++ git rev-parse HEAD
  ++ nix-build -A cardano-db-sync -o db-sync-node
  error: getting status of '/home/runner/work/cardano-node-tests/cardano-node-tests/run_workdir/cardano-db-sync/default.nix': No such file or directory
```
Link: https://github.com/input-output-hk/cardano-node-tests/actions/runs/5012973825/jobs/8985531621

Update `nix` build command structure to build new version of `cardano-db-sync` 
from:
`nix-build -A cardano-db-sync -o db-sync-node`
to:
`nix build .#cardano-db-sync -o db-sync-node`