### PR TITLE
Update requests to 2.31.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1360,21 +1360,21 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.28.2"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
-    {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -1818,4 +1818,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fe8f84987f2b86dc1fc9c81b084cd0c8d2cd956df1a3f5b1cd682aee3a282929"
+content-hash = "29fb8d68a6ee7b9630198967cb88a421c2626b859026b10414633649aab40f55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ pytest-order = "^1.1.0"
 pytest-select = "^0.1.2"
 pytest-xdist = "~3.1.0"
 PyYAML = "^6.0"
-requests = "^2.28.2"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
There is a vulnerability in the requests version we use. See https://github.com/input-output-hk/cardano-node-tests/security/dependabot/2