### PR TITLE
Fix race conditions in tests that use `add_ignore_rule`

### DIFF
--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -248,9 +248,8 @@ class TestNegativeNetworkIdEnv:
     """Negative tests for `CARDANO_NODE_NETWORK_ID`."""
 
     @pytest.fixture
-    def ignore_log_errors(self) -> Generator[None, None, None]:
+    def ignore_log_errors(self) -> None:
         """Ignore expected handshake errors in the log files."""
-        yield
         logfiles.add_ignore_rule(
             files_glob="*.stdout",
             regex="HandshakeError.*Refused NodeToClient",

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -688,21 +688,6 @@ class TestNegative:
             tx_name=temp_template,
         )
 
-        # It should NOT be possible to submit a transaction with incorrect network magic
-        with pytest.raises(clusterlib.CLIError) as excinfo:
-            cluster.cli(
-                [
-                    "transaction",
-                    "submit",
-                    "--testnet-magic",
-                    str(cluster.network_magic + 100),
-                    "--tx-file",
-                    str(out_file_signed),
-                    f"--{cluster.protocol}-mode",
-                ]
-            )
-        assert "HandshakeError" in str(excinfo.value)
-
         logfiles.add_ignore_rule(
             files_glob="*.stdout",
             regex="HandshakeError",
@@ -717,6 +702,21 @@ class TestNegative:
             # Ignore errors for next 20 seconds
             skip_after=time.time() + 20,
         )
+
+        # It should NOT be possible to submit a transaction with incorrect network magic
+        with pytest.raises(clusterlib.CLIError) as excinfo:
+            cluster.cli(
+                [
+                    "transaction",
+                    "submit",
+                    "--testnet-magic",
+                    str(cluster.network_magic + 100),
+                    "--tx-file",
+                    str(out_file_signed),
+                    f"--{cluster.protocol}-mode",
+                ]
+            )
+        assert "HandshakeError" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
     def test_wrong_signing_key(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -666,6 +666,15 @@ class TestLocking:
             plutus_op=plutus_op,
             amount=amount,
         )
+
+        logfiles.add_ignore_rule(
+            files_glob="*.stdout",
+            regex="ValidationTagMismatch",
+            ignore_file_id="plutus_always_fails",
+            # Ignore errors for next 20 seconds
+            skip_after=time.time() + 20,
+        )
+
         err, __ = spend_raw._spend_locked_txin(
             temp_template=temp_template,
             cluster_obj=cluster,
@@ -677,14 +686,6 @@ class TestLocking:
             expect_failure=True,
         )
         assert "PlutusFailure" in err, err
-
-        logfiles.add_ignore_rule(
-            files_glob="*.stdout",
-            regex="ValidationTagMismatch",
-            ignore_file_id="plutus_always_fails",
-            # Ignore errors for next 20 seconds
-            skip_after=time.time() + 20,
-        )
 
     @allure.link(helpers.get_vcs_link())
     def test_script_invalid(


### PR DESCRIPTION
When ignore rule is added after a command that produces the error has already run, another test can finish right after the error message is added to log file and before the ignore rule is created, and report the error. Fix this race condition - the ignore rule has to be added before the error-producing command runs.