### PR TITLE
Rename `GH_TOKEN` to more standard `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           cat .github_ci_env
           cat .github_ci_env >> $GITHUB_ENV
-          echo "GH_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
       - name: Get previous test results
         if: inputs.testrun_name && inputs.skip_passed
         run: |

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cat .github_ci_env
           cat .github_ci_env >> $GITHUB_ENV
-          echo "GH_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
       - name: Run CLI regression tests
         id: testing-step
         run: ./.github/node_upgrade.sh

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -13,8 +13,8 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 
-if os.environ.get("GH_TOKEN"):
-    gh_issue.GHIssue.TOKEN = os.environ.get("GH_TOKEN")
+if os.environ.get("GITHUB_TOKEN"):
+    gh_issue.GHIssue.TOKEN = os.environ.get("GITHUB_TOKEN")
 
 
 class GH:

--- a/deploy_doc.sh
+++ b/deploy_doc.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DOC_SRC="src_docs"
 
-unset GH_TOKEN GITHUB_TOKEN
+unset GITHUB_TOKEN
 
 # check that "$DOC_SRC" dir exists
 if [ ! -d "$DOC_SRC" ]; then

--- a/src_docs/source/conf.py
+++ b/src_docs/source/conf.py
@@ -118,7 +118,7 @@ html_css_files = [
 ]
 
 # Clear tokens from the output
-os.environ["GITHUB_TOKEN"] = os.environ["GH_TOKEN"] = "token_XXXXXXXXXXXXXXXXXXXX"
+os.environ["GITHUB_TOKEN"] = "token_XXXXXXXXXXXXXXXXXXXX"
 
 # Resolve function for the linkcode extension.
 


### PR DESCRIPTION
We still need to use `GH_TOKEN` secret inside reusable workflows due to `GITHUB_TOKEN` being reserved name.