### PR TITLE
Update GH Actions Buildkite Plugin

### DIFF
--- a/.github/workflows/db_sync_full_sync.yaml
+++ b/.github/workflows/db_sync_full_sync.yaml
@@ -47,19 +47,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: trigger the Buildkite pipeline - run db-sync full sync test
+        uses: 'buildkite/trigger-pipeline-action@v1.5.0'
         env:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+          PIPELINE: 'input-output-hk/qa-db-sync-full-sync'
+          BRANCH: 'db_sync_tests'
+          MESSAGE: ':github: Triggered by GitHub Action'
           AWS_DB_USERNAME: ${{ secrets.AWS_DB_USERNAME }}
           AWS_DB_PASS: ${{ secrets.AWS_DB_PASS }}
           AWS_DB_NAME: ${{ secrets.AWS_DB_NAME }}
           AWS_DB_HOSTNAME: ${{ secrets.AWS_DB_HOSTNAME }}
-        uses: zegocover/buildkite-pipeline-action@master
-        with:
-          branch: db_sync_tests
-          access_token: '${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}'
-          pipeline: 'input-output-hk/qa-db-sync-full-sync'
-          message: ':github: Triggered by GitHub Action'
-          env: '{
+          BUILD_ENV_VARS: '{
           "node_pr":"${{ github.event.inputs.node_pr }}",
           "node_branch":"${{ github.event.inputs.node_branch }}",
           "node_version":"${{ github.event.inputs.node_version }}",

--- a/.github/workflows/db_sync_snapshot_restoration.yaml
+++ b/.github/workflows/db_sync_snapshot_restoration.yaml
@@ -39,19 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: trigger the Buildkite pipeline - run db sync snapshot restoration
+        uses: 'buildkite/trigger-pipeline-action@v1.5.0'
         env:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+          PIPELINE: 'input-output-hk/qa-db-sync-snapshot-restoration'
+          BRANCH: 'db_sync_tests'
+          MESSAGE: ':github: Triggered by GitHub Action'
           AWS_DB_USERNAME: ${{ secrets.AWS_DB_USERNAME }}
           AWS_DB_PASS: ${{ secrets.AWS_DB_PASS }}
           AWS_DB_NAME: ${{ secrets.AWS_DB_NAME }}
           AWS_DB_HOSTNAME: ${{ secrets.AWS_DB_HOSTNAME }}
-        uses: zegocover/buildkite-pipeline-action@master
-        with:
-          branch: db_sync_tests
-          access_token: '${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}'
-          pipeline: 'input-output-hk/qa-db-sync-snapshot-restoration'
-          message: ':github: Triggered by GitHub Action'
-          env: '{
+          BUILD_ENV_VARS: '{
           "node_pr":"${{ github.event.inputs.node_pr }}",
           "node_branch":"${{ github.event.inputs.node_branch }}",
           "node_version":"${{ github.event.inputs.node_version }}",

--- a/.github/workflows/node_sync_test.yaml
+++ b/.github/workflows/node_sync_test.yaml
@@ -5,69 +5,156 @@ on:
     branches:
       - sync_tests
     inputs:
-      tag_no1:
-        description: tag number1 - used for initial sync, from clean state
+      build_mode:
+        description: how to get the cardano node/cli files - nix(, cabal, prebuilt)
         required: true
+        default: "nix"
+      tag_no1:
+        description: rev_label in db/visuals (1.33.0-rc2 (tag number) or 1.33.0 (release number) or 1.33.0_PR2124 (for not released and not tagged runs with a specific node PR/version))
+        required: true
+        default: "None"
+      node_rev1:
+        description: desired cardano-node revision (used for initial sync) - cardano-node (tags/1.33.0-rc2) tag or branch
+        required: true
+        default: "None"
+      node_topology1:
+        description: desired cardano-node topology type (used for initial sync) - legacy, p2p
+        required: true
+        default: "legacy"
+      node_start_arguments1:
+        description: extra arguments to be used when starting the node using tag_no1 (--a1 --a2 21)
+        required: false
+        default: "None"
       tag_no2:
-        description: tag number2 - used for final sync, from existing state
+        description: rev_label in db/visuals (1.33.0-rc2 (tag number) or 1.33.0 (release number) or 1.33.0_PR2124 (for not released and not tagged runs with a specific node PR/version))
+        required: true
+        default: "None"
+      node_rev2:
+        description: desired cardano-node revision (used for final sync) - cardano-node (tags/1.33.0-rc2) tag or branch
+        required: true
+        default: "None"
+      node_topology2:
+        description: desired cardano-node topology type (used for final sync) - legacy, p2p
+        required: true
+        default: "legacy"
+      node_start_arguments2:
+        description: extra arguments to be used when starting the node using tag_no2 (--a1 --a2 21)
         required: false
         default: "None"
-      hydra_eval_no1:
-        description: hydra_eval_no1 - used for getting node prebuilt files for the initial sync
-        required: false
-        default: "None"
-      hydra_eval_no2:
-        description: hydra_eval_no2 - used for getting node prebuilt files for the final sync
-        required: false
-        default: "None"
-
 jobs:
   node_sync_test_mainnet:
     runs-on: ubuntu-latest
     steps:
       - name: trigger the Buildkite pipeline - run sync tests on Mainnet
+        uses: 'buildkite/trigger-pipeline-action@v1.5.0'
         env:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+          PIPELINE: 'input-output-hk/qa-sync-tests'
+          BRANCH: 'sync_tests'
+          MESSAGE: ':github: Triggered by GitHub Action'
           AWS_DB_USERNAME: ${{ secrets.AWS_DB_USERNAME }}
           AWS_DB_PASS: ${{ secrets.AWS_DB_PASS }}
           AWS_DB_NAME: ${{ secrets.AWS_DB_NAME }}
           AWS_DB_HOSTNAME: ${{ secrets.AWS_DB_HOSTNAME }}
           BLOCKFROST_API_KEY: ${{ secrets.BLOCKFROST_API_KEY }}
-        uses: zegocover/buildkite-pipeline-action@master
-        with:
-          access_token: '${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}'
-          pipeline: 'input-output-hk/qa-sync-tests'
-          message: ':github: Triggered by GitHub Action'
-          env: '{
+          BUILD_ENV_VARS: '{
+          "env":"mainnet",
+          "build_mode":"${{ github.event.inputs.build_mode }}",
+          "node_rev1":"${{ github.event.inputs.node_rev1 }}",
+          "node_rev2":"${{ github.event.inputs.node_rev2 }}",
           "tag_no1":"${{ github.event.inputs.tag_no1 }}",
           "tag_no2":"${{ github.event.inputs.tag_no2 }}",
-          "hydra_eval_no1":"${{ github.event.inputs.hydra_eval_no1 }}",
-          "hydra_eval_no2":"${{ github.event.inputs.hydra_eval_no2 }}",
+          "node_topology1":"${{ github.event.inputs.node_topology1 }}",
+          "node_topology2":"${{ github.event.inputs.node_topology2 }}",
+          "node_start_arguments1":"${{ github.event.inputs.node_start_arguments1 }}",
+          "node_start_arguments2":"${{ github.event.inputs.node_start_arguments2 }}",
           "BLOCKFROST_API_KEY":"${{ secrets.BLOCKFROST_API_KEY }}",
           "AWS_DB_USERNAME":"${{ secrets.AWS_DB_USERNAME }}",
           "AWS_DB_PASS":"${{ secrets.AWS_DB_PASS }}",
           "AWS_DB_NAME":"${{ secrets.AWS_DB_NAME }}",
           "AWS_DB_HOSTNAME":"${{ secrets.AWS_DB_HOSTNAME }}"
           }'
-          branch: 'sync_tests'
   node_sync_test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        env: [shelley_qa, testnet, staging]
+        env: [preview, preprod]
+        cabal: ["3.8.1.0"]
+        ghc: ["8.10.7"]
+        branch:
+          - sync_tests
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 600
+
+    env:
+      # Modify this value to "invalidate" the cabal cache.
+      CABAL_CACHE_VERSION: "2023-04-30"
+
+      # Modify this value to "invalidate" the secp cache.
+      SECP_CACHE_VERSION: "2022-12-30"
+
+      # current ref from: 27.02.2022
+      SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+
     steps:
+
+      - name: Install Haskell
+        if: matrix.os == 'windows-latest'
+        uses: input-output-hk/setup-haskell@v1
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+          pacman-packages: >
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-libsodium
+            mingw-w64-x86_64-openssl
+            base-devel
+            autoconf-wrapper
+            autoconf
+            automake
+            libtool
+            make
+
+      - name: Update Windows path with executables locations
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: $env:PATH+="D:\a\cardano-node-tests\cardano-node-tests\cardano_node_tests"
+
+
+      - name: Install secp256k1
+        if: matrix.os == 'windows-latest'
+        uses: input-output-hk/setup-secp256k1@v1
+        with:
+          git-ref: ${{ env.SECP256K1_REF }}
+          cache-version: ${{ env.SECP_CACHE_VERSION }}
+
+      - uses: actions/checkout@v2
+      - name: "[PowerShell] Add build script path"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-Content $env:GITHUB_PATH "$(pwd)/.github/bin"
+
       - name: checkout cardano-node-tests repo
         uses: actions/checkout@v2
         with:
           path: cardano_node_tests
           ref: sync_tests
+
+      - uses: cachix/install-nix-action@v20
+        if: matrix.os != 'windows-latest'
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo=
+            substituters = https://cache.nixos.org https://cache.iog.io https://iohk.cachix.org
+            allow-import-from-derivation = true
+
       - name: run actions/setup-python@v2
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
       - name: install dependencies
         run: |
           pip install pymysql
@@ -75,13 +162,17 @@ jobs:
           pip install psutil
           pip install pandas
           pip install blockfrost-python
+          pip install GitPython
+
       - name: run sync test
         env:
           BLOCKFROST_API_KEY: ${{ secrets.BLOCKFROST_API_KEY }}
         run: |
+          ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
           cd cardano_node_tests
           echo "current branch2: $(git branch --show-current)"
-          python sync_tests/node_sync_test.py -t1 "${{ github.event.inputs.tag_no1 }}" -t2 "${{ github.event.inputs.tag_no2 }}" -e1 "${{ github.event.inputs.hydra_eval_no1 }}" -e2 "${{ github.event.inputs.hydra_eval_no2 }}" -e ${{ matrix.env }}
+          python sync_tests/node_sync_test.py -e ${{ matrix.env }} -b ${{ github.event.inputs.build_mode }} -t1 "${{ github.event.inputs.tag_no1 }}" -t2 "${{ github.event.inputs.tag_no2 }}" -r1 "${{ github.event.inputs.node_rev1 }}" -r2 "${{ github.event.inputs.node_rev2 }}" -n1 "${{ github.event.inputs.node_topology1 }}" -n2 "${{ github.event.inputs.node_topology2 }}" -a1="${{ github.event.inputs.node_start_arguments1 }}" -a2="${{ github.event.inputs.node_start_arguments2 }}"
+
       - name: write the test results into the database
         env:
           AWS_DB_USERNAME: ${{ secrets.AWS_DB_USERNAME }}
@@ -93,6 +184,7 @@ jobs:
           cd cardano_node_tests
           echo "current branch3: $(git branch --show-current)"
           python sync_tests/node_write_sync_values_to_db.py -e ${{ matrix.env }}
+
       - name: generate artifacts
         uses: actions/upload-artifact@v2
         if: always()
@@ -101,3 +193,5 @@ jobs:
           path: |
             cardano_node_tests/logfile.log
             cardano_node_tests/sync_results.json
+            cardano_node_tests/${{ matrix.env }}-config.json
+            cardano_node_tests/${{ matrix.env }}-topology.json


### PR DESCRIPTION
The current [GH Actions plugin](https://github.com/Zegocover/buildkite-pipeline-action) for triggering Builkite jobs uses deprecated commands https://github.com/Zegocover/buildkite-pipeline-action/blob/master/main.py#L122-L127 that:
> Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error.

Instead of fixing it in original repository or creating a fork with fix this Pull Request switches to new and official plugin which in effect will resolve all issues.

Article here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

