### PR TITLE
Enable `create-script-context` in CI

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -23,11 +23,35 @@ mkdir -p "$WORKDIR"
 export TMPDIR="$WORKDIR/tmp"
 mkdir -p "$TMPDIR"
 
-if [ "${CI_ENABLE_DBSYNC:-"false"}" != "false" ]; then
-  # setup dbsync
-  # shellcheck disable=SC1090,SC1091
-  . .github/source_dbsync.sh
-fi
+# setup dbsync (disabled by default)
+case "${CI_ENABLE_DBSYNC:-"false"}" in
+  "true" | 1)
+    # shellcheck disable=SC1090,SC1091
+    . .github/source_dbsync.sh
+    ;;
+  "false" | 0)
+    ;;
+  *)
+    echo "Unknown value for CI_ENABLE_DBSYNC: ${CI_ENABLE_DBSYNC}" >&2
+    exit 1
+    ;;
+esac
+
+# setup plutus-apps (enabled by default)
+# The "plutus-apps" repo is needed for the `create-script-context` tool, which is used by the
+# Plutus tests that are testing script context.
+case "${CI_ENABLE_PLUTUS_APPS:-"true"}" in
+  "true" | 1)
+    # shellcheck disable=SC1090,SC1091
+    . .github/source_plutus_apps.sh
+    ;;
+  "false" | 0)
+    ;;
+  *)
+    echo "Unknown value for CI_ENABLE_PLUTUS: ${CI_ENABLE_PLUTUS}" >&2
+    exit 1
+    ;;
+esac
 
 if [ "${CI_TOPOLOGY:-""}" = "p2p" ]; then
   export ENABLE_P2P="true"

--- a/.github/source_dbsync.sh
+++ b/.github/source_dbsync.sh
@@ -44,7 +44,7 @@ fi
 git rev-parse HEAD
 
 # build db-sync
-nix build .#cardano-db-sync -o db-sync-node
+nix build --accept-flake-config .#cardano-db-sync -o db-sync-node
 export DBSYNC_REPO="$PWD"
 
 pushd "$REPODIR" || exit 1

--- a/.github/source_plutus_apps.sh
+++ b/.github/source_plutus_apps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "::group::plutus-apps setup"
+
+pushd "$WORKDIR" || exit 1
+
+# Clone plutus-apps if needed
+if [ ! -e plutus-apps ]; then
+  git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/input-output-hk/plutus-apps.git
+fi
+
+pushd plutus-apps || exit 1
+git pull origin main
+git rev-parse HEAD
+
+# Build `create-script-context`
+nix build --accept-flake-config .#create-script-context -o create-script-context
+
+# Add `create-script-context` to PATH
+PATH="$(readlink -m create-script-context/bin)":"$PATH"
+export PATH
+
+pushd "$REPODIR" || exit 1
+
+echo "::endgroup::"

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -702,28 +702,15 @@ class TestBuildMinting:
         )
         assert tx_output_dummy
 
-        tx_file_dummy = cluster.g_transaction.sign_tx(
-            tx_body_file=tx_output_dummy.out_file,
-            signing_key_files=tx_files_step2.signing_key_files,
-            tx_name=f"{temp_template}_dummy",
-        )
-
         # generate the "real" redeemer
         redeemer_file = Path(f"{temp_template}_script_context.redeemer")
 
-        try:
-            clusterlib_utils.create_script_context(
-                cluster_obj=cluster,
-                plutus_version=1,
-                redeemer_file=redeemer_file,
-                tx_file=tx_file_dummy,
-            )
-        except AssertionError as err:
-            if "DeserialiseFailure" not in str(err):
-                raise
-            blockers.GH(
-                issue=583, repo="input-output-hk/plutus-apps", message="DeserialiseFailure"
-            ).finish_test()
+        plutus_common.create_script_context_w_blockers(
+            cluster_obj=cluster,
+            plutus_version=1,
+            redeemer_file=redeemer_file,
+            tx_file=tx_output_dummy.out_file,
+        )
 
         plutus_mint_data = [plutus_mint_data_dummy[0]._replace(redeemer_file=redeemer_file)]
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -14,7 +14,6 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import plutus_common
 from cardano_node_tests.tests.tests_plutus import mint_raw
-from cardano_node_tests.utils import blockers
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -1095,28 +1094,15 @@ class TestMinting:
         )
         assert tx_output_dummy
 
-        tx_file_dummy = cluster.g_transaction.sign_tx(
-            tx_body_file=tx_output_dummy.out_file,
-            signing_key_files=tx_files_step2.signing_key_files,
-            tx_name=f"{temp_template}_dummy",
-        )
-
         # generate the "real" redeemer
         redeemer_file = Path(f"{temp_template}_script_context.redeemer")
 
-        try:
-            clusterlib_utils.create_script_context(
-                cluster_obj=cluster,
-                plutus_version=1,
-                redeemer_file=redeemer_file,
-                tx_file=tx_file_dummy,
-            )
-        except AssertionError as err:
-            if "DeserialiseFailure" not in str(err):
-                raise
-            blockers.GH(
-                issue=583, repo="input-output-hk/plutus-apps", message="DeserialiseFailure"
-            ).finish_test()
+        plutus_common.create_script_context_w_blockers(
+            cluster_obj=cluster,
+            plutus_version=1,
+            redeemer_file=redeemer_file,
+            tx_file=tx_output_dummy.out_file,
+        )
 
         plutus_mint_data = [plutus_mint_data_dummy[0]._replace(redeemer_file=redeemer_file)]
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -15,7 +15,6 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import plutus_common
 from cardano_node_tests.tests.tests_plutus import spend_build
-from cardano_node_tests.utils import blockers
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -226,21 +225,13 @@ class TestBuildLocking:
 
         # generate the "real" redeemer
         redeemer_file = Path(f"{temp_template}_script_context.redeemer")
-        tx_file_dummy = Path(f"{tx_output_dummy.out_file.with_suffix('')}.signed")
 
-        try:
-            clusterlib_utils.create_script_context(
-                cluster_obj=cluster,
-                plutus_version=1,
-                redeemer_file=redeemer_file,
-                tx_file=tx_file_dummy,
-            )
-        except AssertionError as err:
-            if "DeserialiseFailure" not in str(err):
-                raise
-            blockers.GH(
-                issue=583, repo="input-output-hk/plutus-apps", message="DeserialiseFailure"
-            ).finish_test()
+        plutus_common.create_script_context_w_blockers(
+            cluster_obj=cluster,
+            plutus_version=1,
+            redeemer_file=redeemer_file,
+            tx_file=tx_output_dummy.out_file,
+        )
 
         plutus_op = plutus_op_dummy._replace(redeemer_file=redeemer_file)
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -17,7 +17,6 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import plutus_common
 from cardano_node_tests.tests.tests_plutus import spend_raw
-from cardano_node_tests.utils import blockers
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -263,21 +262,13 @@ class TestLocking:
 
         # generate the "real" redeemer
         redeemer_file = Path(f"{temp_template}_script_context.redeemer")
-        tx_file_dummy = Path(f"{tx_output_dummy.out_file.with_suffix('')}.signed")
 
-        try:
-            clusterlib_utils.create_script_context(
-                cluster_obj=cluster,
-                plutus_version=1,
-                redeemer_file=redeemer_file,
-                tx_file=tx_file_dummy,
-            )
-        except AssertionError as err:
-            if "DeserialiseFailure" not in str(err):
-                raise
-            blockers.GH(
-                issue=583, repo="input-output-hk/plutus-apps", message="DeserialiseFailure"
-            ).finish_test()
+        plutus_common.create_script_context_w_blockers(
+            cluster_obj=cluster,
+            plutus_version=1,
+            redeemer_file=redeemer_file,
+            tx_file=tx_output_dummy.out_file,
+        )
 
         plutus_op = plutus_op_dummy._replace(redeemer_file=redeemer_file)
 

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -1048,29 +1048,26 @@ def create_script_context(
     tx_file: Optional[Path] = None,
 ) -> None:
     """Run the `create-script-context` command (available in plutus-apps)."""
-    version_args = []
-    # TODO: remove once `--plutus-*` args are in main branch
-    if helpers.tool_has("create-script-context --plutus-v1"):
-        if plutus_version == 1:
-            version_args = ["--plutus-v1"]
-        elif plutus_version == 2:
-            version_args = ["--plutus-v2"]
-        else:
-            raise AssertionError(f"Unknown plutus version: {plutus_version}")
+    if plutus_version == 1:
+        version_arg = "--plutus-v1"
+    elif plutus_version == 2:
+        version_arg = "--plutus-v2"
+    else:
+        raise AssertionError(f"Unknown plutus version: {plutus_version}")
 
     if tx_file:
         cmd_args = [
             "create-script-context",
             "--generate-tx",
             str(tx_file),
-            *version_args,
+            version_arg,
             f"--{cluster_obj.protocol}-mode",
             *cluster_obj.magic_args,
             "--out-file",
             str(redeemer_file),
         ]
     else:
-        cmd_args = ["create-script-context", *version_args, "--out-file", str(redeemer_file)]
+        cmd_args = ["create-script-context", version_arg, "--out-file", str(redeemer_file)]
 
     helpers.run_command(cmd_args)
     assert redeemer_file.exists()


### PR DESCRIPTION
Make `create-script-context` tool availoable when running on CI and run tests that depend on the tool by default (can be disabled by exporting `CI_ENABLE_PLUTUS_APPS=false`).