### PR TITLE
Update GH Actions for tracking mainnet TX per epoch

### DIFF
--- a/.github/workflows/node_mainnet_tx_count_per_epoch.yaml
+++ b/.github/workflows/node_mainnet_tx_count_per_epoch.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout cardano-node-tests repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: cardano_node_tests
           ref: sync_tests
-      - name: run actions/setup-python@v2
-        uses: actions/setup-python@v2
+      - name: setup Python
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - name: install dependencies


### PR DESCRIPTION
Update GH Actions to new version:
>Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This is automatic (scheduled) workflow so I think it needs to be updated on `master`:

```
on:
  schedule:
    - cron: '0 8 * * *'
```

