### PR TITLE
Add the `framework.log` log file for framework-related messages

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -26,6 +26,7 @@ from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
+from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils import temptools
 
 LOGGER = logging.getLogger(__name__)
@@ -222,6 +223,9 @@ class ClusterGetter:
             self.log(
                 f"c{self.cluster_instance_num}: failed to start cluster:\n{excp}\ncluster dead"
             )
+            logfiles.framework_logger().error(
+                "Failed to start cluster instance 'c%s':\n%s", self.cluster_instance_num, excp
+            )
             if not configuration.IS_XDIST:
                 pytest.exit(msg=f"Failed to start cluster, exception: {excp}", returncode=1)
             (self.instance_dir / common.CLUSTER_DEAD_FILE).touch()
@@ -248,6 +252,11 @@ class ClusterGetter:
             self.log(
                 f"c{self.cluster_instance_num}: failed to setup test addresses:\n{err}\n"
                 "cluster dead"
+            )
+            logfiles.framework_logger().error(
+                "Failed to setup test addresses on instance 'c%s':\n%s",
+                self.cluster_instance_num,
+                excp,
             )
             if not configuration.IS_XDIST:
                 pytest.exit(msg=f"Failed to setup test addresses, exception: {err}", returncode=1)

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -233,7 +233,11 @@ def testenv_setup_teardown(
     tmp_path_factory: TempPathFactory, worker_id: str, request: FixtureRequest
 ) -> Generator[None, None, None]:
     """Setup and teardown test environment."""
+    # Export env variables with Pytest tmp dirs, so these are available outside of fixtures
     pytest_root_tmp = temptools.get_pytest_root_tmp(tmp_path_factory)
+    os.environ["PYTEST_ROOT_TMP"] = str(pytest_root_tmp)
+    pytest_worker_tmp = temptools.get_pytest_worker_tmp(tmp_path_factory)
+    os.environ["PYTEST_WORKER_TMP"] = str(pytest_worker_tmp)
 
     running_session_glob = ".running_session"
 

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -232,45 +232,50 @@ def _save_env_for_allure(pytest_config: Config) -> None:
 def testenv_setup_teardown(
     tmp_path_factory: TempPathFactory, worker_id: str, request: FixtureRequest
 ) -> Generator[None, None, None]:
+    """Setup and teardown test environment."""
     pytest_root_tmp = temptools.get_pytest_root_tmp(tmp_path_factory)
 
+    running_session_glob = ".running_session"
+
     with locking.FileLockIfXdist(f"{pytest_root_tmp}/{cluster_management.CLUSTER_LOCK}"):
-        # save environment info for Allure
-        if not list(pytest_root_tmp.glob(".started_session_*")):
+        # Save environment info for Allure
+        if not list(pytest_root_tmp.glob(f"{running_session_glob}_*")):
             _save_env_for_allure(request.config)
 
-        (pytest_root_tmp / f".started_session_{worker_id}").touch()
+        (pytest_root_tmp / f"{running_session_glob}_{worker_id}").touch()
 
     yield
 
     with locking.FileLockIfXdist(f"{pytest_root_tmp}/{cluster_management.CLUSTER_LOCK}"):
-        # save CLI coverage to dir specified by `--cli-coverage-dir`
+        # Save CLI coverage to dir specified by `--cli-coverage-dir`
         cluster_manager_obj = cluster_management.ClusterManager(
             tmp_path_factory=tmp_path_factory, worker_id=worker_id, pytest_config=request.config
         )
         cluster_manager_obj.save_worker_cli_coverage()
 
-        # perform cleanup if this is the last running pytest worker
-        (pytest_root_tmp / f".started_session_{worker_id}").unlink()
-        if not list(pytest_root_tmp.glob(".started_session_*")):
-            # perform testnet cleanup
+        # Remove file indicating that testing session on this worker is running
+        (pytest_root_tmp / f"{running_session_glob}_{worker_id}").unlink()
+
+        # Perform cleanup if this is the last running pytest worker
+        if not list(pytest_root_tmp.glob(f"{running_session_glob}_*")):
+            # Perform testnet cleanup
             _testnet_cleanup(pytest_root_tmp=pytest_root_tmp)
 
             if configuration.DEV_CLUSTER_RUNNING:
-                # save cluster artifacts
+                # Save cluster artifacts
                 artifacts_base_dir = request.config.getoption(artifacts.ARTIFACTS_BASE_DIR_ARG)
                 if artifacts_base_dir:
                     state_dir = cluster_nodes.get_cluster_env().state_dir
                     artifacts.save_cluster_artifacts(save_dir=pytest_root_tmp, state_dir=state_dir)
             else:
-                # stop all cluster instances, save artifacts
+                # Stop all cluster instances, save artifacts
                 _stop_all_cluster_instances(
                     tmp_path_factory=tmp_path_factory,
                     worker_id=worker_id,
                     pytest_config=request.config,
                 )
 
-            # copy collected artifacts to dir specified by `--artifacts-base-dir`
+            # Copy collected artifacts to dir specified by `--artifacts-base-dir`
             artifacts.copy_artifacts(pytest_tmp_dir=pytest_root_tmp, pytest_config=request.config)
 
 

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -34,7 +34,13 @@ TCallable = TypeVar("TCallable", bound=Callable)  # pylint: disable=invalid-name
 
 
 def callonce(func: TCallable) -> TCallable:
-    """Call a function and cache its return value."""
+    """Call a function and cache its return value.
+
+    .. warning::
+       The function arguments are not considered when caching the result.
+       Therefore, this decorator should be used only for functions without arguments
+       or for functions with constant arguments.
+    """
     result: list = []
 
     @functools.wraps(func)


### PR DESCRIPTION
Add new `framework.log` log file for framework-related messages. The new log file exists per pytest worker and is checked during each test teardown, same as node log files. It is currently used for logging failures to start cluster instances.

The rationale behind the new log file is that tests can now report framework issues that would otherwise be silently ignored. Eg. when cluster instance fails to start, like it was the case because of node issue https://github.com/input-output-hk/cardano-node/issues/5294, the failure would not be reported and tests would continue running on working cluster instances.