### PR TITLE
Initialize pytest temp dirs once

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -15,7 +15,6 @@ from typing import Optional
 
 import pytest
 from _pytest.config import Config
-from _pytest.tmpdir import TempPathFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import common
@@ -92,7 +91,6 @@ class ClusterGetter:
 
     def __init__(
         self,
-        tmp_path_factory: TempPathFactory,
         worker_id: str,
         pytest_config: Config,
         num_of_instances: int,
@@ -100,11 +98,10 @@ class ClusterGetter:
     ) -> None:
         self.pytest_config = pytest_config
         self.worker_id = worker_id
-        self.tmp_path_factory = tmp_path_factory
         self.num_of_instances = num_of_instances
         self.log = log_func
 
-        self.pytest_tmp_dir = temptools.get_pytest_root_tmp(self.tmp_path_factory)
+        self.pytest_tmp_dir = temptools.get_pytest_root_tmp()
         self.cluster_lock = f"{self.pytest_tmp_dir}/{common.CLUSTER_LOCK}"
 
         self._cluster_instance_num = -1
@@ -240,10 +237,9 @@ class ClusterGetter:
             fp_out.write(cluster_instance_id)
         self.log(f"c{self.cluster_instance_num}: started cluster instance '{cluster_instance_id}'")
 
-        # Create temp dir for faucet addresses data.
-        # Pytest's mktemp adds number to the end of the dir name, so keep the trailing '_'
-        # as separator. Resulting dir name is e.g. 'addrs_data_ci3_0'.
-        tmp_path = Path(self.tmp_path_factory.mktemp(f"addrs_data_ci{self.cluster_instance_num}_"))
+        # Create temp dir for faucet addresses data
+        tmp_path = temptools.get_pytest_worker_tmp() / f"addrs_data_ci{self.cluster_instance_num}"
+        tmp_path.mkdir(parents=True, exist_ok=True)
 
         # setup faucet addresses
         try:

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -15,7 +15,6 @@ from typing import List
 from typing import Optional
 
 from _pytest.config import Config
-from _pytest.tmpdir import TempPathFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cache
@@ -58,13 +57,10 @@ class FixtureCache:
 class ClusterManager:
     """Set of management methods for cluster instances."""
 
-    def __init__(
-        self, tmp_path_factory: TempPathFactory, worker_id: str, pytest_config: Config
-    ) -> None:
+    def __init__(self, worker_id: str, pytest_config: Config) -> None:
         self.worker_id = worker_id
         self.pytest_config = pytest_config
-        self.tmp_path_factory = tmp_path_factory
-        self.pytest_tmp_dir = temptools.get_pytest_root_tmp(tmp_path_factory)
+        self.pytest_tmp_dir = temptools.get_pytest_root_tmp()
 
         if configuration.IS_XDIST:
             self.range_num = 5
@@ -348,7 +344,6 @@ class ClusterManager:
         """
         # get number of initialized cluster instance once it is possible to start a test
         instance_num = cluster_getter.ClusterGetter(
-            tmp_path_factory=self.tmp_path_factory,
             worker_id=self.worker_id,
             pytest_config=self.pytest_config,
             num_of_instances=self.num_of_instances,

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import allure
 import pytest
-from _pytest.tmpdir import TempPathFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
@@ -21,9 +20,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def epoch_length_start_cluster(tmp_path_factory: TempPathFactory) -> Path:
+def epoch_length_start_cluster() -> Path:
     """Update *epochLength* to 1200."""
-    shared_tmp = temptools.get_pytest_shared_tmp(tmp_path_factory)
+    shared_tmp = temptools.get_pytest_shared_tmp()
 
     # need to lock because this same fixture can run on several workers in parallel
     with locking.FileLockIfXdist(f"{shared_tmp}/startup_files_epoch_1200.lock"):
@@ -50,9 +49,9 @@ def epoch_length_start_cluster(tmp_path_factory: TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="module")
-def slot_length_start_cluster(tmp_path_factory: TempPathFactory) -> Path:
+def slot_length_start_cluster() -> Path:
     """Update *slotLength* to 0.3."""
-    shared_tmp = temptools.get_pytest_shared_tmp(tmp_path_factory)
+    shared_tmp = temptools.get_pytest_shared_tmp()
 
     # need to lock because this same fixture can run on several workers in parallel
     with locking.FileLockIfXdist(f"{shared_tmp}/startup_files_slot_03.lock"):

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -13,7 +13,6 @@ from typing import Tuple
 import allure
 import pytest
 import requests
-from _pytest.tmpdir import TempPathFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
@@ -52,9 +51,9 @@ SKIPIF_HF_SHORTCUT = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="module")
-def short_kes_start_cluster(tmp_path_factory: TempPathFactory) -> Path:
+def short_kes_start_cluster() -> Path:
     """Update *slotsPerKESPeriod* and *maxKESEvolutions*."""
-    shared_tmp = temptools.get_pytest_shared_tmp(tmp_path_factory)
+    shared_tmp = temptools.get_pytest_shared_tmp()
     max_kes_evolutions = 10
 
     # need to lock because this same fixture can run on several workers in parallel

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -19,7 +19,6 @@ import hypothesis
 import hypothesis.strategies as st
 import pytest
 from _pytest.fixtures import FixtureRequest
-from _pytest.tmpdir import TempPathFactory
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
@@ -39,9 +38,9 @@ DEREG_BUFFER_SEC = 30
 
 
 @pytest.fixture(scope="module")
-def pool_cost_start_cluster(tmp_path_factory: TempPathFactory) -> Path:
+def pool_cost_start_cluster() -> Path:
     """Update *minPoolCost* to 500."""
-    shared_tmp = temptools.get_pytest_shared_tmp(tmp_path_factory)
+    shared_tmp = temptools.get_pytest_shared_tmp()
 
     # need to lock because this same fixture can run on several workers in parallel
     with locking.FileLockIfXdist(f"{shared_tmp}/startup_files_pool_500.lock"):

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -76,12 +76,7 @@ class RotableLog(NamedTuple):
 
 @helpers.callonce
 def get_framework_log_path() -> Path:
-    pytest_worker_tmp = os.environ.get("PYTEST_WORKER_TMP")
-    if not pytest_worker_tmp:
-        raise RuntimeError("PYTEST_WORKER_TMP environment variable is not set")
-
-    tempdir = Path(pytest_worker_tmp)
-    return tempdir / "framework.log"
+    return temptools.get_pytest_worker_tmp() / "framework.log"
 
 
 def _look_back_found(buffer: List[str]) -> bool:

--- a/cardano_node_tests/utils/temptools.py
+++ b/cardano_node_tests/utils/temptools.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 from _pytest.tmpdir import TempPathFactory
 
@@ -7,35 +8,59 @@ from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 
 
-@helpers.callonce
-def get_pytest_worker_tmp(tmp_path_factory: TempPathFactory) -> Path:
-    """Return pytest temporary directory for the current worker.
+class PytestTempDirs:
+    """Pytest temporary directories that are used accross the framework.
+
+    The class is initialized in `conftest.py` where we have access to the `tmp_path_factory`
+    fixture.
+    """
+
+    pytest_worker_tmp: Optional[Path] = None
+    pytest_root_tmp: Optional[Path] = None
+    pytest_shared_tmp: Optional[Path] = None
+
+    _err_init_str = "PytestTempDirs are not initialized"
+
+    @classmethod
+    def init(cls, tmp_path_factory: TempPathFactory) -> None:
+        worker_tmp = Path(tmp_path_factory.getbasetemp())
+        cls.pytest_worker_tmp = worker_tmp
+
+        root_tmp = worker_tmp.parent if configuration.IS_XDIST else worker_tmp
+        cls.pytest_root_tmp = root_tmp
+
+        shared_tmp = root_tmp / "tmp"
+        shared_tmp.mkdir(parents=True, exist_ok=True)
+        cls.pytest_shared_tmp = shared_tmp
+
+
+def get_pytest_worker_tmp() -> Path:
+    """Return Pytest temporary directory for the current worker.
 
     When running pytest with multiple workers, each worker has it's own base temporary
     directory inside the "root" temporary directory.
     """
-    worker_tmp = Path(tmp_path_factory.getbasetemp())
-    return worker_tmp
+    if PytestTempDirs.pytest_worker_tmp is None:
+        raise RuntimeError(PytestTempDirs._err_init_str)
+    return PytestTempDirs.pytest_worker_tmp
 
 
-@helpers.callonce
-def get_pytest_root_tmp(tmp_path_factory: TempPathFactory) -> Path:
-    """Return root of the pytest temporary directory for a single pytest run."""
-    worker_tmp = get_pytest_worker_tmp(tmp_path_factory)
-    root_tmp = worker_tmp.parent if configuration.IS_XDIST else worker_tmp
-    return root_tmp
+def get_pytest_root_tmp() -> Path:
+    """Return root of the Pytest temporary directory for a single Pytest run."""
+    if PytestTempDirs.pytest_root_tmp is None:
+        raise RuntimeError(PytestTempDirs._err_init_str)
+    return PytestTempDirs.pytest_root_tmp
 
 
-@helpers.callonce
-def get_pytest_shared_tmp(tmp_path_factory: TempPathFactory) -> Path:
-    """Return shared temporary directory for a single pytest run.
+def get_pytest_shared_tmp() -> Path:
+    """Return shared temporary directory for a single Pytest run.
 
-    Temporary directory that can be shared by multiple pytest workers, e.g. for creating lock files.
+    Temporary directory that can be shared by multiple Pytest workers, e.g. for creating
+    lock files.
     """
-    root_tmp = get_pytest_root_tmp(tmp_path_factory)
-    shared_tmp = root_tmp / "tmp"
-    shared_tmp.mkdir(parents=True, exist_ok=True)
-    return shared_tmp
+    if PytestTempDirs.pytest_shared_tmp is None:
+        raise RuntimeError(PytestTempDirs._err_init_str)
+    return PytestTempDirs.pytest_shared_tmp
 
 
 @helpers.callonce


### PR DESCRIPTION
Initialize pytest temp dirs with value of `tmp_path_factory` in `conftest.py`, so the value of `tmp_path_factory` is needed only once during initialization.