### PR TITLE
Fix argument detection

### DIFF
--- a/cardano_node_tests/cluster_scripts/babbage/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/babbage/start-cluster-hfc
@@ -130,7 +130,7 @@ fi
 
 
 CERT_ERA_ARG=("--shelley-era")
-if cardano-cli stake-address registration-certificate --shelley-era 2>&1 |\
+if { cardano-cli stake-address registration-certificate --shelley-era 2>&1; true; } |\
   { read -r i; [[ "$i" == *Invalid* ]]; }; then
   CERT_ERA_ARG=()
 fi

--- a/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster-hfc
+++ b/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster-hfc
@@ -96,7 +96,7 @@ fi
 
 
 CERT_ERA_ARG=("--babbage-era")
-if cardano-cli stake-address registration-certificate --babbage-era 2>&1 |\
+if { cardano-cli stake-address registration-certificate --babbage-era 2>&1; true; } |\
   { read -r i; [[ "$i" == *Invalid* ]]; }; then
   CERT_ERA_ARG=()
 fi


### PR DESCRIPTION
We are using `set -o pipefail`, so the command before pipe cannot exit with failing status code.