### PR TITLE
Xfail if cardano-api issue 269 is present on cardano-node devel

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -130,6 +130,7 @@ class TestLeadershipSchedule:
                 issue=269,
                 repo="input-output-hk/cardano-api",
                 message="Broken `nextEpochEligibleLeadershipSlots`",
+                check_on_devel=False,
             )
             if (
                 VERSIONS.node > version.parse("8.1.2")


### PR DESCRIPTION
The issue is fixed, but the cardano-api that includes the fix is not used by current cardano-node master yet.