### PR TITLE
Assume `--metrics-port` is always available

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/run-cardano-submit-api
+++ b/cardano_node_tests/cluster_scripts/conway/run-cardano-submit-api
@@ -2,18 +2,15 @@
 
 testnet_magic="$(<./state-cluster%%INSTANCE_NUM%%/db-bft1/protocolMagicId)"
 
-# TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
-metrics_port="$(cardano-submit-api --metrics-port 8081 2>&1 | { read -r i; if [[ "$i" == *Invalid* ]]; then echo ""; else echo "--metrics-port %%METRICS_SUBMIT_API_PORT%%"; fi; })"
-
 echo "Starting cardano-submit-api: cardano-submit-api"
   echo "--config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json"
   echo "--socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket"
   echo "--listen-address 127.0.0.1"
   echo "--port %%SUBMIT_API_PORT%%"
-  echo "$metrics_port"
+  echo "--metrics-port %%METRICS_SUBMIT_API_PORT%%"
   echo --testnet-magic "$testnet_magic"
 echo "..or, once again, in a single line:"
-echo cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% "$metrics_port" --testnet-magic "$testnet_magic"
+echo cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"
 
 # shellcheck disable=SC2086
-exec cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% $metrics_port --testnet-magic "$testnet_magic"
+exec cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"

--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -109,21 +109,7 @@ wait_for_epoch() {
   exit 1
 }
 
-enable_submit_api() {
-  type cardano-submit-api >/dev/null 2>&1 || return 1
-
-  # TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
-  # If the metrics port is not available, we can start the `cardano-submit-api` only on the first
-  # cluster instance.
-  [[ "$CARDANO_NODE_SOCKET_PATH" == */cluster0/* ]] && return 0
-  if cardano-submit-api --metrics-port 8081 2>&1 | { read -r i; [[ "$i" == *Invalid* ]]; }; then
-    return 1
-  fi
-
-  return 0
-}
-
-ENABLE_SUBMIT_API="$(enable_submit_api && echo 1 || echo 0)"
+ENABLE_SUBMIT_API="$(type cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
 if [ -e "$SCRIPT_DIR/shell_env" ]; then
   # shellcheck disable=SC1090,SC1091

--- a/cardano_node_tests/cluster_scripts/conway_fast/run-cardano-submit-api
+++ b/cardano_node_tests/cluster_scripts/conway_fast/run-cardano-submit-api
@@ -2,18 +2,15 @@
 
 testnet_magic="$(<./state-cluster%%INSTANCE_NUM%%/db-bft1/protocolMagicId)"
 
-# TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
-metrics_port="$(cardano-submit-api --metrics-port 8081 2>&1 | { read -r i; if [[ "$i" == *Invalid* ]]; then echo ""; else echo "--metrics-port %%METRICS_SUBMIT_API_PORT%%"; fi; })"
-
 echo "Starting cardano-submit-api: cardano-submit-api"
   echo "--config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json"
   echo "--socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket"
   echo "--listen-address 127.0.0.1"
   echo "--port %%SUBMIT_API_PORT%%"
-  echo "$metrics_port"
+  echo "--metrics-port %%METRICS_SUBMIT_API_PORT%%"
   echo --testnet-magic "$testnet_magic"
 echo "..or, once again, in a single line:"
-echo cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% "$metrics_port" --testnet-magic "$testnet_magic"
+echo cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"
 
 # shellcheck disable=SC2086
-exec cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% $metrics_port --testnet-magic "$testnet_magic"
+exec cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"


### PR DESCRIPTION
If node can run in Conway, submit-api is recent enough to have `--metrics-port`.