### PR TITLE
feat(pyrefly): add pyrefly type checker integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,13 @@ repos:
     additional_dependencies: [sphinx, toml]
 - repo: local
   hooks:
+  - id: pyrefly
+    name: pyrefly
+    entry: pyrefly
+    args: [ check, --remove-unused-ignores ]
+    pass_filenames: false
+    language: system
+    types: [python]
   - id: mypy
     name: mypy
     entry: mypy

--- a/cardano_node_tests/cardano_cli_coverage.py
+++ b/cardano_node_tests/cardano_cli_coverage.py
@@ -105,9 +105,11 @@ def merge_coverage(dict_a: dict, dict_b: dict) -> dict:
     mergeable = (list, set, tuple)
     addable = (int, float)
     for key, value in dict_b.items():
+        # pyrefly: ignore  # invalid-argument
         if key in dict_a and isinstance(value, mergeable) and isinstance(dict_a[key], mergeable):
             new_list = set(dict_a[key]).union(value)
             dict_a[key] = sorted(new_list)
+        # pyrefly: ignore  # invalid-argument
         elif key in dict_a and isinstance(value, addable) and isinstance(dict_a[key], addable):
             dict_a[key] += value
         # Skipped arguments and commands are not in the available commands dict
@@ -126,6 +128,7 @@ def cli(cli_args: tp.Iterable[str]) -> str:
     assert not isinstance(cli_args, str), "`cli_args` must be sequence of strings"
     with subprocess.Popen(list(cli_args), stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
         __, stderr = p.communicate()
+    # pyrefly: ignore  # missing-attribute
     return stderr.decode()
 
 

--- a/cardano_node_tests/pytest_plugins/xdist_scheduler.py
+++ b/cardano_node_tests/pytest_plugins/xdist_scheduler.py
@@ -104,6 +104,7 @@ class OneLongScheduling(scheduler.LoadScopeScheduling):
         scope, work_unit = None, None
 
         # Check if there are any long-running tests already pending
+        # pyrefly: ignore  # bad-argument-type
         long_pending = self._is_long_pending(assigned_to_node)
 
         if long_pending:

--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -197,8 +197,8 @@ class TestDBSync:
                     f"Expected: value > {prev_rec.epoch_slot_no} vs Returned: {rec.epoch_slot_no}"
                 )
 
-            if rec.block_no is None or (
-                prev_rec.block_no and rec.block_no != prev_rec.block_no + 1
+            if (rec.block_no is None and prev_rec.block_no is not None) or (
+                prev_rec.block_no is not None and rec.block_no != prev_rec.block_no + 1
             ):
                 errors.append(
                     "'block_no' value is different than expected; "
@@ -211,6 +211,7 @@ class TestDBSync:
                     f"Expected: {prev_rec.id} vs Returned: {rec.previous_id}"
                 )
 
+            # pyrefly: ignore  # unknown
             prev_rec = rec
 
         if errors:

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -290,7 +290,9 @@ class TestKES:
             ignore_file_id=worker_id,
         )
         # Search for expected errors only in log file corresponding to pool with expired KES
-        expected_errors = [(f"{expire_node_name}.stdout", err) for err in expected_err_regexes]
+        expected_errors: list[tuple[str, str]] = [
+            (f"{expire_node_name}.stdout", err) for err in expected_err_regexes
+        ]
 
         with logfiles.expect_errors(expected_errors, worker_id=worker_id):
             LOGGER.info(

--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -65,9 +65,9 @@ class TestNodeReconnect:
         try:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = str(new_socket)
             utxos = cluster_obj.g_query.get_utxo(address=address, tx_raw_output=tx_raw_output)
-            return utxos
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return utxos
 
     def node_get_tip(
         self,
@@ -82,9 +82,9 @@ class TestNodeReconnect:
         try:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = str(new_socket)
             tip = cluster_obj.g_query.get_tip()
-            return tip
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return tip
 
     def node_submit_tx(
         self,
@@ -112,9 +112,9 @@ class TestNodeReconnect:
                 tx_files=tx_files,
                 verify_tx=False,
             )
-            return tx_raw_output
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return tx_raw_output
 
     def get_prometheus_metrics(self, port: int) -> requests.Response:
         response = http_client.get_session().get(f"http://localhost:{port}/metrics", timeout=10)

--- a/cardano_node_tests/tests/test_rollback.py
+++ b/cardano_node_tests/tests/test_rollback.py
@@ -128,9 +128,9 @@ class TestRollback:
         try:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = str(new_socket)
             utxos = cluster_obj.g_query.get_utxo(address=address, tx_raw_output=tx_raw_output)
-            return utxos
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return utxos
 
     def node_submit_tx(
         self,
@@ -157,9 +157,9 @@ class TestRollback:
                 txouts=txouts,
                 tx_files=tx_files,
             )
-            return tx_raw_output
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return tx_raw_output
 
     def node_wait_for_block(
         self,
@@ -174,9 +174,10 @@ class TestRollback:
 
         try:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = str(new_socket)
-            return cluster_obj.wait_for_block(block=block_no)
+            new_block = cluster_obj.wait_for_block(block=block_no)
         finally:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
+        return new_block
 
     @allure.link(helpers.get_vcs_link())
     # There's a submission delay of 60 sec. Therefore on testnet with low `securityParam`,

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -2144,6 +2144,7 @@ class TestIncrementalSigning:
                     tx_name=f"{temp_template}_from{idx}_r{r}",
                 )
 
+        assert tx_signed is not None  # for pyrefly
         submit_utils.submit_tx(
             submit_method=submit_method,
             cluster_obj=cluster,

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -1701,6 +1701,7 @@ class TestIncrementalSigning:
                 )
 
         # It is not possible to submit Tx with missing required skey
+        assert tx_signed is not None  # for pyrefly
         with pytest.raises((clusterlib.CLIError, submit_api.SubmitApiError)) as excinfo:
             submit_utils.submit_tx(
                 submit_method=submit_method,

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -438,6 +438,8 @@ class TestDReps:
                 if use_build_cmd and submit_method == "cli":
 
                     def _query_func():
+                        if not drep_data:
+                            return
                         dbsync_utils.check_off_chain_drep_registration(
                             drep_data=drep_data, metadata=drep_metadata_content
                         )
@@ -587,9 +589,10 @@ class TestDReps:
         assert drep_data and drep_data.voting_anchor_id
 
         def _query_func():
-            dbsync_utils.check_off_chain_vote_fetch_error(
-                voting_anchor_id=drep_data.voting_anchor_id
-            )
+            if drep_data and drep_data.voting_anchor_id is not None:
+                dbsync_utils.check_off_chain_vote_fetch_error(
+                    voting_anchor_id=drep_data.voting_anchor_id
+                )
 
         reqc.db021.start(url=helpers.get_vcs_link())
         dbsync_utils.retry_query(query_func=_query_func, timeout=360)

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -682,6 +682,7 @@ class TestPParamUpdate:
             anchor_data = governance_utils.get_default_anchor_data()
             # Increment count for a submitted proposal
             nonlocal submitted_proposal_count
+            # pyrefly: ignore  # unknown-name
             submitted_proposal_count += 1
             return conway_common.propose_pparams_update(
                 cluster_obj=cluster,

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -20,6 +20,7 @@ CLUSTER_INSTANCE_ID_FILENAME = "cluster_instance_id.log"
 def save_cli_coverage(cluster_obj: clusterlib.ClusterLib, pytest_config: Config) -> pl.Path | None:
     """Save CLI coverage info."""
     cli_coverage_dir = pytest_config.getoption(CLI_COVERAGE_ARG)
+    # pyrefly: ignore  # missing-attribute
     if not (cli_coverage_dir and hasattr(cluster_obj, "cli_coverage") and cluster_obj.cli_coverage):
         return None
 

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -67,7 +67,11 @@ class ClusterType:
 
     def __init__(self) -> None:
         self.type = "unknown"
-        self.cluster_scripts = cluster_scripts.ScriptsTypes()
+        self.cluster_scripts: (
+            cluster_scripts.ScriptsTypes
+            | cluster_scripts.TestnetScripts
+            | cluster_scripts.LocalScripts
+        ) = cluster_scripts.ScriptsTypes()
 
     @property
     def testnet_type(self) -> str:
@@ -204,9 +208,7 @@ class TestnetCluster(ClusterType):
     def __init__(self) -> None:
         super().__init__()
         self.type = ClusterType.TESTNET
-        self.cluster_scripts: cluster_scripts.ScriptsTypes | cluster_scripts.TestnetScripts = (
-            cluster_scripts.TestnetScripts()
-        )
+        self.cluster_scripts = cluster_scripts.TestnetScripts()
 
         # Cached values
         self._testnet_type = ""

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -629,6 +629,7 @@ def mint_or_burn_witness(
         )
 
     # Submit signed TX
+    assert tx_witnessed_file is not None  # for pyrefly
     submit_utils.submit_tx(
         submit_method=submit_method,
         cluster_obj=cluster_obj,
@@ -729,6 +730,7 @@ def mint_or_burn_sign(
         )
 
     # Submit signed transaction
+    assert out_file_signed is not None  # for pyrefly
     submit_utils.submit_tx(
         submit_method=submit_method,
         cluster_obj=cluster_obj,
@@ -880,7 +882,9 @@ def _get_ledger_state_cmd(
     # Record cli coverage
     if hasattr(cluster_obj, "cli_coverage"):
         custom_clusterlib.record_cli_coverage(
-            cli_args=cardano_cli_args, coverage_dict=cluster_obj.cli_coverage
+            cli_args=cardano_cli_args,
+            # pyrefly: ignore  # missing-attribute
+            coverage_dict=cluster_obj.cli_coverage,
         )
 
     return ledger_state_cmd

--- a/cardano_node_tests/utils/dbsync_check_tx.py
+++ b/cardano_node_tests/utils/dbsync_check_tx.py
@@ -367,12 +367,14 @@ def check_tx_collaterals(
         and not (tx_raw_output.total_collateral_amount or tx_raw_output.return_collateral_txouts)
     ):
         protocol_params = cluster_obj.g_query.get_protocol_params()
+        # pyrefly: ignore  # no-matching-overload, bad-argument-type
         tx_collaterals_amount = clusterlib.calculate_utxos_balance(utxos=list(tx_collaterals))
         tx_collateral_output_amount = int(
             tx_collaterals_amount
             - tx_raw_output.fee * protocol_params["collateralPercentage"] / 100
         )
         db_collateral_output_amount = clusterlib.calculate_utxos_balance(
+            # pyrefly: ignore  # no-matching-overload, bad-argument-type
             utxos=list(response.collateral_outputs)
         )
 

--- a/cardano_node_tests/utils/dbsync_service_manager.py
+++ b/cardano_node_tests/utils/dbsync_service_manager.py
@@ -98,11 +98,6 @@ class Table(enum.StrEnum):
     VOTING_ANCHOR = "voting_anchor"
     VOTING_PROCEDURE = "voting_procedure"
 
-    @classmethod
-    def get_all_tables(cls) -> list[str]:
-        """Return all table names as a list of strings."""
-        return [table.value for table in cls]
-
 
 class Column:
     class Tx(enum.StrEnum):
@@ -395,7 +390,7 @@ class DBSyncManager:
         LOGGER.debug(f"Effective config: {config}")
 
         with open(config_file, encoding="utf-8") as fp_in:
-            current_dbsync_config = yaml.safe_load(fp_in) or {}
+            current_dbsync_config: dict = yaml.safe_load(fp_in) or {}
 
         current_dbsync_config["insert_options"] = config
 

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -100,11 +100,14 @@ def run_command(
     stdout, stderr = p.communicate()
 
     if not ignore_fail and p.returncode != 0:
+        # pyrefly: ignore  # missing-attribute
         err_dec = stderr.decode()
+        # pyrefly: ignore  # missing-attribute
         err_dec = err_dec or stdout.decode()
         msg = f"An error occurred while running `{cmd_str}`: {err_dec}"
         raise AssertionError(msg)
 
+    # pyrefly: ignore  # bad-return
     return stdout
 
 
@@ -293,7 +296,9 @@ def flatten(
             first = next(remainder)
         except StopIteration:
             break
+        # pyrefly: ignore  # invalid-argument
         if isinstance(first, ltypes) and not isinstance(first, (str, bytes)):
+            # pyrefly: ignore  # bad-argument-type
             remainder = itertools.chain(first, remainder)
         else:
             yield first

--- a/cardano_node_tests/utils/requirements.py
+++ b/cardano_node_tests/utils/requirements.py
@@ -100,17 +100,15 @@ def collect_executed_req(base_dir: pl.Path) -> dict:
             req_rec = json.load(in_fp)
 
         group_name = req_rec["group"]
-        group_collected = collected.get(group_name)
+        group_collected: dict = collected.get(group_name) or {}
         if not group_collected:
-            group_collected = {}
             collected[group_name] = group_collected
 
         req_id = req_rec["id"]
-        id_collected = group_collected.get(req_id)
+        id_collected: dict = group_collected.get(req_id) or {}
         if id_collected and id_collected["status"] == Statuses.success.name:
             continue
         if not id_collected:
-            id_collected = {}
             group_collected[req_id] = id_collected
         id_collected["status"] = req_rec["status"]
         id_collected["url"] = req_rec.get("url") or ""
@@ -126,8 +124,12 @@ def merge_reqs(*reqs: dict[str, dict]) -> dict:
             merged_group = merged.get(gname) or {}
             for req_id, req_data in greqs.items():
                 merged_rec = merged_group.get(req_id) or {}
-                merged_status_val = Statuses[merged_rec.get("status") or "uncovered"].value
+                merged_status_key = merged_rec.get("status") or "uncovered"
+                # pyrefly: ignore  # bad-specialization, not-a-type
+                merged_status_val = Statuses[merged_status_key].value
+                # pyrefly: ignore  # bad-specialization
                 req_status_val = Statuses[req_data["status"]].value
+                # pyrefly: ignore  # missing-attribute
                 if not merged_rec or req_status_val < merged_status_val:
                     merged_group[req_id] = req_data
             merged[gname] = merged_group
@@ -160,6 +162,7 @@ def get_mapped_req(mapping: pl.Path, executed_req: dict) -> dict:  # noqa: C901
             dependencies_failures = []
 
             for p_req in dependencies:
+                # pyrefly: ignore  # no-matching-overload, bad-argument-type
                 p_status = executed_group.get(p_req, {}).get("status")
 
                 if not url:

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -40,7 +40,7 @@ class Versions:
         self.command_era_name = configuration.COMMAND_ERA
 
         if self.command_era_name and self.command_era_name in self.MAP.values():
-            self.transaction_era_name = self.command_era_name
+            self.transaction_era_name: str = self.command_era_name
         else:
             self.transaction_era_name = self.MAP[self.DEFAULT_TX_ERA]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1095,7 +1095,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -1366,6 +1365,25 @@ cffi = ">=1.4.1"
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
+
+[[package]]
+name = "pyrefly"
+version = "0.17.0"
+description = "A faster Python type checker written in Rust"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pyrefly-0.17.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8e58c85564020ff7d286414bb6834110688cd345ef2ca52455e2b2b9dcc945ac"},
+    {file = "pyrefly-0.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:570efd8c77aaf5206962ea925ebec4770b6b81c4707280159edc424cac410977"},
+    {file = "pyrefly-0.17.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a532b35687bd83c5f6bca220d96756dee4d18668da6bec426eb6d056e86a64"},
+    {file = "pyrefly-0.17.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:85af9067dff57b5cd5b2dad55e4cd4815382ce7e2f2b89a6aea8b668e22d768e"},
+    {file = "pyrefly-0.17.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459338ea37996ada78814a79d40403789b9154949ea462e812f42b726f1f08ff"},
+    {file = "pyrefly-0.17.0-py3-none-win32.whl", hash = "sha256:c01a5785d517b727dd36832ff6a418a91e3a902c9227f3f13e7b9172b3ec0529"},
+    {file = "pyrefly-0.17.0-py3-none-win_amd64.whl", hash = "sha256:4a96cb962453a89ee71c5cb0f8e513b02fa3111ce6e933ded6234a7b88a04318"},
+    {file = "pyrefly-0.17.0-py3-none-win_arm64.whl", hash = "sha256:b13d540da0a3c38c2dde6a92e37d3af6fde695795d5c9b02d34f319f05cdd7f2"},
+    {file = "pyrefly-0.17.0.tar.gz", hash = "sha256:dc3271269731a173174f317e73011d95735143a626dcd8c22e82f527c8480e12"},
+]
 
 [[package]]
 name = "pytest"
@@ -2064,4 +2082,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "dfdf1a3de662d0cee2182dc0c93599342160b6e2fb300064e6e755121a0e81d3"
+content-hash = "a886b6cbda903903b320246e9108a187f3d505cd62152164323d7357a3ab5339"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ types-PyYAML = "^6.0.12.20240917"
 types-requests = "^2.32.0.20241016"
 mypy = "^1.13.0"
 ipython = "^8.29.0"
+pyrefly = "^0.17.0"
 
 [tool.poetry.group.docs]
 optional = true
@@ -110,6 +111,14 @@ no_implicit_optional = true
 allow_untyped_globals = false
 warn_unused_configs = true
 warn_return_any = true
+
+[tool.pyrefly]
+python_version = "3.11.0"
+project_includes = ["cardano_node_tests", "framework_tests"]
+replace_imports_with_any = ["allure.*", "hypothesis.*", "pytest.*", "pytest_subtests.*", "psycopg2.*", "requests.*"]
+ignore_errors_in_generated_code = true
+use_untyped_imports = true
+ignore_missing_source = true
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
- Add pyrefly as a dev dependency in pyproject.toml and poetry.lock.
- Configure pyrefly with project-specific settings.
- Integrate pyrefly into pre-commit hooks for Python files.
- Add type ignore comments for pyrefly in various modules to suppress specific errors and improve compatibility.
- Refactor some type annotations and variable initializations for better type checking.
- Remove unused method from dbsync_service_manager.Table.