### PR TITLE
chore(pyproject): remove redundant black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,6 @@ cardano-cli-coverage = "cardano_node_tests.cardano_cli_coverage:main"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
Removed the [tool.black] section from pyproject.toml as it is no longer needed. The line length configuration is now managed by ruff, ensuring consistency and reducing duplication in formatting settings.