### PR TITLE
fix(cluster): check supervisord socket before stopping

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -750,8 +750,11 @@ set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
-supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
+if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+fi
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -606,8 +606,11 @@ set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
-supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
+if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+fi
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -606,8 +606,11 @@ set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
-supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
+if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+fi
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -159,8 +159,11 @@ set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\$SCRIPT_DIR/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
-supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
+if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+fi
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"


### PR DESCRIPTION
Add a check to ensure the supervisord socket file exists before attempting to stop all processes with supervisorctl in cluster start scripts. This prevents errors when the socket is missing and improves script robustness.