### PR TITLE
refactor: replace AssertionError with RuntimeError

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -741,7 +741,7 @@ def create_script_context_w_blockers(
             redeemer_file=redeemer_file,
             tx_file=tx_file,
         )
-    except AssertionError as err:
+    except RuntimeError as err:
         str_err = str(err)
         if "Unwitnessed Tx ConwayEra" in str_err:
             pytest.xfail("create-script-context: unsupported 'Unwitnessed Tx ConwayEra'")

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -152,7 +152,7 @@ class TestCLI:
 
         try:
             helpers.run_in_bash(command=cmd)
-        except AssertionError as err:
+        except RuntimeError as err:
             if "cardano-cli: TODO" in str(err) or "Could not JSON decode TextEnvelopeCddl" in str(
                 err
             ):
@@ -1146,7 +1146,7 @@ class TestAdvancedQueries:
 
         try:
             ledger_state = clusterlib_utils.get_ledger_state(cluster_obj=cluster)
-        except AssertionError as err:
+        except RuntimeError as err:
             if "Invalid numeric literal at line" in str(err):
                 issues.node_3859.finish_test()
             raise

--- a/cardano_node_tests/tests/test_ledger_state.py
+++ b/cardano_node_tests/tests/test_ledger_state.py
@@ -51,7 +51,7 @@ class TestLedgerState:
 
         try:
             ledger_state = clusterlib_utils.get_ledger_state(cluster_obj=cluster)
-        except AssertionError as err:
+        except RuntimeError as err:
             if "Invalid numeric literal at line" not in str(err):
                 raise
             issues.node_3859.finish_test()

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -104,7 +104,7 @@ def run_command(
         # pyrefly: ignore  # missing-attribute
         err_dec = err_dec or stdout.decode()
         msg = f"An error occurred while running `{cmd_str}`: {err_dec}"
-        raise AssertionError(msg)
+        raise RuntimeError(msg)
 
     # pyrefly: ignore  # bad-return
     return stdout
@@ -276,7 +276,7 @@ def tool_has(command: str) -> bool:
     err_str = ""
     try:
         run_command(command)
-    except AssertionError as err:
+    except RuntimeError as err:
         err_str = str(err)
     else:
         return True


### PR DESCRIPTION
Update exception handling to use RuntimeError instead of AssertionError across helpers and test files. This change clarifies the intent of exceptions raised during command execution and error handling, and improves consistency in error reporting throughout the codebase.