### PR TITLE
fix(ci): correct SCRIPTS_DIRNAME assignment in byron cluster

### DIFF
--- a/.github/node_upgrade_pytest.sh
+++ b/.github/node_upgrade_pytest.sh
@@ -52,7 +52,7 @@ if [ "$1" = "step1" ]; then
   fi
 
   if [ "${CI_BYRON_CLUSTER:-"false"}" != "false" ]; then
-    : "${SCRIPTS_DIRNAME:="$CLUSTER_ERA"}_slow"
+    : "${SCRIPTS_DIRNAME:="${CLUSTER_ERA}_slow"}"
   else
     : "${SCRIPTS_DIRNAME:="${CLUSTER_ERA}_fast"}"
   fi


### PR DESCRIPTION
Fixes a bug in the SCRIPTS_DIRNAME assignment for the byron cluster condition in node_upgrade_pytest.sh. The previous logic incorrectly placed the "_slow" suffix outside the variable expansion, which could lead to unexpected results. This change ensures the suffix is appended properly within the variable expansion.