### PR TITLE
fix(pyproject): correct license identifier to Apache-2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cardano-node-tests"
 version = "0.1.0"
 description = "Functional tests for cardano-node"
-license = "Apache License 2.0"
+license = "Apache-2.0"
 authors = [
     "Martin Kourim <martin.kourim@iohk.io>",
     "Sara Tomaz <sara.tomaz@iohk.io>",


### PR DESCRIPTION
Updated the license field in pyproject.toml to use the SPDX-compliant identifier "Apache-2.0" instead of the previous non-standard value. This improves compatibility with tools that parse license metadata.