### PR TITLE
chore: remove pytype configuration and checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ init_lint:
 .PHONY: lint
 lint:
 	pre-commit run -a --show-diff-on-failure --color=always
-	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_node_tests; fi
 
 
 # check if development environment is set up correctly

--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -61,7 +61,6 @@ class GHIssue:
         cached_state = self.issue_cache.get(identifier)
 
         if cached_state is None:
-            assert self.github  # for pytype
             try:
                 cached_state = self.github.get_repo(self.repo).get_issue(self.number).state.lower()
             except github.UnknownObjectException:

--- a/cardano_node_tests/utils/model_ekg.py
+++ b/cardano_node_tests/utils/model_ekg.py
@@ -3,7 +3,7 @@
 #   timestamp: 2021-03-10T11:38:36+00:00
 from __future__ import annotations
 
-from pydantic import BaseModel  # pytype: disable=import-error
+from pydantic import BaseModel
 from pydantic import Field
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,6 @@ ignore = ["ANN401", "B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404
 [tool.ruff.lint.isort]
 force-single-line = true
 
-[tool.pytype]
-python_version = "3.11"
-disable = ["import-error"]
-
 [tool.mypy]
 python_version = "3.11"
 show_error_context = true


### PR DESCRIPTION
This commit removes all references to pytype from the Makefile, code, and pyproject.toml. The lint target no longer runs pytype, and related comments and configuration sections have been deleted.