### PR TITLE
feat(docker): add --pull flag to always fetch latest base image during build

### DIFF
--- a/cabal_build_tests/run.sh
+++ b/cabal_build_tests/run.sh
@@ -54,6 +54,7 @@ echo "Using base image: $BASE_IMAGE"
 echo "Building image: $TAG"
 
 $container_manager build . \
+  --pull \
   -f Dockerfile \
   --build-arg BASE_IMAGE="$BASE_IMAGE" \
   -t "$TAG" \

--- a/runner/runc.sh
+++ b/runner/runc.sh
@@ -191,6 +191,7 @@ echo "Command:           $CMD"
 echo
 
 $container_manager build "$SCRIPT_DIR" \
+  --pull \
   -f "$SCRIPT_DIR/Dockerfile" \
   --build-arg BASE_IMAGE="$BASE_IMAGE" \
   -t "$TAG" \


### PR DESCRIPTION
Added the --pull option to Docker build commands in both cabal_build_tests/run.sh and runner/runc.sh to ensure the latest base image is used during image builds.