### PR TITLE
chore(devshell): add gnumake to nativeBuildInputs in base shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         {
           devShells = rec {
             base = pkgs.mkShell {
-              nativeBuildInputs = with pkgs; [ bash coreutils curl git gnugrep gnutar jq procps xz ];
+              nativeBuildInputs = with pkgs; [ bash coreutils curl git gnugrep gnumake gnutar jq procps xz ];
             };
             postgres = pkgs.mkShell {
               nativeBuildInputs = with pkgs; [ glibcLocales postgresql lsof procps ];


### PR DESCRIPTION
Include gnumake in the base devShell.