### PR TITLE
feat: replace readlink -m with more compatible directory resolution

### DIFF
--- a/.source.dev
+++ b/.source.dev
@@ -13,7 +13,7 @@
   return 1
 }
 
-_root_dir_cnt="$(readlink -m "${BASH_SOURCE[0]}/..")"
+_root_dir_cnt="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" || { echo "Cannot determine root dir, returning." >&2; return 1; }
 
 # Source additional environment variables from .env.sh
 if [ -e "$_root_dir_cnt/.env.sh" ]; then

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
 TESTNET_DIR="${1:?"Testnet dir needed"}"
-SCRIPT_DIR="$(readlink -m "${0%/*}")"
+SCRIPT_DIR="$(cd "${0%/*}" && pwd)" || { echo "Cannot determine SCRIPT_DIR, exiting." >&2; exit 1; }
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 # Fail if PWD is STATE_CLUSTER, as STATE_CLUSTER will be deleted
@@ -143,7 +143,7 @@ cat > "$STATE_CLUSTER/supervisord_start" <<EoF
 
 set -uo pipefail
 
-SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
+SCRIPT_DIR="\$(cd "\${0%/*}" && pwd)" || { echo "Cannot determine SCRIPT_DIR, exiting." >&2; exit 1; }
 
 cd "\$SCRIPT_DIR/.."
 
@@ -155,7 +155,7 @@ cat > "$STATE_CLUSTER/stop-cluster" <<EoF
 
 set -uo pipefail
 
-SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
+SCRIPT_DIR="\$(cd "\${0%/*}" && pwd)" || { echo "Cannot determine SCRIPT_DIR, exiting." >&2; exit 1; }
 PID_FILE="\$SCRIPT_DIR/supervisord.pid"
 SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 

--- a/runner/cli_coverage.sh
+++ b/runner/cli_coverage.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-tests_repo="$(readlink -m "${0%/*}/..")"
+tests_repo="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine test repo dir, exiting." >&2; exit 1; }
 
 get_coverage() {
   if [ "$(echo "$tests_repo"/.cli_coverage/*)" = "$tests_repo/.cli_coverage/*" ] || ! command -v cardano-cli >/dev/null 2>&1; then

--- a/runner/create_results.sh
+++ b/runner/create_results.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-tests_repo="$(readlink -m "${0%/*}/..")"
+tests_repo="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine tests repo dir, exiting." >&2; exit 1; }
 reports_dir="$tests_repo/.reports"
 if [ "$(echo "$reports_dir"/*.json)" = "$reports_dir/*.json" ]; then
   echo "No reports found in $reports_dir" >&2

--- a/runner/node_upgrade.sh
+++ b/runner/node_upgrade.sh
@@ -23,7 +23,7 @@ df -h .
 
 retval=0
 
-REPODIR="$(readlink -m "${0%/*}/..")"
+REPODIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
 export REPODIR
 cd "$REPODIR"
 

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -203,10 +203,10 @@ elif [ "$1" = "step2" ]; then
   # print path to cardano-node binaries
   echo "pool1 node binary:"
   pool1_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool1)"
-  readlink -m "/proc/$pool1_pid/exe"
+  readlink -f "/proc/$pool1_pid/exe"
   echo "pool3 node binary:"
   pool3_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool3)"
-  readlink -m "/proc/$pool3_pid/exe"
+  readlink -f "/proc/$pool3_pid/exe"
 
   # check that nodes are running
   if [ "$pool1_pid" = 0 ] || [ "$pool3_pid" = 0 ]; then
@@ -361,10 +361,10 @@ elif [ "$1" = "step3" ]; then
   # print path to cardano-node binaries
   echo "pool1 node binary:"
   pool1_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool1)"
-  readlink -m "/proc/$pool1_pid/exe"
+  readlink -f "/proc/$pool1_pid/exe"
   echo "pool3 node binary:"
   pool3_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool3)"
-  readlink -m "/proc/$pool3_pid/exe"
+  readlink -f "/proc/$pool3_pid/exe"
 
   # check that nodes are running
   if [ "$pool1_pid" = 0 ] || [ "$pool3_pid" = 0 ]; then

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -13,7 +13,7 @@ df -h .
 
 retval=0
 
-REPODIR="$(readlink -m "${0%/*}/..")"
+REPODIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
 cd "$REPODIR"
 
 export WORKDIR="$REPODIR/run_workdir"
@@ -151,7 +151,7 @@ _cleanup_testnet_on_interrupt() {
 
   _PYTEST_CURRENT="$(find "$WORKDIR" -type l -name pytest-current)"
   [ -z "$_PYTEST_CURRENT" ] && return
-  _PYTEST_CURRENT="$(readlink -m "$_PYTEST_CURRENT")"
+  _PYTEST_CURRENT="$(readlink -f "$_PYTEST_CURRENT")"
   export _PYTEST_CURRENT
 
   echo "::endgroup::" # end group for the group that was interrupted

--- a/runner/reqs_coverage.sh
+++ b/runner/reqs_coverage.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
 
-tests_repo="$(readlink -m "${0%/*}/..")"
+tests_repo="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine tests repo dir, exiting." >&2; exit 1; }
 
 get_coverage() {
   if [ ! -e "$ARTIFACTS_DIR" ]; then

--- a/runner/run_tests.sh
+++ b/runner/run_tests.sh
@@ -37,7 +37,7 @@ ARTIFACTS_DIR="${ARTIFACTS_DIR:-.artifacts}"
 COVERAGE_DIR="${COVERAGE_DIR:-.cli_coverage}"
 REPORTS_DIR="${REPORTS_DIR:-.reports}"
 
-_TOP_DIR="$(readlink -m "${0%/*}/..")"
+_TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
 . "$_TOP_DIR/scripts/common.sh"
 

--- a/runner/setup_venv.sh
+++ b/runner/setup_venv.sh
@@ -6,7 +6,7 @@
 }
 
 _VENV_DIR="${_VENV_DIR:-"${WORKDIR:?}/.venv"}"
-_TOP_DIR="$(readlink -m "${BASH_SOURCE[0]}/../..")"
+_TOP_DIR="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)" || { echo "Cannot determine top dir, returning." >&2; return 1; }
 
 if [ "${1:-""}" = "clean" ]; then
   rm -rf "$_VENV_DIR"

--- a/runner/source_cardano_cli.sh
+++ b/runner/source_cardano_cli.sh
@@ -34,7 +34,7 @@ cardano_cli_print_path_prepend() {
 
   local out="cardano-cli-build${node_bindir_postfix}"
   local bin_dir
-  bin_dir="$(readlink -m "${out}/bin")" || { cd "$origpwd" || true; return 1; }
+  bin_dir="$(readlink -f "${out}/bin")" || { cd "$origpwd" || true; return 1; }
 
   cd "$origpwd" || return 1
   echo "${bin_dir:+"${bin_dir}:"}"

--- a/runner/source_cardano_node.sh
+++ b/runner/source_cardano_node.sh
@@ -55,7 +55,7 @@ cardano_bins_print_path_prepend() {
     local out="${out_prefix}-build${node_bindir_postfix}"
     local bin_dir
 
-    bin_dir="$(readlink -m "${out}/bin")" || return 1
+    bin_dir="$(readlink -f "${out}/bin")" || return 1
     node_path_prepend="${node_path_prepend:+"${node_path_prepend}:"}${bin_dir}"
   }
 

--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -133,9 +133,9 @@ if is_truthy "${SMASH:-}" && [ ! -e "${WORKDIR}/smash-server/bin/cardano-smash-s
 fi
 
 # Add `cardano-db-sync` and `cardano-smash-server` to PATH_PREPEND
-PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m "${WORKDIR}/db-sync-node/bin")"
+PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -f "${WORKDIR}/db-sync-node/bin")"
 if [ -e smash-server/bin/cardano-smash-server ]; then
-  PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m "${WORKDIR}/smash-server/bin")"
+  PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -f "${WORKDIR}/smash-server/bin")"
 fi
 export PATH_PREPEND
 

--- a/scripts/check_dev_env.sh
+++ b/scripts/check_dev_env.sh
@@ -4,7 +4,7 @@
 
 set -uo pipefail
 
-_TOP_DIR="$(readlink -m "${0%/*}"/..)"
+_TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
 . "$_TOP_DIR/scripts/common.sh"
 

--- a/scripts/reinstall_editable.sh
+++ b/scripts/reinstall_editable.sh
@@ -9,9 +9,9 @@ if [ $# -ne 1 ]; then
   usage >&2
   exit 2
 fi
-REPO_PATH="$(readlink -m "$1")"
+REPO_PATH="$(readlink -f "$1")"
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 cd "$TOP_DIR"
 
 # Activate python virtual environment

--- a/scripts/restart_dev_cluster.sh
+++ b/scripts/restart_dev_cluster.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
 . "$TOP_DIR/scripts/common.sh"
 

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -24,7 +24,7 @@ case "${1:-""}" in
 esac
 
 ORIG_PWD="$PWD"
-REPODIR="$(readlink -m "${0%/*}/..")"
+REPODIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
 export WORKDIR="$REPODIR/dev_workdir"
 
 if [ "$ORIG_PWD" = "$WORKDIR" ]; then

--- a/scripts/test_block_production.sh
+++ b/scripts/test_block_production.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 # The database file will be created if missing
 if [ -z "${BLOCK_PRODUCTION_DB:-}" ]; then

--- a/scripts/test_node_reconnect.sh
+++ b/scripts/test_node_reconnect.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 export \
   CLUSTERS_COUNT=1 \

--- a/scripts/test_rollbacks.sh
+++ b/scripts/test_rollbacks.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 export NUM_POOLS="${NUM_POOLS:-"10"}" CLUSTERS_COUNT=1 TEST_THREADS=0
 

--- a/scripts/update_node_bins.sh
+++ b/scripts/update_node_bins.sh
@@ -13,9 +13,9 @@ if [ $# -ne 1 ]; then
   usage >&2
   exit 2
 fi
-REPO_PATH="$(readlink -m "$1")"
+REPO_PATH="$(readlink -f "$1")"
 
-TOP_DIR="$(readlink -m "${0%/*}/..")"
+TOP_DIR="$(cd "${0%/*}/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 BUILD_OUTPUT_DIR="$REPO_PATH/.nix_tests_bins"
 BIN_DIR="$TOP_DIR/.bin_node"
 


### PR DESCRIPTION
Switch scripts from `readlink -m` to a POSIX-compatible method using `cd ... && pwd` for resolving absolute paths. Also, update usages of `readlink -m` for symlink resolution to more compatible `readlink -f`, where applicable. Add error handling to exit or return with a message if directory resolution fails. No functional changes intended.