### PR TITLE
Fix  retry on submit timeout

### DIFF
--- a/cardano_node_tests/utils/custom_clusterlib.py
+++ b/cardano_node_tests/utils/custom_clusterlib.py
@@ -99,7 +99,7 @@ class ClusterLib(clusterlib.ClusterLib):
         """
         # Set a default timeout. This is a change of behavior compared to the base class!
         if timeout is None:
-            timeout = 120
+            timeout = 300
 
         cli_args_strs_all = [str(arg) for arg in cli_args]
         if add_default_args:

--- a/cardano_node_tests/utils/submit_api.py
+++ b/cardano_node_tests/utils/submit_api.py
@@ -1,7 +1,6 @@
 """Utilities for `cardano-submit-api` REST service."""
 
 import binascii
-import contextlib
 import dataclasses
 import json
 import logging
@@ -68,20 +67,16 @@ def post_cbor(*, cbor_file: clusterlib.FileType, url: str) -> requests.Response:
         if r > 1:
             LOGGER.warning(f"Resubmitting transaction to submit-api. Attempt {r}/{attempts}.")
 
-        response = None
-        with contextlib.suppress(requests.exceptions.ReadTimeout):
-            response = http_client.get_session().post(
-                url, headers=headers, data=cbor_binary, timeout=60
-            )
+        response = http_client.get_session().post(
+            url, headers=headers, data=cbor_binary, timeout=300
+        )
 
-        if response is not None and not response and "MempoolTxTooSlow" in response.text:
-            # Repeat the request as the transaction didn't make it to mempool
-            pass
-        elif response is not None:
-            break
+        if not response and "MempoolTxTooSlow" in response.text:
+            if r < attempts:
+                time.sleep(random.uniform(0, r))
+            continue
 
-        if r < attempts:
-            time.sleep(random.uniform(0, r))
+        break
     else:
         err = f"Failed to submit the tx after {attempts} attempts."
         raise SubmitApiError(err)
@@ -132,20 +127,21 @@ def submit_tx(
         wait_blocks: A number of new blocks to wait for (default = 2).
     """
     txid = ""
-    err = None
+    err: Exception | None = None
     attempts = 20
     for r in range(1, attempts + 1):
         if r == 1:
-            txid = submit_tx_bare(tx_file=tx_file).txid
+            try:
+                txid = submit_tx_bare(tx_file=tx_file).txid
+            except requests.exceptions.ReadTimeout as exc:
+                err = exc
         else:
-            if not txid:
-                msg = "The TxId is not known."
-                raise SubmitApiError(msg)
             LOGGER.warning(
                 f"Resubmitting transaction '{txid}' (from '{tx_file}'). Attempt {r}/{attempts}."
             )
             try:
                 submit_tx_bare(tx_file=tx_file)
+                err = None
             except SubmitApiError as exc:
                 # Check if resubmitting failed because an input UTxO was already spent
                 exc_str = str(exc)
@@ -157,6 +153,12 @@ def submit_tx(
                     raise
                 err = exc
                 # If here, the TX is likely still in mempool and we need to wait
+            except requests.exceptions.ReadTimeout as exc:
+                # If here, the TX might have been successfully submitted, but
+                # the timeout occurred before we got response.
+                err = exc
+
+        txid = txid or cluster_obj.g_transaction.get_txid(tx_file=tx_file)
 
         cluster_obj.wait_for_new_block(wait_blocks)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "allure-pytest (>=2.15.2,<3.0.0)",
-    "cardano-clusterlib (>=0.10.1,<0.11.0)",
+    "cardano-clusterlib (>=0.10.2,<0.11.0)",
     "cardonnay (>=0.3.4,<0.4.0)",
     "cbor2 (>=5.7.1,<6.0.0)",
     "filelock (>=3.20.0,<4.0.0)",

--- a/uv.lock
+++ b/uv.lock
@@ -78,14 +78,14 @@ wheels = [
 
 [[package]]
 name = "cardano-clusterlib"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/ac/7496f82d02ba464bdfe05efa08f1a636237efc88bd73ffc4bf56a797a0ea/cardano_clusterlib-0.10.1.tar.gz", hash = "sha256:1271f178fec565c5a761cc7df7784e867a7b88c5fc3b1edc5488865be2c26c84", size = 75330, upload-time = "2026-03-30T14:29:39.239Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/c0/b9a7027d57b69cadb06d44e1d833ee24dd685f84795ea2c696289164b6e2/cardano_clusterlib-0.10.2.tar.gz", hash = "sha256:6d1b15207bf7b96fd557ecbe09d268de9d4c83b5bc9135d11fba7285e10fe51f", size = 75494, upload-time = "2026-04-10T17:59:23.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/48/3d6cec2caee0f79c4bfcb0b9e749067ceac3302682c21df9b39b751a6b46/cardano_clusterlib-0.10.1-py3-none-any.whl", hash = "sha256:7d909b288d1bd059a13b10a5059c1409c9d2c18a647aa0f8df65b0cb490c3416", size = 76766, upload-time = "2026-03-30T14:29:37.934Z" },
+    { url = "https://files.pythonhosted.org/packages/79/e8/836652d582bdd1e7265082ac2b7e9d2291a957daa99715b7360b503b8010/cardano_clusterlib-0.10.2-py3-none-any.whl", hash = "sha256:236ff09e37a8e464107a980800f9350de7341d55771d0258dc3561ef7927bca5", size = 76839, upload-time = "2026-04-10T17:59:22.397Z" },
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "allure-pytest", specifier = ">=2.15.2,<3.0.0" },
-    { name = "cardano-clusterlib", specifier = ">=0.10.1,<0.11.0" },
+    { name = "cardano-clusterlib", specifier = ">=0.10.2,<0.11.0" },
     { name = "cardonnay", specifier = ">=0.3.4,<0.4.0" },
     { name = "cbor2", specifier = ">=5.7.1,<6.0.0" },
     { name = "filelock", specifier = ">=3.20.0,<4.0.0" },


### PR DESCRIPTION
This pull request focuses on improving the reliability and robustness of transaction submission to the Cardano Submit API by increasing timeouts and enhancing error handling. The changes also include a dependency update of `cardano-clusterlib` to a version that improves timeout handling for submit with `cardano-cli`.

**Timeout and Error Handling Improvements:**

* Increased the default timeout for CLI commands in `custom_clusterlib.py` from 120 seconds to 300 seconds to prevent premature failures during long-running operations.
* Increased the HTTP request timeout in `post_cbor` from 60 seconds to 300 seconds and removed the use of `contextlib.suppress` for `ReadTimeout`, allowing better error visibility and handling.
* Improved error handling in `submit_tx` by explicitly catching `requests.exceptions.ReadTimeout` and storing the exception for later use, ensuring that timeouts are retried and handled appropriately. [[1]](diffhunk://#diff-4586f13ec18d100e51e86bdc4878beaf24f8a9f53334d8447493266b804def2aL135-R144) [[2]](diffhunk://#diff-4586f13ec18d100e51e86bdc4878beaf24f8a9f53334d8447493266b804def2aR156-R159)

**Dependency Updates:**

* Updated the `cardano-clusterlib` dependency in `pyproject.toml` to version `>=0.10.2,<0.11.0` to stay current with upstream changes and bug fixes.

**Code Cleanup:**

* Removed the unused `contextlib` import from `submit_api.py` as it is no longer needed after the refactor.