### PR TITLE
feat(env): bump db-sync to 13.7.0.1 in nightly dbsync environment

### DIFF
--- a/runner/env_nightly_dbsync
+++ b/runner/env_nightly_dbsync
@@ -1,7 +1,7 @@
 CLUSTER_ERA=conway
 COMMAND_ERA=latest
 MARKEXPR=dbsync or smash
-DBSYNC_REV=13.6.0.5
-DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.6.0.5/cardano-db-sync-13.6.0.5-linux.tar.gz
+DBSYNC_REV=13.7.0.1
+DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.7.0.1/cardano-db-sync-13.7.0.1-linux.tar.gz
 SMASH=true
 DBSYNC_SKIP_INDEXES=true


### PR DESCRIPTION
Upgrade DBSYNC_REV and DBSYNC_TAR_URL to version 13.7.0.1 for the nightly dbsync environment.