### PR TITLE
feat(docs): clarify not to add Co-Authored-By lines

### DIFF
--- a/agent_docs/commits.md
+++ b/agent_docs/commits.md
@@ -1,3 +1,5 @@
 # Commits
 
 Run `git commit` with `-n`. Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.
+
+Do not add Co-Authored-By lines to commit messages.


### PR DESCRIPTION
Update commit message guidelines to specify that Co-Authored-By lines should not be included in commit messages.