### PR TITLE
fix(ci): use valid email in send-mail from field

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -171,7 +171,7 @@ jobs:
           password: ${{secrets.GMAIL_PASSWORD}}
           subject: "Status: ${{ steps.testing-step.outcome }}; workflow: ${{ github.workflow }}"
           to: ${{secrets.CI_FAIL_MAILS}}
-          from: Cardano GitHub Actions
+          from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
           body: "Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           reply_to: noreply@github.com
           attachments: testrun-report.html

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -137,7 +137,7 @@ jobs:
           password: ${{secrets.GMAIL_PASSWORD}}
           subject: "Status: ${{ steps.testing-step.outcome }}; workflow: ${{ github.workflow }}"
           to: ${{secrets.CI_FAIL_MAILS}}
-          from: Cardano GitHub Actions
+          from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
           body: "Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           reply_to: noreply@github.com
           attachments: testrun-report.html


### PR DESCRIPTION
The dawidd6/action-send-mail v16 requires a valid email address in the 'from' field. Use RFC 5322 format with GMAIL_USERNAME secret as the sender address.