### PR TITLE
chore(env): bump db-sync to 13.7.0.2 in nightly config

### DIFF
--- a/runner/env_nightly_dbsync
+++ b/runner/env_nightly_dbsync
@@ -1,7 +1,7 @@
 CLUSTER_ERA=conway
 COMMAND_ERA=latest
 MARKEXPR=dbsync or smash
-DBSYNC_REV=13.7.0.1
-DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.7.0.1/cardano-db-sync-13.7.0.1-linux.tar.gz
+DBSYNC_REV=13.7.0.2
+DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.7.0.2/cardano-db-sync-13.7.0.2-linux.tar.gz
 SMASH=true
 DBSYNC_SKIP_INDEXES=true


### PR DESCRIPTION
Update DBSYNC_REV and DBSYNC_TAR_URL to version 13.7.0.2 in runner/env_nightly_dbsync for nightly db-sync testing.