### PR TITLE
feat(ci): add consensus_mode input to regression workflows

### DIFF
--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -45,6 +45,13 @@ on:
         - disk
         - disklmdb
         default: ""
+      consensus_mode:
+        type: choice
+        description: "Consensus mode"
+        options:
+        - Praos
+        - Genesis
+        default: "Praos"
       allow_unstable_error_msgs:
         type: boolean
         default: false
@@ -74,6 +81,7 @@ jobs:
       cluster_era: ${{ inputs.cluster_era }}
       markexpr: ${{ inputs.markexpr }}
       utxo_backend: ${{ inputs.utxo_backend }}
+      consensus_mode: ${{ inputs.consensus_mode }}
       allow_unstable_error_msgs: ${{ inputs.allow_unstable_error_msgs }}
       byron_cluster: ${{ inputs.byron_cluster }}
       testrun_name: ${{ inputs.testrun_name }}

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -37,6 +37,13 @@ on:
         - disk
         - disklmdb
         default: ""
+      consensus_mode:
+        type: choice
+        description: "Consensus mode"
+        options:
+        - Praos
+        - Genesis
+        default: "Praos"
       allow_unstable_error_msgs:
         type: boolean
         default: false
@@ -65,6 +72,7 @@ jobs:
       cluster_era: ${{ inputs.cluster_era }}
       markexpr: ${{ inputs.markexpr }}
       utxo_backend: ${{ inputs.utxo_backend }}
+      consensus_mode: ${{ inputs.consensus_mode }}
       allow_unstable_error_msgs: ${{ inputs.allow_unstable_error_msgs }}
       byron_cluster: ${{ inputs.byron_cluster }}
       testrun_name: ${{ inputs.testrun_name }}

--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         type: string
         default: ""
+      consensus_mode:
+        required: false
+        type: string
+        default: ""
       allow_unstable_error_msgs:
         required: false
         type: boolean
@@ -91,6 +95,7 @@ jobs:
           echo "MARKEXPR=${{ inputs.markexpr }}" >> .github_ci_env
           echo "UTXO_BACKEND=${{ inputs.utxo_backend }}" >> .github_ci_env
           echo "ALLOW_UNSTABLE_ERROR_MESSAGES=${{ inputs.allow_unstable_error_msgs }}" >> .github_ci_env
+          echo "CI_CONSENSUS_MODE=${{ inputs.consensus_mode }}" >> .github_ci_env
           echo "CI_BYRON_CLUSTER=${{ inputs.byron_cluster }}" >> .github_ci_env
           echo "CI_TESTRUN_NAME=${{ inputs.testrun_name }}" >> .github_ci_env
           echo "CI_SKIP_PASSED=${{ inputs.skip_passed }}" >> .github_ci_env

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -77,6 +77,10 @@ elif is_truthy "${CI_BYRON_CLUSTER:-}"; then
   export TESTNET_VARIANT="${CLUSTER_ERA:-conway}_slow"
 fi
 
+if [ "${CI_CONSENSUS_MODE:-}" = "Genesis" ]; then
+  export USE_GENESIS_MODE=true
+fi
+
 export CARDANO_NODE_SOCKET_PATH_CI="$WORKDIR/state-cluster0/bft1.socket"
 
 # assume we run tests on testnet when `BOOTSTRAP_DIR` is set


### PR DESCRIPTION
- Added `consensus_mode` input to `.github/workflows/regression.yaml`, `regression-dbsync.yaml`, and `regression_reusable.yaml` with options for "Praos" and "Genesis".
- Passed `consensus_mode` through workflow jobs and set `CI_CONSENSUS_MODE` in the environment.
- Updated `runner/regression.sh` to export `USE_GENESIS_MODE=true` when `CI_CONSENSUS_MODE` is "Genesis".

This enables selecting the consensus mode for regression test runs.