### PR TITLE
fix(runner): add executable permissions to dbsync_download/bin/*

### DIFF
--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -64,6 +64,7 @@ if [ -n "${DBSYNC_TAR_URL:-}" ]; then
   rm -rf dbsync_download
   mkdir -p dbsync_download
   tar -C dbsync_download -xzf "$DBSYNC_TAR_FILE" || exit 1
+  chmod +x dbsync_download/bin/*  # TODO: Remove this line once the tarball has the correct permissions set
   rm -f "$DBSYNC_TAR_FILE"
   rm -f db-sync-node
   ln -s dbsync_download db-sync-node || exit 1


### PR DESCRIPTION
Add a temporary chmod step to ensure binaries in dbsync_download/bin are executable after extraction. This is a workaround until the tarball is packaged with correct permissions.