### PR TITLE
fix(runner): fix running PostgreSQL in containers

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE}
 #   #!/usr/bin/env -S nix develop --accept-flake-config .#base -c bash
 # Busybox env does not support -S and would fail with "unrecognized option".
 RUN if command -v apk > /dev/null 2>&1; then \
-        apk add --no-cache bash coreutils; \
+        apk add --no-cache bash coreutils shadow; \
     fi
 
 # Install ca-certificates on Debian-based images.

--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -18,7 +18,7 @@ stop_postgres() {
   local psql_pid
   psql_pid="$(<"$psql_pid_file")"
   for _ in {1..5}; do
-    if ! kill "$psql_pid"; then
+    if ! kill "$psql_pid" 2>/dev/null; then
       break
     fi
     sleep 1
@@ -153,8 +153,26 @@ export PGHOST=localhost
 export PGUSER=postgres
 export PGPORT=5432
 
-# start and setup postgres
-./scripts/postgres-start.sh "$WORKDIR/postgres" -k
+# Start and setup postgres
+if [ "$UID" -eq 0 ]; then
+  # If running as root, which is the case for containers, create a postgres user because postgres cannot run as root
+  if ! id -u postgres >/dev/null 2>&1; then
+    useradd -m -s /bin/sh postgres
+  fi
+
+  mkdir -p "$WORKDIR/postgres"
+  chown postgres:postgres "$WORKDIR/postgres"
+  # shellcheck disable=SC2016
+  REPODIR="$REPODIR" WORKDIR="$WORKDIR" SU="$(command -v su)" nix develop \
+    --accept-flake-config .#postgres -i -k PGHOST -k PGPORT -k PGUSER -k REPODIR -k WORKDIR -k SU --command bash -c '
+    "$SU" postgres -c "PATH=\"$PATH\" \"$REPODIR/scripts/postgres-start.sh\" \"$WORKDIR/postgres\" -k"
+  ' || {
+    echo "Failed to start postgres as postgres user, line $LINENO in sourced db-sync setup" >&2  # assert
+    exit 1
+  }
+else
+  ./scripts/postgres-start-nix.sh "$WORKDIR/postgres" -k
+fi
 
 cd "$_origpwd" || exit 1
 unset _origpwd

--- a/scripts/postgres-start-nix.sh
+++ b/scripts/postgres-start-nix.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env -S nix develop --accept-flake-config .#postgres -i -k PGHOST -k PGPORT -k PGUSER -c bash
+# shellcheck shell=bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/postgres-start.sh" "$@"

--- a/scripts/postgres-start.sh
+++ b/scripts/postgres-start.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env -S nix develop --accept-flake-config .#postgres -i -k PGHOST -k PGPORT -k PGUSER -c bash
-# shellcheck shell=bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR

--- a/testnets_bootstrap_template/README.md
+++ b/testnets_bootstrap_template/README.md
@@ -40,14 +40,14 @@ Running db-sync
 * If you **do not** already have a database and snapshot for the given testnet, start Postgres with a clean database:
 
     ```sh
-    /path/to/cardano-node-tests-repo/scripts/postgres-start.sh ~/tmp/postgres-for-testnet/ -k
+    /path/to/cardano-node-tests-repo/scripts/postgres-start-nix.sh ~/tmp/postgres-for-testnet/ -k
     ./postgres-setup.sh
     ```
 
 * If you **do** already have a database and snapshot, start Postgres using the existing data:
 
     ```sh
-    /path/to/cardano-node-tests-repo/scripts/postgres-start.sh ~/tmp/postgres-for-testnet/
+    /path/to/cardano-node-tests-repo/scripts/postgres-start-nix.sh ~/tmp/postgres-for-testnet/
     ```
 
 * Start db-sync **only after the node is fully synced**:


### PR DESCRIPTION
- Add shadow package to Dockerfile for user management.
- Update source_dbsync.sh to create and use a 'postgres' user when running as root (e.g., in containers).
- Add scripts/postgres-start-nix.sh to run postgres-start.sh within a Nix shell.
- Refactor scripts/postgres-start.sh to use a plain bash shebang.
- Update documentation to reference postgres-start-nix.sh for starting Postgres.