### PR TITLE
refactor(runner): pass argv through to container without re-quoting

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -6,8 +6,11 @@
 # Works whether /nix is bind-mounted from the host or nix was installed inside
 # the container at image-build time (single-user, no-daemon install).
 #
+# The command is run via env(1), so leading NAME=value arguments become
+# environment variables for the command itself.
+#
 # Usage (via runc.sh):
-#   ./runc.sh 'NODE_REV="10.7.0" MARKEXPR="testnets" ./runner/regression.sh'
+#   ./runc.sh -- NODE_REV=10.7.0 MARKEXPR='not long' ./runner/regression.sh
 
 set -eu
 
@@ -44,6 +47,8 @@ fi
 
 cd "${REPO_DIR:?REPO_DIR is not set}" || exit 1
 
-# Execute the command passed as arguments, interpreted by bash so that inline
-# env-var assignments (e.g. NODE_REV="10.7.0" ./script.sh) are handled correctly.
-exec bash -c "$*"
+# Use env(1) so leading NAME=value arguments are applied as environment
+# variables for the command, matching the behaviour of a plain shell command
+# line without needing bash -c (which would require the caller to pre-quote
+# everything into a single string).
+exec env -- "$@"

--- a/runner/runc.sh
+++ b/runner/runc.sh
@@ -24,10 +24,12 @@ Usage: $script_name [OPTIONS] [--] command [args...]
 
 Build a container image and run tests inside it.
 
-The command and its arguments are concatenated into a single string and
-executed inside the container via 'bash -c', so shell features like
-variable expansion, pipes, and redirections are available.  Be mindful
-of quoting: the entire command string is interpreted by the shell.
+The command and its arguments are passed through to the container as
+argv (via env(1), so leading NAME=value tokens are applied as
+environment variables for the command).  No extra shell escaping is
+required.  If you need shell features like pipes, redirections, or
+variable expansion, wrap the command explicitly, e.g.
+'-- bash -c "cmd1 | cmd2"'.
 
 Options:
   -h, --help                        Show this help message and exit.
@@ -70,9 +72,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-CMD="$*"
-
-if [ -z "$CMD" ]; then
+if [ $# -eq 0 ]; then
   echo "Error: No command provided." >&2
   usage >&2
   exit 2
@@ -201,7 +201,7 @@ esac
 echo "Using base image:  $BASE_IMAGE"
 echo "Building image:    $TAG"
 echo "Repository:        $REPO_DIR"
-echo "Command:           $CMD"
+echo "Command:           $*"
 echo
 
 $container_manager build "$SCRIPT_DIR" \
@@ -228,4 +228,4 @@ $container_manager run \
   "${EXTRA_MOUNTS[@]}" \
   -e REPO_DIR="$REPO_DIR" \
   "$TAG" \
-  "$CMD"
+  "$@"


### PR DESCRIPTION
runc.sh forwards "$@" straight to the container and entrypoint.sh uses `exec env "$@"` so leading NAME=value tokens become env vars for the command.  Callers no longer need to wrap the whole command in a single quoted string, e.g.

    ./runner/runc.sh -- MARKEXPR='dbsync or smash' ./runner/regression.sh

Shell features (pipes, redirections, expansion) are no longer applied implicitly; wrap with `-- bash -c '...'` when needed.