### PR TITLE
test(pparam_update): detect db-sync issue #2105

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -139,6 +139,12 @@ dbsync_1825 = blockers.GH(
     repo="IntersectMBO/cardano-db-sync",
     message="Wrong PlutusV2 script cost when the same script is used twice.",
 )
+dbsync_2105 = blockers.GH(
+    issue=2105,
+    repo="IntersectMBO/cardano-db-sync",
+    fixed_in="13.7.0.3",
+    message="Swapped min_pool_cost / coins_per_utxo_size.",
+)
 
 ledger_3731 = blockers.GH(
     issue=3731,

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -4,6 +4,7 @@ import fractions
 import logging
 import pathlib as pl
 import random
+import re
 
 import allure
 import pytest
@@ -1357,9 +1358,35 @@ class TestPParamUpdate:
         except AssertionError as exc:
             db_errors_final.append(f"db-sync proposal refunds error: {exc}")
 
-        if db_errors_final:
-            raise AssertionError("\n".join(db_errors_final))
+        def _is_dbsync_2105(dbe: str) -> bool:
+            header = re.search(
+                r"Unexpected parameter proposal values in db-sync:\n(.*)", dbe, re.DOTALL
+            )
+            if not header:
+                return False
+            names = []
+            for line in header.group(1).strip().splitlines():
+                name_match = re.match(r"Param value for (\w+):", line)
+                if not name_match:
+                    return False
+                names.append(name_match.group(1))
+            return set(names) == {"min_pool_cost", "coins_per_utxo_size"}
+
+        matched_2105 = []
+        remaining_errors = []
+        for dbe in db_errors_final:
+            if _is_dbsync_2105(dbe):
+                matched_2105.append(dbe)
+            else:
+                remaining_errors.append(dbe)
+
+        if remaining_errors:
+            annotated = [f"{m} (db-sync issue #2105)" for m in matched_2105]
+            raise AssertionError("\n".join(remaining_errors + annotated))
         [r.success() for r in (reqc.cip080, reqc.cip081, reqc.cip082, reqc.cip083)]
+
+        if matched_2105:
+            issues.dbsync_2105.finish_test()
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke

--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -935,8 +935,6 @@ def _check_param_proposal(
     failures = []
 
     for param_name, protocol_value in params_map.items():
-        if protocol_value is None:
-            continue
         db_value = getattr(param_proposal_db, param_name, _MISSING)
         if db_value is _MISSING or db_value == protocol_value:
             continue


### PR DESCRIPTION
Identify swapped min_pool_cost / coins_per_utxo_size errors from db-sync and flag them as known issue 2105 instead of failing the test. If unrelated db-sync errors remain, raise as before but keep the 2105 matches annotated. Also drop the None skip in _check_param_proposal so swaps with None on one side surface.