### PR TITLE
update(runner): remove executable permissions from dbsync_download/bi…

### DIFF
--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -64,7 +64,6 @@ if [ -n "${DBSYNC_TAR_URL:-}" ]; then
   rm -rf dbsync_download
   mkdir -p dbsync_download
   tar -C dbsync_download -xzf "$DBSYNC_TAR_FILE" || exit 1
-  chmod +x dbsync_download/bin/*  # TODO: Remove this line once the tarball has the correct permissions set
   rm -f "$DBSYNC_TAR_FILE"
   rm -f db-sync-node
   ln -s dbsync_download db-sync-node || exit 1


### PR DESCRIPTION
Remove temporary chmod +x step after db-sync archive creation logic was fixed. This is a workaround until the tarball is packaged with correct permissions.

PR Link: https://github.com/IntersectMBO/cardano-db-sync/pull/2100

Result:
```sh
artur@workstation:~/Projects/Archives/DB-Sync$ ll bin/13.7.0.4/
drwxr-xr-x artur artur 4.0 KB Tue Apr 28 21:10:57 2026  ./                           --
drwxr-xr-x artur artur 4.0 KB Wed Apr 29 15:01:55 2026  ../                          --
.r-xr-xr-x artur artur  91 MB Tue Apr 28 21:10:57 2026  cardano-db-sync*             --
.r-xr-xr-x artur artur  78 MB Tue Apr 28 21:10:57 2026  cardano-db-tool*             --
.r-xr-xr-x artur artur  41 MB Tue Apr 28 21:10:57 2026  cardano-smash-server*        --
.r-xr-xr-x artur artur  26 MB Tue Apr 28 21:10:57 2026  http-get-json-metadata*      --
.r-xr-xr-x artur artur  33 MB Tue Apr 28 21:10:57 2026  test-http-get-json-metadata* --

```