### PR TITLE
test(ledger): xfail stake-snapshot on ledger#5788 placeholder

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -208,6 +208,11 @@ ledger_5365 = blockers.GH(
     fixed_in="10.6.0.0",
     message="queryPoolState returns current pool params instead of the future ones.",
 )
+ledger_5788 = blockers.GH(
+    issue=5788,
+    repo="IntersectMBO/cardano-ledger",
+    message="queryStakeSnapshots returns 1 for empty snapshots instead of 0.",
+)
 
 network_5281 = blockers.GH(
     issue=5281,

--- a/cardano_node_tests/tests/test_ledger_state.py
+++ b/cardano_node_tests/tests/test_ledger_state.py
@@ -289,6 +289,11 @@ class TestLedgerState:
                 errors.append(f"active_go: {sum_go} < {stake_snapshot['activeStakeGo']}")
 
         if errors:
+            unknown_errs = [e for e in errors if e not in {"total_set: 0 != 1", "total_go: 0 != 1"}]
+            if not unknown_errs:
+                issues.ledger_5788.finish_test()
+
+        if errors:
             with open(f"{temp_template}.pickle", "wb") as out_data:
                 pickle.dump(ledger_state_data, out_data)
             err_joined = "\n".join(errors)


### PR DESCRIPTION
Empty `pstakeSet`/`pstakeGo` snapshots return total=1 (1 lovelace) instead of 0 due to NonZero Coin placeholder in emptySnapShot. Match the resulting `total_set: 0 != 1` / `total_go: 0 != 1` errors and xfail via `issues.ledger_5788`.