### PR TITLE
Improve MempoolTxTooSlow retry logic and reduce testnet parallelism

### DIFF
--- a/cardano_node_tests/utils/submit_api.py
+++ b/cardano_node_tests/utils/submit_api.py
@@ -61,7 +61,10 @@ def post_cbor(*, cbor_file: clusterlib.FileType, url: str) -> requests.Response:
     with open(cbor_file, "rb") as in_fp:
         cbor_binary = in_fp.read()
 
-    r = 0
+    # Retry only on `MempoolTxTooSlow`, which is a wallclock soft-timeout in the node's
+    # mempool. It is transient when caused by GC pauses, snapshot writes, or CPU spikes;
+    # backoff must outlast those. If it persists after a few retries, the cause is not
+    # transient (expensive tx or overloaded node) and further retries won't help.
     attempts = 6
     for r in range(1, attempts + 1):
         if r > 1:
@@ -71,17 +74,20 @@ def post_cbor(*, cbor_file: clusterlib.FileType, url: str) -> requests.Response:
             url, headers=headers, data=cbor_binary, timeout=300
         )
 
-        if not response and "MempoolTxTooSlow" in response.text:
+        if response.status_code == 400 and "MempoolTxTooSlow" in response.text:
             if r < attempts:
-                time.sleep(random.uniform(0, r))
-            continue
+                time.sleep(random.uniform(2, 10))
+                continue
+            err = (
+                f"Failed to submit the tx after {attempts} attempts due to "
+                f"`MempoolTxTooSlow`: {response.text}"
+            )
+            raise SubmitApiError(err)
 
-        break
-    else:
-        err = f"Failed to submit the tx after {attempts} attempts."
-        raise SubmitApiError(err)
+        return response
 
-    return response
+    msg = f"Unreachable: loop exited without return after {attempts} attempts."
+    raise RuntimeError(msg)
 
 
 def submit_tx_bare(*, tx_file: clusterlib.FileType) -> SubmitApiOut:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "allure-pytest (>=2.15.2,<3.0.0)",
-    "cardano-clusterlib (>=0.10.2,<0.11.0)",
+    "cardano-clusterlib (>=0.10.3,<0.11.0)",
     "cardonnay (>=0.3.4,<0.4.0)",
     "cbor2 (>=5.7.1,<6.0.0)",
     "filelock (>=3.20.0,<4.0.0)",

--- a/runner/run_tests.sh
+++ b/runner/run_tests.sh
@@ -196,7 +196,7 @@ target_testpr() {
 target_testnets() {
   export FORBID_RESTART=true
   export CLUSTERS_COUNT=1
-  TEST_THREADS="${TEST_THREADS:-15}"
+  TEST_THREADS="${TEST_THREADS:-6}"
   SESSION_TIMEOUT="${SESSION_TIMEOUT:-20h}"
   ensure_markexpr_default "testnets"
 

--- a/uv.lock
+++ b/uv.lock
@@ -78,14 +78,14 @@ wheels = [
 
 [[package]]
 name = "cardano-clusterlib"
-version = "0.10.2"
+version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/c0/b9a7027d57b69cadb06d44e1d833ee24dd685f84795ea2c696289164b6e2/cardano_clusterlib-0.10.2.tar.gz", hash = "sha256:6d1b15207bf7b96fd557ecbe09d268de9d4c83b5bc9135d11fba7285e10fe51f", size = 75494, upload-time = "2026-04-10T17:59:23.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/96/84198db8d598deefe17a001bf9a2d10c0238cbc0645fd0049037d1c6a275/cardano_clusterlib-0.10.3.tar.gz", hash = "sha256:6f8b3893a70f48c38c789f82bb9f972c6b2ee32ec8d324d6b62aac4deb1cc1b3", size = 76010, upload-time = "2026-05-05T15:18:39.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/e8/836652d582bdd1e7265082ac2b7e9d2291a957daa99715b7360b503b8010/cardano_clusterlib-0.10.2-py3-none-any.whl", hash = "sha256:236ff09e37a8e464107a980800f9350de7341d55771d0258dc3561ef7927bca5", size = 76839, upload-time = "2026-04-10T17:59:22.397Z" },
+    { url = "https://files.pythonhosted.org/packages/10/78/047fb2841b23cac2f5adc258388eeb5035b5dd20f5e07f044f1b1380ac40/cardano_clusterlib-0.10.3-py3-none-any.whl", hash = "sha256:0336725cc5217f7fe14cd20868efd415bce1c55fdf7005c3d24ce644c362577e", size = 76969, upload-time = "2026-05-05T15:18:38.153Z" },
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "allure-pytest", specifier = ">=2.15.2,<3.0.0" },
-    { name = "cardano-clusterlib", specifier = ">=0.10.2,<0.11.0" },
+    { name = "cardano-clusterlib", specifier = ">=0.10.3,<0.11.0" },
     { name = "cardonnay", specifier = ">=0.3.4,<0.4.0" },
     { name = "cbor2", specifier = ">=5.7.1,<6.0.0" },
     { name = "filelock", specifier = ">=3.20.0,<4.0.0" },


### PR DESCRIPTION
This pull request introduces several improvements to the transaction submission logic and updates dependencies and test runner configuration. The main focus is on making transaction retries more robust and transparent, as well as updating resource usage for test runs.

**Transaction submission improvements:**

* The retry logic in `post_cbor` (in `submit_api.py`) now only retries on `MempoolTxTooSlow` errors, with a more appropriate backoff (2-10 seconds), and provides clearer error messages when retries are exhausted. If the retry loop exits unexpectedly, a `RuntimeError` is raised to catch unreachable code paths. [[1]](diffhunk://#diff-4586f13ec18d100e51e86bdc4878beaf24f8a9f53334d8447493266b804def2aL64-R67) [[2]](diffhunk://#diff-4586f13ec18d100e51e86bdc4878beaf24f8a9f53334d8447493266b804def2aL74-R91)

**Dependency updates:**

* The `cardano-clusterlib` dependency is updated to version `>=0.10.3,<0.11.0` in `pyproject.toml` to ensure compatibility with recent changes.

**Test runner configuration:**

* The default number of test threads for `target_testnets` in `run_tests.sh` is reduced from 15 to 6, likely to reduce resource contention or improve test stability.