### PR TITLE
refactor(xdist): use enum + varargs for split keys

### DIFF
--- a/cardano_node_tests/pytest_plugins/xdist_scheduler.py
+++ b/cardano_node_tests/pytest_plugins/xdist_scheduler.py
@@ -29,8 +29,8 @@ class OneLongScheduling(scheduler.LoadScopeScheduling):
     can reorder them independently, and the number of in-flight tests sharing a given
     split key is capped at the available cluster instance capacity
     (see ``self.clusters_count``). A test that locks multiple shared resources can
-    declare several keys at once with a comma-separated value
-    (e.g. ``@pytest.mark.xdist_split("governance,plutus")``); the cap is then
+    declare several keys at once as positional args
+    (e.g. ``@pytest.mark.xdist_split("governance", "plutus")``); the cap is then
     enforced independently for each key.
 
     Without this cap, when many tests with the same split key are collected together
@@ -120,7 +120,7 @@ class OneLongScheduling(scheduler.LoadScopeScheduling):
         """Return the set of split keys encoded in a nodeid (empty if none).
 
         A test can declare multiple split keys (locking multiple shared resources)
-        via ``@pytest.mark.xdist_split("a,b")``; each key is encoded as its own
+        via ``@pytest.mark.xdist_split("a", "b")``; each key is encoded as its own
         ``@split=<key>`` suffix.
         """
         param_end_idx = nodeid.rfind("]")
@@ -277,16 +277,12 @@ def pytest_collection_modifyitems(items: list) -> None:
 
         # Add the split key(s) to nodeid as suffix. Recognized by the scheduler to spread
         # tests sharing a heavy runtime resource across workers, without grouping them.
-        # Multiple keys can be supplied as a comma-separated string for tests that lock
-        # several shared resources (e.g. "governance,plutus").
+        # Multiple keys can be supplied as separate positional args for tests that lock
+        # several shared resources (e.g. ``xdist_split("governance", "plutus")``).
         if split_marker:
-            skey = (
-                split_marker.args[0]
-                if len(split_marker.args) > 0
-                else split_marker.kwargs.get("name", "default")
-            )
-            for raw in skey.split(","):
-                k = raw.strip()
+            skeys = split_marker.args or (split_marker.kwargs.get("name", "default"),)
+            for raw in skeys:
+                k = str(raw).strip()
                 if k:
                     comps.append(f"{SPLIT_NODEID_PREFIX}{k}")
 

--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -1,4 +1,5 @@
 import contextlib
+import enum
 import logging
 import string
 import time
@@ -30,6 +31,27 @@ ORDER5_BYRON = (
     pytest.mark.order(5) if "_fast" not in configuration.TESTNET_VARIANT else pytest.mark.noop
 )
 LONG_BYRON = pytest.mark.long if "_fast" not in configuration.TESTNET_VARIANT else pytest.mark.noop
+
+
+class XdSplits(enum.StrEnum):
+    """Known split keys for the ``xdist_split`` pytest marker.
+
+    Each member names a heavy shared resource. Tests that lock such a resource
+    declare the matching key (or several, as separate positional args) so the
+    custom xdist scheduler caps concurrent in-flight tests sharing the key at
+    the cluster instance capacity, instead of letting workers stall on the
+    cluster manager. See ``cardano_node_tests.pytest_plugins.xdist_scheduler``.
+
+    Example:
+        ``@pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)``
+
+    Members:
+        governance: Governance setup (committee, DReps, constitution, etc.).
+        plutus: Plutus cost model / built-ins state shared across tests.
+    """
+
+    governance = "governance"
+    plutus = "plutus"
 
 
 _BLD_SKIP_REASON = ""

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -566,7 +566,7 @@ class TestCommittee:
         [r.success() for r in (reqc.db010, reqc.db011)]
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     @pytest.mark.dbsync
     @pytest.mark.dbsync_config
@@ -1356,7 +1356,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_empty_committee(
         self,
@@ -1719,7 +1719,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_committee_zero_threshold(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -312,7 +312,7 @@ class TestConstitution:
     """Tests for constitution."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.dbsync
     @pytest.mark.long
     def test_change_constitution(

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -1632,7 +1632,7 @@ class TestDRepActivity:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(5)
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_drep_inactivity(  # noqa: C901
         self,

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -1565,7 +1565,7 @@ def get_subtests() -> tp.Generator[tp.Callable]:  # noqa: C901
 
 class TestGovernanceGuardrails:
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_guardrails(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -47,7 +47,7 @@ class TestHardfork:
     """Tests for hard-fork."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_hardfork(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_no_confidence.py
+++ b/cardano_node_tests/tests/tests_conway/test_no_confidence.py
@@ -52,7 +52,7 @@ class TestNoConfidence:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_no_confidence_action(
         self,
@@ -321,7 +321,7 @@ class TestNoConfidence:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split("governance")
+    @pytest.mark.xdist_split(common.XdSplits.governance)
     @pytest.mark.long
     def test_committee_min_size(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -261,7 +261,7 @@ class TestPParamUpdate:
     """Tests for protocol parameters update."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split("governance,plutus")
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)
     @pytest.mark.long
     @pytest.mark.dbsync
     def test_pparam_update(  # noqa: C901

--- a/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
+++ b/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
@@ -65,7 +65,7 @@ class TestUpdateBuiltIns:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split("governance,plutus")
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)
     @pytest.mark.long
     @pytest.mark.upgrade_step1
     def test_update_in_pv9(


### PR DESCRIPTION
Add `common.XdSplits` StrEnum to centralize known xdist_split keys (governance, plutus) and replace string literals at callsites. Extend the `xdist_split` marker to accept multiple keys as separate positional args instead of a comma-separated string, killing the f-string CSV idiom for tests locking several shared resources.