### PR TITLE
Refactor protocol version handling and update bitwise script gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can fine-tune test runs using these environment variables:
 | ------------------------------- | --------------------------------------------------- |
 | `BOOTSTRAP_DIR`                 | Bootstrap testnet directory.                        |
 | `CLUSTERS_COUNT`                | Number of clusters to launch (default: 9).          |
-| `CLUSTER_ERA`                   | Cluster era (default: `conway`).                    |
+| `CLUSTER_ERA`                   | Testnet Cluster era (default: `conway`).            |
 | `COMMAND_ERA`                   | CLI command target era.                             |
 | `KEEP_CLUSTERS_RUNNING`         | Don't shut down clusters after tests.               |
 | `MARKEXPR`                      | Marker expression for pytest filtering.             |

--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -294,7 +294,14 @@ UNDETERMINED_COST = ExecutionCost(
 )
 
 
-# ----- All succeeding bitwise tests ----- #
+# Rotate/shift bitwise builtins succeed pre-PV11 and fail under PV11+ on node >= 11.0.0.
+_ROTATE_SHIFT_SCRIPTS_V3 = (
+    ("succeedingRotateByteStringPolicyScriptV3.plutus", 22767760, 109004, 7932),
+    ("succeedingShiftByteStringPolicyScriptV3.plutus", 17914625, 85787, 6242),
+)
+_ROTATE_SHIFT_NAMES_V3 = tuple(s[0] for s in _ROTATE_SHIFT_SCRIPTS_V3)
+_PV11_BITWISE_FAILS = VERSIONS.cluster_era >= 11 and VERSIONS.node >= version.parse("11.0.0")
+
 
 # Tuples of (script_name, per_time, per_space, fixed_cost) for each succeeding bitwise script.
 SUCCEEDING_BITWISE_SCRIPTS_V3 = (
@@ -306,22 +313,10 @@ SUCCEEDING_BITWISE_SCRIPTS_V3 = (
     ("succeedingFindFirstSetBitPolicyScriptV3.plutus", 8071583, 40221, 2903),
     ("succeedingReadBitPolicyScriptV3.plutus", 15272720, 82724, 5875),
     ("succeedingReplicateBytePolicyScriptV3.plutus", 4585827, 22946, 1655),
-    ("succeedingRotateByteStringPolicyScriptV3.plutus", 22767760, 109004, 7932),
-    ("succeedingShiftByteStringPolicyScriptV3.plutus", 17914625, 85787, 6242),
     ("succeedingWriteBitsPolicyScriptV3.plutus", 90629019, 462457, 33219),
+    *(() if _PV11_BITWISE_FAILS else _ROTATE_SHIFT_SCRIPTS_V3),
 )
 
-SUCCEEDING_MINTING_BITWISE_SCRIPTS_V3 = tuple(
-    PlutusScriptData(
-        script_file=SCRIPTS_V3_DIR / script_name,
-        script_type=clusterlib.ScriptTypes.PLUTUS_V3,
-        execution_cost=ExecutionCost(per_time=per_time, per_space=per_space, fixed_cost=fixed_cost),
-    )
-    for script_name, per_time, per_space, fixed_cost in SUCCEEDING_BITWISE_SCRIPTS_V3
-)
-
-
-# ----- All failing bitwise tests ----- #
 
 FAILING_BITWISE_SCRIPT_FILES_V3 = (
     "failingReadBitPolicyScriptV3_1.plutus",
@@ -363,6 +358,17 @@ FAILING_BITWISE_SCRIPT_FILES_V3 = (
     "failingWriteBitsPolicyScriptV3_17.plutus",
     "failingWriteBitsPolicyScriptV3_18.plutus",
     "failingWriteBitsPolicyScriptV3_19.plutus",
+    *(_ROTATE_SHIFT_NAMES_V3 if _PV11_BITWISE_FAILS else ()),
+)
+
+
+SUCCEEDING_MINTING_BITWISE_SCRIPTS_V3 = tuple(
+    PlutusScriptData(
+        script_file=SCRIPTS_V3_DIR / script_name,
+        script_type=clusterlib.ScriptTypes.PLUTUS_V3,
+        execution_cost=ExecutionCost(per_time=per_time, per_space=per_space, fixed_cost=fixed_cost),
+    )
+    for script_name, per_time, per_space, fixed_cost in SUCCEEDING_BITWISE_SCRIPTS_V3
 )
 
 
@@ -388,6 +394,106 @@ SUCCEEDING_MINTING_RIPEMD_160_SCRIPTS_V3 = (MINTING_RIPEMD_160_V3,)
 #
 # Includes tests for casing on constants, which will be released together with batch 6 in PV 11
 
+# Extra batch6 scripts available only on node >= 10.7.0.
+_NODE_10_7_PLUS = VERSIONS.node >= version.parse("10.7.0")
+_BATCH6_NODE_10_7_EXTRA_SUCCEEDING = (
+    ("succeedingG1MultiScalarMulPolicyScript1_V3_110.plutus", 9183574944, 437274, 687367),
+    ("succeedingG1MultiScalarMulPolicyScript2_V3_110.plutus", 9915620336, 477870, 742490),
+    ("succeedingG2MultiScalarMulPolicyScript1a_V3_110.plutus", 9008519498, 199418, 661021),
+    ("succeedingG2MultiScalarMulPolicyScript1b_V3_110.plutus", 7170645678, 250628, 531465),
+    ("succeedingG2MultiScalarMulPolicyScript2a_V3_110.plutus", 8521851043, 193470, 625589),
+    ("succeedingG2MultiScalarMulPolicyScript2b_V3_110.plutus", 9372322810, 304876, 693336),
+    ("succeedingDeleteExistingCoinPolicyScript_V3_100.plutus", 2272287, 6579, 544),
+    ("succeedingDeleteExistingCoinPolicyScript_V3_110.plutus", 2176287, 5979, 502),
+    ("succeedingDeleteMissingCoinPolicyScript_V3_100.plutus", 2291175, 6579, 545),
+    ("succeedingDeleteMissingCoinPolicyScript_V3_110.plutus", 2195175, 5979, 504),
+    ("succeedingInsertExistingCoinPolicyScript_V3_100.plutus", 2291175, 6579, 545),
+    ("succeedingInsertExistingCoinPolicyScript_V3_110.plutus", 2195175, 5979, 504),
+    ("succeedingInsertNewCoinPolicyScript_V3_100.plutus", 1769425, 5692, 457),
+    ("succeedingInsertNewCoinPolicyScript_V3_110.plutus", 1673425, 5092, 415),
+    ("succeedingLookupMissingCoinPolicyScript_V3_100.plutus", 1265613, 4847, 371),
+    ("succeedingLookupMissingCoinPolicyScript_V3_110.plutus", 1169613, 4247, 330),
+    ("succeedingScaleValueNegativePolicyScript_V3_100.plutus", 3973637, 7417, 715),
+    ("succeedingScaleValueNegativePolicyScript_V3_110.plutus", 3877637, 6817, 673),
+    ("succeedingScaleValuePositivePolicyScript_V3_100.plutus", 3973637, 7417, 715),
+    ("succeedingScaleValuePositivePolicyScript_V3_110.plutus", 3877637, 6817, 673),
+    ("succeedingScaleValueZeroPolicyScript_V3_100.plutus", 2846094, 6228, 565),
+    ("succeedingScaleValueZeroPolicyScript_V3_110.plutus", 2750094, 5628, 524),
+    ("succeedingUnionValueAssociativePolicyScript_V3_100.plutus", 7288077, 11023, 1162),
+    ("succeedingUnionValueAssociativePolicyScript_V3_110.plutus", 7192077, 10423, 1120),
+    (
+        "succeedingUnionValueAssociativeSingleCoinPolicyScript_V3_100.plutus",
+        5989072,
+        10893,
+        1061,
+    ),
+    (
+        "succeedingUnionValueAssociativeSingleCoinPolicyScript_V3_110.plutus",
+        5893072,
+        10293,
+        1019,
+    ),
+    ("succeedingUnionValueCommutativePolicyScript_V3_100.plutus", 4964712, 8860, 870),
+    ("succeedingUnionValueCommutativePolicyScript_V3_110.plutus", 4868712, 8260, 828),
+    ("succeedingUnionValueCommutativeSingleCoinPolicyScript_V3_100.plutus", 4615604, 8816, 842),
+    ("succeedingUnionValueCommutativeSingleCoinPolicyScript_V3_110.plutus", 4519604, 8216, 800),
+    ("succeedingUnionValueEmptyIdentityPolicyScript_V3_100.plutus", 5679334, 9379, 951),
+    ("succeedingUnionValueEmptyIdentityPolicyScript_V3_110.plutus", 5583334, 8779, 910),
+    ("succeedingUnionValueInversablePolicyScript_V3_100.plutus", 3456713, 7406, 677),
+    ("succeedingUnionValueInversablePolicyScript_V3_110.plutus", 3360713, 6806, 636),
+    ("succeedingValueContainsDisjointPolicyScript_V3_100.plutus", 2611834, 6536, 566),
+    ("succeedingValueContainsDisjointPolicyScript_V3_110.plutus", 2515834, 5936, 524),
+    ("succeedingValueContainsEmptyPolicyScript_V3_100.plutus", 3522852, 7880, 709),
+    ("succeedingValueContainsEmptyPolicyScript_V3_110.plutus", 3426852, 7280, 668),
+    ("succeedingValueContainsIsSubValuePolicyScript_V3_100.plutus", 3087582, 7123, 634),
+    ("succeedingValueContainsIsSubValuePolicyScript_V3_110.plutus", 2991582, 6523, 593),
+    ("succeedingValueContainsReflexivePolicyScript_V3_100.plutus", 2078910, 5391, 461),
+    ("succeedingValueContainsReflexivePolicyScript_V3_110.plutus", 1982910, 4791, 420),
+    ("succeedingValueContainsRightExtraKeyPolicyScript_V3_100.plutus", 3637590, 8010, 725),
+    ("succeedingValueContainsRightExtraKeyPolicyScript_V3_110.plutus", 3541590, 7410, 683),
+    ("succeedingValueContainsRightHigherAmountPolicyScript_V3_100.plutus", 2563834, 6236, 545),
+    ("succeedingValueContainsRightHigherAmountPolicyScript_V3_110.plutus", 2467834, 5636, 504),
+    ("succeedingValueDataRoundTripPolicyScript_V3_100.plutus", 3610826, 6095, 613),
+    ("succeedingValueDataRoundTripPolicyScript_V3_110.plutus", 3514826, 5495, 571),
+    (
+        "succeedingValueContainsIsSubValueSmallerAmountPolicyScript_V3_100.plutus",
+        3087582,
+        7123,
+        634,
+    ),
+    (
+        "succeedingValueContainsIsSubValueSmallerAmountPolicyScript_V3_110.plutus",
+        2991582,
+        6523,
+        593,
+    ),
+)
+_BATCH6_NODE_10_7_EXTRA_FAILING = (
+    "failingInsertInvalidCurrencySymbolPolicyScript_V3_100.plutus",
+    "failingInsertInvalidCurrencySymbolPolicyScript_V3_110.plutus",
+    "failingInsertInvalidTokenNamePolicyScript_V3_100.plutus",
+    "failingInsertInvalidTokenNamePolicyScript_V3_110.plutus",
+    "failingInsertOverflowQuantityPolicyScript_V3_100.plutus",
+    "failingInsertOverflowQuantityPolicyScript_V3_110.plutus",
+    "failingInsertUnderflowQuantityPolicyScript_V3_100.plutus",
+    "failingInsertUnderflowQuantityPolicyScript_V3_110.plutus",
+    "failingScaleValueOverflowPolicyScript_V3_100.plutus",
+    "failingScaleValueOverflowPolicyScript_V3_110.plutus",
+    "failingScaleValueUnderflowPolicyScript_V3_100.plutus",
+    "failingScaleValueUnderflowPolicyScript_V3_110.plutus",
+    "failingUnValueDataInvalidDataPolicyScript_V3_100.plutus",
+    "failingUnValueDataInvalidDataPolicyScript_V3_110.plutus",
+    "failingUnionValueOverflowPolicyScript_V3_100.plutus",
+    "failingUnionValueOverflowPolicyScript_V3_110.plutus",
+    "failingUnionValueUnderflowPolicyScript_V3_100.plutus",
+    "failingUnionValueUnderflowPolicyScript_V3_110.plutus",
+    "failingValueContainsLeftNegativePolicyScript_V3_100.plutus",
+    "failingValueContainsLeftNegativePolicyScript_V3_110.plutus",
+    "failingValueContainsRightNegativePolicyScript_V3_100.plutus",
+    "failingValueContainsRightNegativePolicyScript_V3_110.plutus",
+)
+
+
 # Tuples of (script_name, per_time, per_space, fixed_cost) for each succeeding batch6 script.
 SUCCEEDING_BATCH6_SCRIPTS_V3 = (
     ("caseBoolHappy_V3_110.plutus", 208100, 1400, 96),
@@ -402,6 +508,7 @@ SUCCEEDING_BATCH6_SCRIPTS_V3 = (
     ("succeedingIndexArrayPolicyScript_V3_110.plutus", 2831492, 12706, 938),
     ("succeedingLengthOfArrayPolicyScript_V3_110.plutus", 2060965, 9018, 669),
     ("succeedingListToArrayPolicyScript_V3_110.plutus", 3918949, 15619, 1184),
+    *(_BATCH6_NODE_10_7_EXTRA_SUCCEEDING if _NODE_10_7_PLUS else ()),
 )
 
 FAILING_BATCH6_SCRIPT_FILES_V3 = (
@@ -435,6 +542,7 @@ FAILING_BATCH6_SCRIPT_FILES_V3 = (
     "failingExpModIntegerScript_V3_110_7.plutus",
     "failingExpModIntegerScript_V3_110_8.plutus",
     "failingExpModIntegerScript_V3_110_9.plutus",
+    *(_BATCH6_NODE_10_7_EXTRA_FAILING if _NODE_10_7_PLUS else ()),
 )
 
 OVERSPENDING_BATCH6_SCRIPT_FILES_V3 = (
@@ -444,106 +552,6 @@ OVERSPENDING_BATCH6_SCRIPT_FILES_V3 = (
     "expensiveDropListPolicyScript_V3_110_4.plutus",
     "expensiveDropListPolicyScript_V3_110_5.plutus",
 )
-
-if VERSIONS.node >= version.parse("10.7.0"):
-    SUCCEEDING_BATCH6_SCRIPTS_V3 = (  # type: ignore[assignment]
-        *SUCCEEDING_BATCH6_SCRIPTS_V3,
-        ("succeedingG1MultiScalarMulPolicyScript1_V3_110.plutus", 9183574944, 437274, 687367),
-        ("succeedingG1MultiScalarMulPolicyScript2_V3_110.plutus", 9915620336, 477870, 742490),
-        ("succeedingG2MultiScalarMulPolicyScript1a_V3_110.plutus", 9008519498, 199418, 661021),
-        ("succeedingG2MultiScalarMulPolicyScript1b_V3_110.plutus", 7170645678, 250628, 531465),
-        ("succeedingG2MultiScalarMulPolicyScript2a_V3_110.plutus", 8521851043, 193470, 625589),
-        ("succeedingG2MultiScalarMulPolicyScript2b_V3_110.plutus", 9372322810, 304876, 693336),
-        ("succeedingDeleteExistingCoinPolicyScript_V3_100.plutus", 2272287, 6579, 544),
-        ("succeedingDeleteExistingCoinPolicyScript_V3_110.plutus", 2176287, 5979, 502),
-        ("succeedingDeleteMissingCoinPolicyScript_V3_100.plutus", 2291175, 6579, 545),
-        ("succeedingDeleteMissingCoinPolicyScript_V3_110.plutus", 2195175, 5979, 504),
-        ("succeedingInsertExistingCoinPolicyScript_V3_100.plutus", 2291175, 6579, 545),
-        ("succeedingInsertExistingCoinPolicyScript_V3_110.plutus", 2195175, 5979, 504),
-        ("succeedingInsertNewCoinPolicyScript_V3_100.plutus", 1769425, 5692, 457),
-        ("succeedingInsertNewCoinPolicyScript_V3_110.plutus", 1673425, 5092, 415),
-        ("succeedingLookupMissingCoinPolicyScript_V3_100.plutus", 1265613, 4847, 371),
-        ("succeedingLookupMissingCoinPolicyScript_V3_110.plutus", 1169613, 4247, 330),
-        ("succeedingScaleValueNegativePolicyScript_V3_100.plutus", 3973637, 7417, 715),
-        ("succeedingScaleValueNegativePolicyScript_V3_110.plutus", 3877637, 6817, 673),
-        ("succeedingScaleValuePositivePolicyScript_V3_100.plutus", 3973637, 7417, 715),
-        ("succeedingScaleValuePositivePolicyScript_V3_110.plutus", 3877637, 6817, 673),
-        ("succeedingScaleValueZeroPolicyScript_V3_100.plutus", 2846094, 6228, 565),
-        ("succeedingScaleValueZeroPolicyScript_V3_110.plutus", 2750094, 5628, 524),
-        ("succeedingUnionValueAssociativePolicyScript_V3_100.plutus", 7288077, 11023, 1162),
-        ("succeedingUnionValueAssociativePolicyScript_V3_110.plutus", 7192077, 10423, 1120),
-        (
-            "succeedingUnionValueAssociativeSingleCoinPolicyScript_V3_100.plutus",
-            5989072,
-            10893,
-            1061,
-        ),
-        (
-            "succeedingUnionValueAssociativeSingleCoinPolicyScript_V3_110.plutus",
-            5893072,
-            10293,
-            1019,
-        ),
-        ("succeedingUnionValueCommutativePolicyScript_V3_100.plutus", 4964712, 8860, 870),
-        ("succeedingUnionValueCommutativePolicyScript_V3_110.plutus", 4868712, 8260, 828),
-        ("succeedingUnionValueCommutativeSingleCoinPolicyScript_V3_100.plutus", 4615604, 8816, 842),
-        ("succeedingUnionValueCommutativeSingleCoinPolicyScript_V3_110.plutus", 4519604, 8216, 800),
-        ("succeedingUnionValueEmptyIdentityPolicyScript_V3_100.plutus", 5679334, 9379, 951),
-        ("succeedingUnionValueEmptyIdentityPolicyScript_V3_110.plutus", 5583334, 8779, 910),
-        ("succeedingUnionValueInversablePolicyScript_V3_100.plutus", 3456713, 7406, 677),
-        ("succeedingUnionValueInversablePolicyScript_V3_110.plutus", 3360713, 6806, 636),
-        ("succeedingValueContainsDisjointPolicyScript_V3_100.plutus", 2611834, 6536, 566),
-        ("succeedingValueContainsDisjointPolicyScript_V3_110.plutus", 2515834, 5936, 524),
-        ("succeedingValueContainsEmptyPolicyScript_V3_100.plutus", 3522852, 7880, 709),
-        ("succeedingValueContainsEmptyPolicyScript_V3_110.plutus", 3426852, 7280, 668),
-        ("succeedingValueContainsIsSubValuePolicyScript_V3_100.plutus", 3087582, 7123, 634),
-        ("succeedingValueContainsIsSubValuePolicyScript_V3_110.plutus", 2991582, 6523, 593),
-        ("succeedingValueContainsReflexivePolicyScript_V3_100.plutus", 2078910, 5391, 461),
-        ("succeedingValueContainsReflexivePolicyScript_V3_110.plutus", 1982910, 4791, 420),
-        ("succeedingValueContainsRightExtraKeyPolicyScript_V3_100.plutus", 3637590, 8010, 725),
-        ("succeedingValueContainsRightExtraKeyPolicyScript_V3_110.plutus", 3541590, 7410, 683),
-        ("succeedingValueContainsRightHigherAmountPolicyScript_V3_100.plutus", 2563834, 6236, 545),
-        ("succeedingValueContainsRightHigherAmountPolicyScript_V3_110.plutus", 2467834, 5636, 504),
-        ("succeedingValueDataRoundTripPolicyScript_V3_100.plutus", 3610826, 6095, 613),
-        ("succeedingValueDataRoundTripPolicyScript_V3_110.plutus", 3514826, 5495, 571),
-        (
-            "succeedingValueContainsIsSubValueSmallerAmountPolicyScript_V3_100.plutus",
-            3087582,
-            7123,
-            634,
-        ),
-        (
-            "succeedingValueContainsIsSubValueSmallerAmountPolicyScript_V3_110.plutus",
-            2991582,
-            6523,
-            593,
-        ),
-    )
-    FAILING_BATCH6_SCRIPT_FILES_V3 = (  # type: ignore[assignment]
-        *FAILING_BATCH6_SCRIPT_FILES_V3,
-        "failingInsertInvalidCurrencySymbolPolicyScript_V3_100.plutus",
-        "failingInsertInvalidCurrencySymbolPolicyScript_V3_110.plutus",
-        "failingInsertInvalidTokenNamePolicyScript_V3_100.plutus",
-        "failingInsertInvalidTokenNamePolicyScript_V3_110.plutus",
-        "failingInsertOverflowQuantityPolicyScript_V3_100.plutus",
-        "failingInsertOverflowQuantityPolicyScript_V3_110.plutus",
-        "failingInsertUnderflowQuantityPolicyScript_V3_100.plutus",
-        "failingInsertUnderflowQuantityPolicyScript_V3_110.plutus",
-        "failingScaleValueOverflowPolicyScript_V3_100.plutus",
-        "failingScaleValueOverflowPolicyScript_V3_110.plutus",
-        "failingScaleValueUnderflowPolicyScript_V3_100.plutus",
-        "failingScaleValueUnderflowPolicyScript_V3_110.plutus",
-        "failingUnValueDataInvalidDataPolicyScript_V3_100.plutus",
-        "failingUnValueDataInvalidDataPolicyScript_V3_110.plutus",
-        "failingUnionValueOverflowPolicyScript_V3_100.plutus",
-        "failingUnionValueOverflowPolicyScript_V3_110.plutus",
-        "failingUnionValueUnderflowPolicyScript_V3_100.plutus",
-        "failingUnionValueUnderflowPolicyScript_V3_110.plutus",
-        "failingValueContainsLeftNegativePolicyScript_V3_100.plutus",
-        "failingValueContainsLeftNegativePolicyScript_V3_110.plutus",
-        "failingValueContainsRightNegativePolicyScript_V3_100.plutus",
-        "failingValueContainsRightNegativePolicyScript_V3_110.plutus",
-    )
 
 
 def _get_script_data_succ(r: tuple) -> PlutusScriptData:

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -928,7 +928,7 @@ class TestQueryUTxO:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era != VERSIONS.DEFAULT_CLUSTER_ERA,
+        VERSIONS.transaction_era < VERSIONS.DEFAULT_CLUSTER_ERA,
         reason="works only with the latest TX era",
     )
     @pytest.mark.smoke

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -340,6 +340,11 @@ def get_instance_num() -> int:
 
 def get_cluster_env() -> ClusterEnv:
     """Get cardano cluster environment."""
+    # VERSIONS executes cardano-node and cardano-cli, and the binaries may not be available.
+    # Importing VERSIONS here allows to delay the execution until it's really needed, and avoid
+    # potential issues with missing binaries when the module is imported.
+    from cardano_node_tests.utils.versions import VERSIONS  # noqa: PLC0415
+
     socket_path = pl.Path(os.environ["CARDANO_NODE_SOCKET_PATH"])
     state_dir = socket_path.parent
     work_dir = state_dir.parent
@@ -350,8 +355,8 @@ def get_cluster_env() -> ClusterEnv:
         state_dir=state_dir,
         work_dir=work_dir,
         instance_num=instance_num,
-        cluster_era=configuration.CLUSTER_ERA,
-        command_era=configuration.COMMAND_ERA,
+        cluster_era=VERSIONS.cluster_era_name,
+        command_era=VERSIONS.command_era_name,
     )
     return cluster_env
 

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -1,5 +1,6 @@
 """Cardano node version, cluster era, transaction era, db-sync version."""
 
+import os
 import typing as tp
 
 from packaging import version
@@ -9,9 +10,17 @@ from cardano_node_tests.utils import helpers
 
 
 class Versions:
-    """Cluster era, transaction era, node version info."""
+    """Protocol version, cluster era, transaction era, node version info.
 
-    # Era names for latest corresponding (or current mainnet) protocol version
+    Note:
+        ``cluster_era`` holds the current protocol version (set via the
+        ``PROTOCOL_VERSION`` env var, defaulting to ``DEFAULT_CLUSTER_ERA``),
+        while ``cluster_era_name`` is the era name that corresponds to that
+        protocol version. The era constants below (e.g. ``CONWAY``) are the
+        latest protocol version associated with each era.
+    """
+
+    # Latest protocol version associated with each era
     BYRON: tp.Final[int] = 1
     SHELLEY: tp.Final[int] = 2
     ALLEGRA: tp.Final[int] = 3
@@ -44,17 +53,26 @@ class Versions:
     }
 
     def __init__(self) -> None:
-        self.cluster_era_name = configuration.CLUSTER_ERA or self.MAP[self.DEFAULT_CLUSTER_ERA]
-        self.cluster_era = getattr(self, self.cluster_era_name.upper())
+        protocol_version = int(os.environ.get("PROTOCOL_VERSION") or self.DEFAULT_CLUSTER_ERA)
+        if protocol_version not in self.MAP:
+            msg = (
+                f"Unsupported PROTOCOL_VERSION {protocol_version}; "
+                f"expected one of {sorted(self.MAP)}"
+            )
+            raise ValueError(msg)
+
+        self.cluster_era = protocol_version
+        self.cluster_era_name = self.MAP[self.cluster_era]
 
         self.command_era_name = configuration.COMMAND_ERA
 
+        self.transaction_era = protocol_version
         if self.command_era_name and self.command_era_name in self.MAP.values():
             self.transaction_era_name: str = self.command_era_name
+            if self.MAP[self.transaction_era] != self.transaction_era_name:
+                self.transaction_era = getattr(self, self.transaction_era_name.upper())
         else:
-            self.transaction_era_name = self.MAP[self.DEFAULT_TX_ERA]
-
-        self.transaction_era = getattr(self, self.transaction_era_name.upper())
+            self.transaction_era_name = self.MAP[self.transaction_era]
 
         node_version_db = self.get_cardano_node_version()
         self.node = version.parse(node_version_db["version"])

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -375,6 +375,7 @@ elif [ "$1" = "step3" ]; then
 
   # Hard fork
   pytest cardano_node_tests/tests/test_node_upgrade.py -k test_hardfork || exit 6
+  export PROTOCOL_VERSION=11
 
   # Run smoke tests
   printf "STEP3 tests: %(%H:%M:%S)T\n" -1


### PR DESCRIPTION
This pull request introduces several important updates to the test infrastructure and Plutus script handling, primarily focusing on protocol versioning, environment variable usage, and the conditional inclusion of Plutus scripts based on node and protocol versions. The changes improve clarity and flexibility in test configuration and ensure correct test coverage for different Cardano node versions.

**Protocol version and era handling:**

* Refactored the `VERSIONS` utility to use a `PROTOCOL_VERSION` environment variable for protocol selection, defaulting to the latest cluster era if not set. This also introduces `cluster_era` (protocol version number) and `cluster_era_name` (era name), clarifying their distinction and usage throughout the codebase. (`cardano_node_tests/utils/versions.py`) [[1]](diffhunk://#diff-6db786c8bb74f48f8d8d791b2e56426ae679b8dbbe27d808b66ee61e46947cb8L12-R23) [[2]](diffhunk://#diff-6db786c8bb74f48f8d8d791b2e56426ae679b8dbbe27d808b66ee61e46947cb8L47-R75)
* Updated cluster environment construction to use `VERSIONS.cluster_era_name` and `VERSIONS.command_era_name` instead of configuration values, ensuring consistency with the new protocol versioning logic. (`cardano_node_tests/utils/cluster_nodes.py`)

**Plutus script test selection improvements:**

* Modified the lists of succeeding and failing Plutus V3 bitwise scripts to conditionally include rotate/shift scripts based on protocol and node version, reflecting their changed behavior in PV11+. (`cardano_node_tests/tests/plutus_common.py`) [[1]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957L297-R304) [[2]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957L309-L324) [[3]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957R361-R371)
* Refactored batch6 script lists to conditionally include extra scripts for node >= 10.7.0, improving maintainability and correctness. (`cardano_node_tests/tests/plutus_common.py`) [[1]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957L391-R399) [[2]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957L522-R471) [[3]](diffhunk://#diff-740f63a549818774bf5930af3ff41572b3da6cee1feb8555b603a3bdd8ddc957R497-R556)

**Test runner and documentation updates:**

* Updated the test runner to export `PROTOCOL_VERSION=11` before running smoke tests in upgrade scenarios, ensuring the correct protocol is tested post-upgrade. (`runner/node_upgrade_pytest.sh`)
* Clarified the `CLUSTER_ERA` environment variable description in the documentation to indicate it refers to the testnet cluster era. (`README.md`)

**Test logic correction:**

* Fixed a test skip condition to ensure tests only run when the transaction era is at least the default cluster era, not just equal. (`cardano_node_tests/tests/test_cli.py`)