### PR TITLE
refactor(config): centralize env var parsing helpers

### DIFF
--- a/cardano_node_tests/pytest_plugins/xdist_scheduler.py
+++ b/cardano_node_tests/pytest_plugins/xdist_scheduler.py
@@ -16,6 +16,21 @@ SPLIT_NODEID_PREFIX = "split="
 DEFAULT_MAX_CLUSTERS = 9
 
 
+def _get_env_int(var: str, default: int) -> int:
+    """Read int env var, raising informative ValueError on malformed value.
+
+    Local copy to keep this pytest plugin free of framework-package imports.
+    """
+    raw = os.environ.get(var)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as err:
+        msg = f"Invalid integer value for env var '{var}': {raw!r}"
+        raise ValueError(msg) from err
+
+
 class OneLongScheduling(scheduler.LoadScopeScheduling):
     """Scheduling plugin with long-test balancing and split-key dispersion.
 
@@ -88,7 +103,7 @@ class OneLongScheduling(scheduler.LoadScopeScheduling):
         # DEFAULT_MAX_CLUSTERS; final fallback to 1.
         # PYTEST_XDIST_WORKER_COUNT is NOT used here: xdist sets it only inside
         # worker subprocesses, never on the controller where the scheduler runs.
-        env_count = int(os.environ.get("CLUSTERS_COUNT") or 0)
+        env_count = _get_env_int("CLUSTERS_COUNT", 0)
         self.clusters_count = env_count or min(self.numnodes, DEFAULT_MAX_CLUSTERS) or 1
 
     def _split_scope(self, nodeid: str) -> str:

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -110,9 +110,7 @@ def pytest_configure(config: tp.Any) -> None:
 
     network_magic = configuration.NETWORK_MAGIC_LOCAL
     if configuration.BOOTSTRAP_DIR:
-        with open(
-            pl.Path(configuration.BOOTSTRAP_DIR) / "genesis-shelley.json", encoding="utf-8"
-        ) as in_fp:
+        with open(configuration.BOOTSTRAP_DIR / "genesis-shelley.json", encoding="utf-8") as in_fp:
             genesis = json.load(in_fp)
         network_magic = genesis["networkMagic"]
     config.stash[metadata_key]["network magic"] = network_magic

--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -275,6 +275,7 @@ class TestCollectData:
     @pytest.fixture
     def block_production_db(self) -> tp.Generator[sqlite3.Connection]:
         """Open block production db."""
+        assert configuration.BLOCK_PRODUCTION_DB is not None
         conn = sqlite3.connect(configuration.BLOCK_PRODUCTION_DB)
         yield conn
         conn.close()
@@ -298,7 +299,7 @@ class TestCollectData:
         """
         temp_template = common.get_test_id(cluster)
         rand = clusterlib.get_rand_str(5)
-        num_epochs = int(os.environ.get("BLOCK_PRODUCTION_EPOCHS") or 50)
+        num_epochs = helpers.get_env_int("BLOCK_PRODUCTION_EPOCHS", 50)
         mixed_backends = (
             configuration.MIXED_UTXO_BACKENDS.split() if configuration.MIXED_UTXO_BACKENDS else []
         )

--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import pathlib as pl
 import shutil
 
@@ -26,7 +25,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 DATA_DIR = pl.Path(__file__).parent / "data"
-UPGRADE_TESTS_STEP = int(os.environ.get("UPGRADE_TESTS_STEP") or 0)
+UPGRADE_TESTS_STEP = helpers.get_env_int("UPGRADE_TESTS_STEP", 0)
 
 pytestmark = [
     pytest.mark.skipif(not UPGRADE_TESTS_STEP, reason="not upgrade testing"),

--- a/cardano_node_tests/tests/test_rollback.py
+++ b/cardano_node_tests/tests/test_rollback.py
@@ -24,7 +24,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 ROLLBACK_PAUSE = os.environ.get("ROLLBACK_PAUSE") is not None
-ROLLBACK_NODES_OFFSET = int(os.environ.get("ROLLBACK_NODES_OFFSET") or 1)
+ROLLBACK_NODES_OFFSET = helpers.get_env_int("ROLLBACK_NODES_OFFSET", 1)
 LAST_POOL_NAME = f"pool{configuration.NUM_POOLS}"
 
 

--- a/cardano_node_tests/tests/test_xdist_helper.py
+++ b/cardano_node_tests/tests/test_xdist_helper.py
@@ -5,11 +5,11 @@ gets scheduled as first not long-running test on every pytest worker so the othe
 an actual long-running test.
 """
 
-import os
-
 import pytest
 
-PYTEST_XDIST_WORKER_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 0)
+from cardano_node_tests.utils import helpers
+
+PYTEST_XDIST_WORKER_COUNT = helpers.get_env_int("PYTEST_XDIST_WORKER_COUNT", 0)
 
 pytestmark = pytest.mark.skipif(
     PYTEST_XDIST_WORKER_COUNT == 0, reason="helper test is not needed when running without xdist"

--- a/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
@@ -2,7 +2,6 @@
 
 import enum
 import logging
-import os
 import pathlib as pl
 import typing as tp
 
@@ -23,7 +22,7 @@ from cardano_node_tests.utils import helpers
 LOGGER = logging.getLogger(__name__)
 
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
-UPGRADE_TESTS_STEP = int(os.environ.get("UPGRADE_TESTS_STEP") or 0)
+UPGRADE_TESTS_STEP = helpers.get_env_int("UPGRADE_TESTS_STEP", 0)
 
 # Minimum protocol version required for batch5 built-in functions
 BATCH5_PROT_VERSION = 10

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -529,7 +529,7 @@ class TestnetScripts(ScriptsTypes):
             if not configuration.BOOTSTRAP_DIR:
                 msg = "The 'BOOTSTRAP_DIR' env variable is not set."
                 raise RuntimeError(msg)
-            bootstrap_conf_dir = pl.Path(configuration.BOOTSTRAP_DIR)
+            bootstrap_conf_dir = configuration.BOOTSTRAP_DIR
         if not self._is_bootstrap_conf_dir(bootstrap_conf_dir):
             msg = (
                 f"The 'BOOTSTRAP_DIR' is set to '{bootstrap_conf_dir}'"

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -12,14 +12,18 @@ TX_SUBMISSION_DELAY = 60
 DBSYNC_DB = "dbsync"
 IS_XDIST = bool(os.environ.get("PYTEST_XDIST_TESTRUNUID"))
 
+# Default upper bound on parallel cluster instances when neither CLUSTERS_COUNT
+# is set nor a worker count is available.
+DEFAULT_MAX_CLUSTERS = 9
+
 # Make sure the ports don't overlap with ephemeral port range. It's usually 32768 to 60999.
 # See `cat /proc/sys/net/ipv4/ip_local_port_range`.
-PORTS_BASE = int(os.environ.get("PORTS_BASE") or 23000)
+PORTS_BASE = helpers.get_env_int("PORTS_BASE", 23000)
 
 HAS_CC = not helpers.is_truthy_env_var("NO_CC")
 
 # Number of new blocks before the Tx is considered confirmed. Use default value if set to 0.
-CONFIRM_BLOCKS_NUM = int(os.environ.get("CONFIRM_BLOCKS_NUM") or 0)
+CONFIRM_BLOCKS_NUM = helpers.get_env_int("CONFIRM_BLOCKS_NUM", 0)
 
 # Used also in startup scripts
 UTXO_BACKEND = os.environ.get("UTXO_BACKEND") or ""
@@ -30,46 +34,42 @@ if UTXO_BACKEND not in ("", "mem", "disk", "disklmdb", "empty"):
 MIXED_UTXO_BACKENDS = os.environ.get("MIXED_UTXO_BACKENDS") or ""
 
 # Resolve CARDANO_NODE_SOCKET_PATH
-STARTUP_CARDANO_NODE_SOCKET_PATH = (
-    pl.Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).expanduser().resolve()
-)
+__socket_path = helpers.get_env_path("CARDANO_NODE_SOCKET_PATH")
+if __socket_path is None:
+    __msg = "The `CARDANO_NODE_SOCKET_PATH` env variable is not set."
+    raise RuntimeError(__msg)
+STARTUP_CARDANO_NODE_SOCKET_PATH: pl.Path = __socket_path
 os.environ["CARDANO_NODE_SOCKET_PATH"] = str(STARTUP_CARDANO_NODE_SOCKET_PATH)
 
 # Resolve SCHEDULING_LOG
-SCHEDULING_LOG: str | pl.Path = os.environ.get("SCHEDULING_LOG") or ""
-if SCHEDULING_LOG:
-    SCHEDULING_LOG = pl.Path(SCHEDULING_LOG).expanduser().resolve()
+SCHEDULING_LOG = helpers.get_env_path("SCHEDULING_LOG")
 
 # Resolve BLOCK_PRODUCTION_DB
-BLOCK_PRODUCTION_DB: str | pl.Path = os.environ.get("BLOCK_PRODUCTION_DB") or ""
-if BLOCK_PRODUCTION_DB:
-    BLOCK_PRODUCTION_DB = pl.Path(BLOCK_PRODUCTION_DB).expanduser().resolve()
+BLOCK_PRODUCTION_DB = helpers.get_env_path("BLOCK_PRODUCTION_DB")
 
 COMMAND_ERA = os.environ.get("COMMAND_ERA") or ""
 if COMMAND_ERA not in ("", "latest", "conway"):
     __msg = f"Invalid COMMAND_ERA: {COMMAND_ERA}"
     raise RuntimeError(__msg)
 
-XDIST_WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 0)
-MAX_TESTS_PER_CLUSTER = int(os.environ.get("MAX_TESTS_PER_CLUSTER") or 8)
+XDIST_WORKERS_COUNT = helpers.get_env_int("PYTEST_XDIST_WORKER_COUNT", 0)
+MAX_TESTS_PER_CLUSTER = helpers.get_env_int("MAX_TESTS_PER_CLUSTER", 8)
 # If CLUSTERS_COUNT is not set, use the number of xdist workers or 1
-CLUSTERS_COUNT = int(os.environ.get("CLUSTERS_COUNT") or 0)
-CLUSTERS_COUNT = int(CLUSTERS_COUNT or (min(XDIST_WORKERS_COUNT, 9)) or 1)
+CLUSTERS_COUNT = helpers.get_env_int("CLUSTERS_COUNT", 0)
+CLUSTERS_COUNT = CLUSTERS_COUNT or min(XDIST_WORKERS_COUNT, DEFAULT_MAX_CLUSTERS) or 1
 
 DEV_CLUSTER_RUNNING = helpers.is_truthy_env_var("DEV_CLUSTER_RUNNING")
 FORBID_RESTART = helpers.is_truthy_env_var("FORBID_RESTART")
 
-BOOTSTRAP_DIR: str | pl.Path = os.environ.get("BOOTSTRAP_DIR") or ""
-if BOOTSTRAP_DIR:
-    BOOTSTRAP_DIR = pl.Path(BOOTSTRAP_DIR).expanduser().resolve()
-    if not (BOOTSTRAP_DIR / "genesis-shelley.json").exists():
-        __msg = (
-            f"The `BOOTSTRAP_DIR` is set to '{BOOTSTRAP_DIR}'"
-            ", but the 'genesis-shelley.json' file is not found."
-        )
-        raise RuntimeError(__msg)
+BOOTSTRAP_DIR = helpers.get_env_path("BOOTSTRAP_DIR")
+if BOOTSTRAP_DIR and not (BOOTSTRAP_DIR / "genesis-shelley.json").exists():
+    __msg = (
+        f"The `BOOTSTRAP_DIR` is set to '{BOOTSTRAP_DIR}'"
+        ", but the 'genesis-shelley.json' file is not found."
+    )
+    raise RuntimeError(__msg)
 
-NUM_POOLS = int(os.environ.get("NUM_POOLS") or 3)
+NUM_POOLS = helpers.get_env_int("NUM_POOLS", 3)
 if not BOOTSTRAP_DIR and NUM_POOLS < 3:
     __msg = f"Invalid NUM_POOLS '{NUM_POOLS}': must be >= 3"
     raise RuntimeError(__msg)

--- a/cardano_node_tests/utils/dbsync_service_manager.py
+++ b/cardano_node_tests/utils/dbsync_service_manager.py
@@ -366,7 +366,7 @@ class DBSyncManager:
 
         db_script_template = common_scripts_dir / "postgres-setup.sh"
         if not db_script_template.exists() and configuration.BOOTSTRAP_DIR:
-            db_script_template = pl.Path(configuration.BOOTSTRAP_DIR) / "postgres-setup.sh"
+            db_script_template = configuration.BOOTSTRAP_DIR / "postgres-setup.sh"
 
         if not db_script_template.exists():
             err = f"Database setup script '{db_script_template}' not found."

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -78,6 +78,34 @@ def is_truthy_env_var(var: str) -> bool:
     return (os.environ.get(var) or "").lower() in ("1", "true", "yes", "y", "on", "enabled")
 
 
+def get_env_int(var: str, default: int) -> int:
+    """Read an integer environment variable.
+
+    Returns ``default`` when the variable is unset or empty. Raises a
+    ``ValueError`` naming the offending variable when the value is malformed.
+    """
+    raw = os.environ.get(var)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as err:
+        msg = f"Invalid integer value for env var '{var}': {raw!r}"
+        raise ValueError(msg) from err
+
+
+def get_env_path(var: str) -> pl.Path | None:
+    """Read a path environment variable.
+
+    Returns the resolved ``pathlib.Path`` (with ``~`` expanded) when set,
+    otherwise ``None``.
+    """
+    raw = os.environ.get(var)
+    if not raw:
+        return None
+    return pl.Path(raw).expanduser().resolve()
+
+
 def run_command(
     command: str | list,
     *,

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -1,6 +1,5 @@
 """Cardano node version, cluster era, transaction era, db-sync version."""
 
-import os
 import typing as tp
 
 from packaging import version
@@ -53,7 +52,7 @@ class Versions:
     }
 
     def __init__(self) -> None:
-        protocol_version = int(os.environ.get("PROTOCOL_VERSION") or self.DEFAULT_CLUSTER_ERA)
+        protocol_version = helpers.get_env_int("PROTOCOL_VERSION", self.DEFAULT_CLUSTER_ERA)
         if protocol_version not in self.MAP:
             msg = (
                 f"Unsupported PROTOCOL_VERSION {protocol_version}; "


### PR DESCRIPTION
Add `helpers.get_env_int` and `helpers.get_env_path` for consistent env var handling. `get_env_int` raises an informative `ValueError` on malformed input; `get_env_path` returns `pl.Path | None`.

Make `CARDANO_NODE_SOCKET_PATH` a required var with an explicit `RuntimeError` on missing value (was implicit `KeyError`). Drop redundant `pl.Path(...)` re-wraps at consumers now that `BOOTSTRAP_DIR`, `SCHEDULING_LOG`, and `BLOCK_PRODUCTION_DB` carry proper `Path` types.

The xdist scheduler keeps a local copy of the int helper to avoid importing the framework package from the pytest plugin.