### PR TITLE
feat(dbsync): update docstring warning format in recreate_database

### DIFF
--- a/cardano_node_tests/utils/dbsync_service_manager.py
+++ b/cardano_node_tests/utils/dbsync_service_manager.py
@@ -355,9 +355,9 @@ class DBSyncManager:
     def recreate_database(self) -> None:
         """Reinitializes the PostgreSQL database by running the `postgres-setup.sh` script.
 
-        !!! WARNING !!!
-        This is a DESTRUCTIVE operation!
-        It will delete existing data and recreate the database from scratch.
+        Warning:
+            This is a DESTRUCTIVE operation!
+            It will delete existing data and recreate the database from scratch.
         """
         common_scripts_dir = cluster_scripts.COMMON_DIR
         if not common_scripts_dir:


### PR DESCRIPTION
Reformats the warning in the `recreate_database` method docstring to use a standard "Warning:" block instead of emphasized text. No functional changes.