### PR TITLE
feat(tests): mark test as long in Plutus V3 mint build tests

### DIFF
--- a/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
@@ -270,6 +270,7 @@ class TestPlutusV3Builtins:
     batch6_overspend_scripts = plutus_common.OVERSPENDING_MINTING_BATCH6_SCRIPTS_V3
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.long
     @pytest.mark.team_plutus
     @pytest.mark.upgrade_step1
     @pytest.mark.upgrade_step2


### PR DESCRIPTION
Add @pytest.mark.long to the relevant test in `test_mint_build.py` to indicate it is a long-running test. This helps with test selection and CI configuration.