### PR TITLE
feat(tests): add `heavy` xdist_split key for cluster-locking tests

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -36,6 +36,12 @@ LONG_BYRON = pytest.mark.long if "_fast" not in configuration.TESTNET_VARIANT el
 class XdSplits(enum.StrEnum):
     """Known split keys for the ``xdist_split`` pytest marker.
 
+    Warning:
+        Do not combine this marker with ``cluster_manager.get(marker=...)``. The two
+        work against each other: ``marker=`` groups tagged tests onto the same cluster
+        instance so they run close together, while ``xdist_split`` spreads them across
+        workers to keep them apart.
+
     Each member names a heavy shared resource. Tests that lock such a resource
     declare the matching key (or several, as separate positional args) so the
     custom xdist scheduler caps concurrent in-flight tests sharing the key at
@@ -43,15 +49,15 @@ class XdSplits(enum.StrEnum):
     cluster manager. See ``cardano_node_tests.pytest_plugins.xdist_scheduler``.
 
     Example:
-        ``@pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)``
+        ``@pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)``
 
     Members:
         governance: Governance setup (committee, DReps, constitution, etc.).
-        plutus: Plutus cost model / built-ins state shared across tests.
+        heavy: Tests that require a lot of locked cluster resources.
     """
 
     governance = "governance"
-    plutus = "plutus"
+    heavy = "heavy"
 
 
 _BLD_SKIP_REASON = ""

--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -459,6 +459,7 @@ class TestDynamicBlockProd:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.long
     def test_dynamic_block_production(
         self,

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -135,6 +135,7 @@ class TestBasic:
     """Basic tests for node configuration."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     def test_epoch_length(self, cluster_epoch_length: clusterlib.ClusterLib):
         """Test the *epochLength* configuration.
 
@@ -157,6 +158,7 @@ class TestBasic:
         check_epoch_length(cluster)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     def test_slot_length(self, cluster_slot_length: clusterlib.ClusterLib):
         """Test the *slotLength* configuration.
 

--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -322,6 +322,7 @@ class TestDBSync:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.testnets
     def test_reconnect_dbsync(
         self,

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -134,6 +134,7 @@ class TestKES:
         reason="Runs only on local cluster with HF shortcut.",
     )
     @pytest.mark.order(5)
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.long
     def test_expired_kes(
         self,
@@ -348,6 +349,7 @@ class TestKES:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(6)
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.long
     def test_opcert_invalid_kes_period(
         self,
@@ -602,6 +604,7 @@ class TestKES:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(7)
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.long
     def test_update_valid_opcert(
         self,

--- a/cardano_node_tests/tests/test_pool_saturation.py
+++ b/cardano_node_tests/tests/test_pool_saturation.py
@@ -205,6 +205,7 @@ def _check_pool_records(pool_records: dict[int, PoolRecord]) -> None:
 class TestPoolSaturation:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(5)
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.long
     def test_oversaturated(  # noqa: C901
         self,

--- a/cardano_node_tests/tests/test_tx_mempool.py
+++ b/cardano_node_tests/tests/test_tx_mempool.py
@@ -34,6 +34,7 @@ class TestMempool:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.testnets
     def test_query_mempool_txin(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -566,7 +566,7 @@ class TestCommittee:
         [r.success() for r in (reqc.db010, reqc.db011)]
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     @pytest.mark.dbsync
     @pytest.mark.dbsync_config
@@ -1356,7 +1356,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_empty_committee(
         self,
@@ -1719,7 +1719,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_committee_zero_threshold(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -312,7 +312,7 @@ class TestConstitution:
     """Tests for constitution."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.dbsync
     @pytest.mark.long
     def test_change_constitution(

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -1632,7 +1632,7 @@ class TestDRepActivity:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(5)
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_drep_inactivity(  # noqa: C901
         self,

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -1565,7 +1565,7 @@ def get_subtests() -> tp.Generator[tp.Callable]:  # noqa: C901
 
 class TestGovernanceGuardrails:
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_guardrails(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -47,7 +47,7 @@ class TestHardfork:
     """Tests for hard-fork."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_hardfork(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_no_confidence.py
+++ b/cardano_node_tests/tests/tests_conway/test_no_confidence.py
@@ -52,7 +52,7 @@ class TestNoConfidence:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_no_confidence_action(
         self,
@@ -321,7 +321,7 @@ class TestNoConfidence:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split(common.XdSplits.governance)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     def test_committee_min_size(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -261,7 +261,7 @@ class TestPParamUpdate:
     """Tests for protocol parameters update."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     @pytest.mark.dbsync
     def test_pparam_update(  # noqa: C901

--- a/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
@@ -122,6 +122,7 @@ class TestTreasuryDonation:
         common.check_missing_utxos(cluster_obj=cluster, utxos=out_utxos)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.xdist_split(common.XdSplits.heavy)
     @pytest.mark.needs_dbsync
     def test_dbsync_transfer_treasury_donation(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
+++ b/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
@@ -65,7 +65,7 @@ class TestUpdateBuiltIns:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(not configuration.HAS_CC, reason="Runs only on setup with CC")
-    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     @pytest.mark.upgrade_step1
     def test_update_in_pv9(

--- a/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v3/test_mint_build.py
@@ -330,7 +330,7 @@ class TestPlutusV3Builtins:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.plutus)
+    @pytest.mark.xdist_split(common.XdSplits.governance, common.XdSplits.heavy)
     @pytest.mark.long
     @pytest.mark.team_plutus
     @pytest.mark.upgrade_step1


### PR DESCRIPTION
Replace the `plutus` split key with `heavy` to mark tests that hold scarce cluster resources (e.g. `cluster_singleton`) and are hard to schedule. Apply the marker to known heavy tests across blocks, KES, mempool, pool saturation, dbsync, configuration, treasury donation, and Conway governance suites. Refresh `XdSplits` docstring with a warning against combining with `cluster_manager.get(marker=...)`.