### PR TITLE
fix(runner): reliably kill monitor on exit

### DIFF
--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -28,7 +28,9 @@ if is_venv_active; then
 fi
 
 # Refuse to start if another testrun is already using this workdir.
-acquire_workdir_lock "$WORKDIR" || exit 1
+# `LOCK_FD` is set so background processes (e.g. monitor_system) can drop the
+# inherited lock FD and not keep the lock alive if they outlive this script.
+acquire_workdir_lock "$WORKDIR" LOCK_FD || exit 1
 
 # shellcheck disable=SC1091
 . runner/stop_cluster_instances.sh
@@ -229,8 +231,14 @@ if [ "$(echo "$PWD"/.bin/*)" != "${PWD}/.bin/*" ]; then
   echo
 fi
 
-# function to monitor system resources and log them every 10 minutes
+# Function to monitor system resources and log them every 10 minutes
 monitor_system() {
+  # Drop the inherited workdir lock FD so this background subshell does not
+  # keep the lock held if it outlives the parent script.
+  if [ -n "${LOCK_FD:-}" ]; then
+    exec {LOCK_FD}>&-
+  fi
+
   : > monitor.log
 
   while true; do
@@ -253,9 +261,20 @@ monitor_system() {
 monitor_system &
 MON_PID=$!
 
-# ensure cleanup on ANY exit (success, error, Ctrl-C, set -e, etc.)
-# shellcheck disable=SC2064
-trap "echo 'Stopping monitor'; kill ${MON_PID:-} 2>/dev/null || true" EXIT
+# Kill the sleep child first via pkill -P; otherwise the bash subshell stays blocked
+# in the foreground sleep and SIGTERM is only handled after sleep returns.
+# shellcheck disable=SC2329
+kill_monitor() {
+  if [ -n "${MON_PID:-}" ]; then
+    echo "Stopping monitor with PID $MON_PID"
+    pkill -P "$MON_PID" 2>/dev/null || true
+    kill_and_wait "$MON_PID" || true
+    unset MON_PID
+  fi
+}
+
+# ensure cleanup on ANY exit (success, error, Ctrl-C, set -e, etc.).
+trap 'kill_monitor' EXIT
 
 # Run tests and generate report
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,9 +23,14 @@ is_venv_active() {
 # for the lifetime of the calling shell; it is released automatically on exit.
 # The lock file lives next to the workdir so that wiping the workdir does not
 # drop the lock.
-# Usage: acquire_workdir_lock <workdir>
+# If <fd_var_name> is given, the lock FD number is written into a variable of
+# that name in the caller's scope. Long-lived background processes spawned by
+# the caller can then close the inherited FD (e.g. `exec {LOCK_FD}>&-`) so the
+# lock is released even if they outlive the parent shell.
+# Usage: acquire_workdir_lock <workdir> [<fd_var_name>]
 acquire_workdir_lock() {
   local workdir="${1:?acquire_workdir_lock requires a workdir argument}"
+  local out_var="${2:-}"
   local lockfile="${workdir}.lock"
   local lockfd
 
@@ -46,6 +51,10 @@ acquire_workdir_lock() {
     echo "If no testrun is running, simply retry (the lock is released automatically when the holding process exits)." >&2
     exec {lockfd}>&-
     return 1
+  fi
+
+  if [ -n "$out_var" ]; then
+    printf -v "$out_var" '%s' "$lockfd"
   fi
 }
 
@@ -96,4 +105,28 @@ version_parse() {
   minor="${minor%%[!0-9]*}"
   patch="${patch%%[!0-9]*}"
   printf '%d\n' "$((10#${major:-0} * 1000000 + 10#${minor:-0} * 1000 + 10#${patch:-0}))"
+}
+
+# Send SIGTERM, wait up to 5s for exit, escalate to SIGKILL if still alive.
+# Returns 0 if the process is gone, 1 if it survived even SIGKILL.
+# Note: `wait` only reaps direct children of the calling shell; for non-children
+# the function still returns correctly but cannot harvest the zombie.
+kill_and_wait() {
+  local pid="${1:?Missing PID}"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  if ! kill "$pid" 2>/dev/null; then
+    kill -0 "$pid" 2>/dev/null || return 0
+    return 1
+  fi
+  for _ in {1..5}; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 1
+  done
+  echo "Warning: process $pid did not exit after SIGTERM, sending SIGKILL." >&2
+  kill -9 "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  kill -0 "$pid" 2>/dev/null && return 1
+  return 0
 }


### PR DESCRIPTION
Monitor subshell blocked in foreground `sleep` did not handle SIGTERM until sleep returned, leaving stale processes and a held workdir lock.

- pkill -P the sleep child first, then SIGTERM the subshell, escalate to SIGKILL after 5s
- kill_and_wait: send TERM once, poll with `kill -0`, return non-zero if proc survives
- pass workdir lock FD out so monitor_system can drop it and not keep the lock alive past parent exit