### PR TITLE
feat(ci): preliminary AI analysis of testrun failures

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,3 +17,4 @@ jobs:
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/nightly_cli.yaml
+++ b/.github/workflows/nightly_cli.yaml
@@ -17,3 +17,4 @@ jobs:
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/nightly_dbsync.yaml
+++ b/.github/workflows/nightly_dbsync.yaml
@@ -17,3 +17,4 @@ jobs:
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/nightly_pv11.yaml
+++ b/.github/workflows/nightly_pv11.yaml
@@ -17,3 +17,4 @@ jobs:
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -91,3 +91,4 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
       TCACHE_URL: ${{ secrets.TCACHE_URL }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -82,3 +82,4 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
       TCACHE_URL: ${{ secrets.TCACHE_URL }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -64,9 +64,12 @@ on:
         required: false
       GMAIL_PASSWORD:
         required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
 
 env:
   CI_FAIL_MAILS: ${{ secrets.CI_FAIL_MAILS }}
+  CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
 jobs:
   reusable_run:
@@ -120,6 +123,73 @@ jobs:
           echo "::group::Script setup"
           runner/regression.sh
           echo "::endgroup::"
+      - name: 🤖 Analyze test failures with Claude
+        id: analyze-failures
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        continue-on-error: true
+        uses: anthropics/claude-code-base-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: sonnet
+          max_turns: "40"
+          allowed_tools: "Read,Write,Glob,Grep,Bash(ls:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(find:*),Bash(cut:*),Bash(sort:*),Bash(uniq:*),Bash(awk:*),Bash(jq:*)"
+          prompt: |
+            You are triaging a failed cardano-node-tests regression run. Produce a concise preliminary failure analysis.
+
+            Inputs available in the repo root (use only what exists):
+              - `allure-results/`         — one JSON per test (status, statusDetails.message, statusDetails.trace, stdout/stderr attachments listed by name)
+              - `latest_artifacts/`       — symlink to `artifacts_<timestamp>/`, contains per-test artifact dirs with cluster logs, node stdouts, etc.
+              - `errors_all.log`          — output of `runner/grep_errors.sh` over cluster logs
+              - `scheduling.log`          — cluster instance manager log
+              - `testrun-report.xml`      — junit XML
+              - `monitor.log`             — system resource snapshots every 10 min
+
+            Steps:
+              1. Enumerate failed/broken tests:
+                 `grep -E '"status": "(failed|broken)"' allure-results/*result.json | cut -c1-200`.
+                 (`broken` = pytest error in setup/teardown; `failed` = assertion failure.)
+              2. Group failures by likely root cause (same exception class + message head, same node crash, same infra symptom). Treat one node crash that flunks many tests as a single group.
+              3. For each group: list affected tests (truncate to ~10 with a "+N more" tail), give the most informative 1–3 lines of error context, and classify as one of `node-bug | test-bug | infra-flake | env-issue | unknown` with a short justification.
+              4. Skim `errors_all.log` and `monitor.log` for anything corroborating (OOM, disk pressure, repeated tracebacks).
+
+            Known patterns:
+              - `All cluster instances are dead.` — no cluster instance could start; usually caused by a `cardano-cli` argument change or a `cardano-node` configuration change.
+
+            Constraints:
+              - Output a single markdown file at repo root: `failure_analysis.md`.
+              - Keep it under ~300 lines. No full stack traces — only the most informative line(s).
+              - If a source file is missing, note it once and move on; do not fail.
+              - Do not modify any other files.
+
+            Start now.
+      - name: Read failure analysis into env
+        id: read-analysis
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        run: |
+          if [ -s failure_analysis.md ]; then
+            {
+              echo 'FAILURE_ANALYSIS<<__EOF_ANALYSIS42__'
+              cat failure_analysis.md
+              # ensure delimiter is on its own line even if the file lacks a trailing newline
+              printf '\n__EOF_ANALYSIS42__\n'
+            } >> "$GITHUB_ENV"
+
+            # Surface the analysis in the workflow run UI itself: full content
+            # in a foldable log group, and a copy in the run summary so it's
+            # reachable without downloading the testrun-files artifact.
+            echo "::group::Preliminary failure analysis"
+            cat failure_analysis.md
+            echo
+            echo "::endgroup::"
+            {
+              echo '## 🤖 Preliminary failure analysis'
+              echo
+              cat failure_analysis.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "FAILURE_ANALYSIS=(no analysis produced)" >> "$GITHUB_ENV"
+            echo "::warning::No failure_analysis.md produced by the analyze step."
+          fi
       - name: Report test results
         if: (success() || failure()) && inputs.testrun_name
         run: |
@@ -159,6 +229,7 @@ jobs:
             deselected_tests.txt
             requirements_coverage.json
             monitor.log
+            failure_analysis.md
       - name: ↟ Upload CLI coverage
         uses: actions/upload-artifact@v7
         if: success() || failure()
@@ -177,6 +248,10 @@ jobs:
           subject: "Status: ${{ steps.testing-step.outcome }}; workflow: ${{ github.workflow }}"
           to: ${{secrets.CI_FAIL_MAILS}}
           from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
-          body: "Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body: |
+            Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ── Preliminary failure analysis ──
+            ${{ env.FAILURE_ANALYSIS }}
           reply_to: noreply@github.com
           attachments: testrun-report.html

--- a/runner/create_results.sh
+++ b/runner/create_results.sh
@@ -21,4 +21,5 @@ mv "$reports_dir"/*.properties "$allure_results_dir" 2>/dev/null || :
 echo "Creating results archive $results_tar"
 rm -f "$results_tar"
 tar -C "$tests_repo" -cJf "$results_tar" allure-results
-rm -rf "${allure_results_dir:?}"
+# Keep $allure_results_dir around so post-testrun consumers (e.g. failure
+# analysis) can read it without having to untar the archive.

--- a/runner/save_artifacts.sh
+++ b/runner/save_artifacts.sh
@@ -12,6 +12,10 @@ fi
 NEW_DIR="artifacts_$(date +%Y%m%d%H%M%S)"
 mv "$ARTIFACTS_DIR" "$NEW_DIR" || { echo "Cannot move $ARTIFACTS_DIR to $NEW_DIR" >&2; exit 1; }
 
+# Predictable symlink so post-testrun consumers (e.g. failure analysis) can
+# find the artifacts without having to untar the archive we just created.
+ln -snf "$NEW_DIR" latest_artifacts
+
 echo "Creating artifacts archive $ARTIFACTS_TAR"
 rm -f "$ARTIFACTS_TAR"
 tar -cJf "$ARTIFACTS_TAR" "$NEW_DIR"


### PR DESCRIPTION
Add a regression-workflow step that, on testrun failure, invokes anthropics/claude-code-base-action against the still-uncompressed allure-results/, latest_artifacts/ symlink, errors_all.log and friends, producing failure_analysis.md. The analysis is uploaded with testrun files and inlined into the failure mail body.

To keep originals available without untarring, save_artifacts.sh now creates a latest_artifacts symlink to the renamed artifacts_<timestamp>/ dir, and create_results.sh no longer wipes allure-results/ after archiving.