### PR TITLE
fix(runner): improve monitoring loop robustness and log errors

### DIFF
--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -241,6 +241,7 @@ monitor_system() {
 
   : > monitor.log
 
+  set +e  # don't exit on error in this monitoring loop, just log the error and keep going
   while true; do
     {
       echo "===== $(date) ====="
@@ -251,7 +252,7 @@ monitor_system() {
       echo "--- DISK ---"
       df -h .
       echo
-    } >> monitor.log
+    } >> monitor.log 2>&1
 
     sleep 600 # 10 minutes
   done


### PR DESCRIPTION
- Added `set +e` to prevent the monitoring loop from exiting on errors, ensuring continuous monitoring.
- Redirected stderr to `monitor.log` to capture and log errors alongside standard output.