### PR TITLE
feat(runner): reset traps in monitor_system subshell to avoid interfering with main script

### DIFF
--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -242,6 +242,8 @@ monitor_system() {
   : > monitor.log
 
   set +e  # don't exit on error in this monitoring loop, just log the error and keep going
+  trap - ERR EXIT SIGINT # reset traps in this subshell so they don't interfere with the main script's traps
+
   while true; do
     {
       echo "===== $(date) ====="


### PR DESCRIPTION
Reset ERR, EXIT, and SIGINT traps in the monitor_system subshell within regression.sh to prevent them from affecting the main script's traps. This ensures monitoring errors are isolated and do not disrupt overall script execution.