### PR TITLE
refactor(runner): place testing artifacts under WORKDIR

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -136,27 +136,27 @@ jobs:
           prompt: |
             You are triaging a failed cardano-node-tests regression run. Produce a concise preliminary failure analysis.
 
-            Inputs available in the repo root (use only what exists):
-              - `allure-results/`         — one JSON per test (status, statusDetails.message, statusDetails.trace, stdout/stderr attachments listed by name)
-              - `latest_artifacts/`       — symlink to `artifacts_<timestamp>/`, contains per-test artifact dirs with cluster logs, node stdouts, etc.
-              - `errors_all.log`          — output of `runner/grep_errors.sh` over cluster logs
-              - `scheduling.log`          — cluster instance manager log
-              - `testrun-report.xml`      — junit XML
-              - `monitor.log`             — system resource snapshots every 10 min
+            Inputs available under `run_workdir/` (use only what exists):
+              - `run_workdir/allure-results/`         — one JSON per test (status, statusDetails.message, statusDetails.trace, stdout/stderr attachments listed by name)
+              - `run_workdir/testing_artifacts/`      — per-test artifact dirs with cluster logs, node stdouts, etc.
+              - `run_workdir/errors_all.log`          — output of `runner/grep_errors.sh` over cluster logs
+              - `run_workdir/scheduling.log`          — cluster instance manager log
+              - `run_workdir/testrun-report.xml`      — junit XML
+              - `run_workdir/monitor.log`             — system resource snapshots every 10 min
 
             Steps:
               1. Enumerate failed/broken tests:
-                 `grep -E '"status": "(failed|broken)"' allure-results/*result.json | cut -c1-200`.
+                 `grep -E '"status": "(failed|broken)"' run_workdir/allure-results/*result.json | cut -c1-200`.
                  (`broken` = pytest error in setup/teardown; `failed` = assertion failure.)
               2. Group failures by likely root cause (same exception class + message head, same node crash, same infra symptom). Treat one node crash that flunks many tests as a single group.
               3. For each group: list affected tests (truncate to ~10 with a "+N more" tail), give the most informative 1–3 lines of error context, and classify as one of `node-bug | test-bug | infra-flake | env-issue | unknown` with a short justification.
-              4. Skim `errors_all.log` and `monitor.log` for anything corroborating (OOM, disk pressure, repeated tracebacks).
+              4. Skim `run_workdir/errors_all.log` and `run_workdir/monitor.log` for anything corroborating (OOM, disk pressure, repeated tracebacks).
 
             Known patterns:
               - `All cluster instances are dead.` — no cluster instance could start; usually caused by a `cardano-cli` argument change or a `cardano-node` configuration change.
 
             Constraints:
-              - Output a single markdown file at repo root: `failure_analysis.md`.
+              - Output a single markdown file at: `run_workdir/failure_analysis.md`.
               - Keep it under ~300 lines. No full stack traces — only the most informative line(s).
               - If a source file is missing, note it once and move on; do not fail.
               - Do not modify any other files.
@@ -166,10 +166,10 @@ jobs:
         id: read-analysis
         if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
         run: |
-          if [ -s failure_analysis.md ]; then
+          if [ -s run_workdir/failure_analysis.md ]; then
             {
               echo 'FAILURE_ANALYSIS<<__EOF_ANALYSIS42__'
-              cat failure_analysis.md
+              cat run_workdir/failure_analysis.md
               # ensure delimiter is on its own line even if the file lacks a trailing newline
               printf '\n__EOF_ANALYSIS42__\n'
             } >> "$GITHUB_ENV"
@@ -178,31 +178,31 @@ jobs:
             # in a foldable log group, and a copy in the run summary so it's
             # reachable without downloading the testrun-files artifact.
             echo "::group::Preliminary failure analysis"
-            cat failure_analysis.md
+            cat run_workdir/failure_analysis.md
             echo
             echo "::endgroup::"
             {
               echo '## 🤖 Preliminary failure analysis'
               echo
-              cat failure_analysis.md
+              cat run_workdir/failure_analysis.md
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "FAILURE_ANALYSIS=(no analysis produced)" >> "$GITHUB_ENV"
-            echo "::warning::No failure_analysis.md produced by the analyze step."
+            echo "::warning::No run_workdir/failure_analysis.md produced by the analyze step."
           fi
       - name: Report test results
         if: (success() || failure()) && inputs.testrun_name
         run: |
-          if [ -n "${{ secrets.TCACHE_BASIC_AUTH }}" ] && [ -n "${{ secrets.TCACHE_URL }}" ] && [ -e testrun-report.xml ]; then
+          if [ -n "${{ secrets.TCACHE_BASIC_AUTH }}" ] && [ -n "${{ secrets.TCACHE_URL }}" ] && [ -e run_workdir/testrun-report.xml ]; then
             testrun_name_strip="$(echo "${{ inputs.testrun_name }}" | sed 's/[^a-zA-Z0-9_-]//g')"
-            curl -s -X PUT --fail-with-body -u ${{ secrets.TCACHE_BASIC_AUTH }} "${{ secrets.TCACHE_URL }}/${testrun_name_strip}/${{ github.run_number }}/import" -F "junitxml=@testrun-report.xml"
+            curl -s -X PUT --fail-with-body -u ${{ secrets.TCACHE_BASIC_AUTH }} "${{ secrets.TCACHE_URL }}/${testrun_name_strip}/${{ github.run_number }}/import" -F "junitxml=@run_workdir/testrun-report.xml"
           fi
       - name: ↟ Upload testing artifacts on failure
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: testing-artifacts
-          path: testing_artifacts.tar.xz
+          path: run_workdir/testing_artifacts.tar.xz
       - name: ↟ Upload Allure results
         uses: actions/upload-artifact@v7
         # When using `always()`, you lose ability to manually cancel the workflow.
@@ -210,32 +210,32 @@ jobs:
         if: success() || failure()
         with:
           name: allure-results
-          path: allure-results.tar.xz
+          path: run_workdir/allure-results.tar.xz
       - name: ↟ Upload HTML report
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: testrun-report
-          path: testrun-report.html
+          path: run_workdir/testrun-report.html
       - name: ↟ Upload testrun files
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: testrun-files
           path: |
-            scheduling.log
-            errors_all.log
-            testrun-report.xml
+            run_workdir/scheduling.log
+            run_workdir/errors_all.log
+            run_workdir/testrun-report.xml
             deselected_tests.txt
-            requirements_coverage.json
-            monitor.log
-            failure_analysis.md
+            run_workdir/requirements_coverage.json
+            run_workdir/monitor.log
+            run_workdir/failure_analysis.md
       - name: ↟ Upload CLI coverage
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: cli-coverage
-          path: cli_coverage.json
+          path: run_workdir/cli_coverage.json
       - name: ✉ Mail failure report
         uses: dawidd6/action-send-mail@v17
         if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CI_FAIL_MAILS && github.event_name == 'schedule'
@@ -254,4 +254,4 @@ jobs:
             ── Preliminary failure analysis ──
             ${{ env.FAILURE_ANALYSIS }}
           reply_to: noreply@github.com
-          attachments: testrun-report.html
+          attachments: run_workdir/testrun-report.html

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -82,7 +82,7 @@ jobs:
         if: failure()
         with:
           name: testing-artifacts
-          path: testing_artifacts.tar.xz
+          path: run_workdir/testing_artifacts.tar.xz
       - name: ↟ Upload Allure results for step1
         uses: actions/upload-artifact@v7
         # When using `always()`, you lose ability to manually cancel the workflow.
@@ -90,42 +90,42 @@ jobs:
         if: success() || failure()
         with:
           name: allure-results-step1
-          path: allure-results-step1.tar.xz
+          path: run_workdir/allure-results-step1.tar.xz
       - name: ↟ Upload Allure results for step2
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: allure-results-step2
-          path: allure-results-step2.tar.xz
+          path: run_workdir/allure-results-step2.tar.xz
       - name: ↟ Upload Allure results for step3
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: allure-results-step3
-          path: allure-results-step3.tar.xz
+          path: run_workdir/allure-results-step3.tar.xz
       - name: ↟ Upload HTML reports
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: testrun-reports
           path: |
-            testrun-report-step1.html
-            testrun-report-step2.html
-            testrun-report-step3.html
+            run_workdir/testrun-report-step1.html
+            run_workdir/testrun-report-step2.html
+            run_workdir/testrun-report-step3.html
       - name: ↟ Upload testrun files
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: testrun-files
           path: |
-            scheduling.log
-            errors_all.log
+            run_workdir/scheduling.log
+            run_workdir/errors_all.log
       - name: ↟ Upload CLI coverage
         uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: cli-coverage
-          path: cli_coverage.json
+          path: run_workdir/cli_coverage.json
       - name: ✉ Mail failure report
         uses: dawidd6/action-send-mail@v17
         if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CI_FAIL_MAILS && github.event_name == 'schedule'
@@ -140,4 +140,4 @@ jobs:
           from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
           body: "Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           reply_to: noreply@github.com
-          attachments: testrun-report.html
+          attachments: run_workdir/testrun-report-step1.html,run_workdir/testrun-report-step2.html,run_workdir/testrun-report-step3.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-# Testing artifacts
-/.artifacts/
-/.cli_coverage/
-/.reports/
-
 # Workdir for running tests
 /run_workdir/
 /dev_workdir/
+
+# Legacy testing artifacts dirs (kept to ignore leftovers in existing checkouts)
+/.artifacts/
+/.cli_coverage/
+/.reports/
 
 # Local files
 /tmp*/

--- a/runner/cli_coverage.sh
+++ b/runner/cli_coverage.sh
@@ -2,20 +2,33 @@
 
 set -euo pipefail
 
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <coverage_dir> <output_file>" >&2
+  exit 1
+fi
+
+coverage_dir="$1"
+output_file="$2"
+
 tests_repo="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine test repo dir, exiting." >&2; exit 1; }
 
+if [ ! -d "$coverage_dir" ]; then
+  echo "Coverage dir '$coverage_dir' does not exist, exiting." >&2
+  exit 1
+fi
+
 get_coverage() {
-  if [ "$(echo "$tests_repo"/.cli_coverage/*)" = "$tests_repo/.cli_coverage/*" ] || ! command -v cardano-cli >/dev/null 2>&1; then
+  if [ "$(echo "$coverage_dir"/cli_coverage_*)" = "$coverage_dir/cli_coverage_*" ] || ! command -v cardano-cli >/dev/null 2>&1; then
     return 1
   fi
   oldpwd="$PWD"
   cd "$tests_repo"
   retval=0
   PYTHONPATH="$PWD:${PYTHONPATH:-}" cardano_node_tests/cardano_cli_coverage.py \
-    -i .cli_coverage/cli_coverage_* -o "$1" || retval=1
+    -i "$coverage_dir"/cli_coverage_* -o "$1" || retval=1
   cd "$oldpwd"
   return "$retval"
 }
 
-echo "Generating CLI coverage report to $tests_repo/cli_coverage.json"
-get_coverage "$tests_repo/cli_coverage.json" || : > "$tests_repo/cli_coverage.json"
+echo "Generating CLI coverage report to $output_file"
+get_coverage "$output_file" || : > "$output_file"

--- a/runner/create_results.sh
+++ b/runner/create_results.sh
@@ -2,24 +2,32 @@
 
 set -euo pipefail
 
-tests_repo="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine tests repo dir, exiting." >&2; exit 1; }
-reports_dir="$tests_repo/.reports"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <reports_dir> <output_dir>" >&2
+  exit 1
+fi
+
+reports_dir="$1"
+output_dir="$2"
+
 if [ "$(echo "$reports_dir"/*.json)" = "$reports_dir/*.json" ]; then
   echo "No reports found in $reports_dir" >&2
   exit 1
 fi
 
-results_tar="$tests_repo/allure-results.tar.xz"
-allure_results_dir="$tests_repo/allure-results"
+mkdir -p "$output_dir" || { echo "Cannot create $output_dir" >&2; exit 1; }
+
+results_tar="${output_dir}/allure-results.tar.xz"
+allure_results_dir="${output_dir}/allure-results"
 
 rm -rf "${allure_results_dir:?}"
 mkdir -p "$allure_results_dir"
-mv "$reports_dir"/*.json "$allure_results_dir"
-mv "$reports_dir"/*.txt "$allure_results_dir" 2>/dev/null || :
-mv "$reports_dir"/*.properties "$allure_results_dir" 2>/dev/null || :
+find "$reports_dir" -maxdepth 1 -type f \
+  \( -name '*.json' -o -name '*.txt' -o -name '*.properties' \) \
+  -exec mv -t "$allure_results_dir" {} +
 
 echo "Creating results archive $results_tar"
 rm -f "$results_tar"
-tar -C "$tests_repo" -cJf "$results_tar" allure-results
+tar -C "$output_dir" -cJf "$results_tar" allure-results
 # Keep $allure_results_dir around so post-testrun consumers (e.g. failure
 # analysis) can read it without having to untar the archive.

--- a/runner/grep_errors.sh
+++ b/runner/grep_errors.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
-ERR_LOGFILE="${PWD}/errors_all.log"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <artifacts_dir> <output_file>" >&2
+  exit 1
+fi
 
-cd "$ARTIFACTS_DIR" || { echo "Cannot switch to $ARTIFACTS_DIR" >&2; exit 1; }
-grep -r --include "*.stdout" --include "*.stderr" -Ei ":error:|failed|failure" . > "$ERR_LOGFILE" || :
+artifacts_dir="$1"
+output_file="$2"
+
+cd "$artifacts_dir" || { echo "Cannot switch to $artifacts_dir" >&2; exit 1; }
+grep -r --include "*.stdout" --include "*.stderr" -Ei ":error:|failed|failure" . > "$output_file" || :

--- a/runner/node_upgrade.sh
+++ b/runner/node_upgrade.sh
@@ -76,15 +76,15 @@ mkdir -p "$TMPDIR"
 
 export CARDANO_NODE_SOCKET_PATH_CI="$WORKDIR/state-cluster0/bft1.socket"
 
-export ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
-rm -rf "${ARTIFACTS_DIR:?}"
+export ARTIFACTS_DIR="${WORKDIR}/artifacts"
 mkdir -p "$ARTIFACTS_DIR"
 
-export COVERAGE_DIR="${COVERAGE_DIR:-".cli_coverage"}"
-rm -rf "${COVERAGE_DIR:?}"
+export COVERAGE_DIR="${WORKDIR}/cli_coverage"
 mkdir -p "$COVERAGE_DIR"
 
-export SCHEDULING_LOG=scheduling.log
+export REPORTS_DIR="${WORKDIR}/reports"
+
+export SCHEDULING_LOG="${WORKDIR}/scheduling.log"
 : > "$SCHEDULING_LOG"
 
 export DEV_CLUSTER_RUNNING=true FORBID_RESTART=true CLUSTERS_COUNT=1 TEST_THREADS=10 NUM_POOLS="${NUM_POOLS:-4}"
@@ -188,14 +188,14 @@ if [ ! -e "$WORKDIR/.nix_setup" ]; then
 fi
 
 # grep testing artifacts for errors
-./runner/grep_errors.sh
+./runner/grep_errors.sh "$ARTIFACTS_DIR" "${WORKDIR}/errors_all.log"
 
 _last_cleanup
 
 # prepare artifacts for upload in GitHub Actions
 if [ -n "${GITHUB_ACTIONS:-}" ]; then
   # save testing artifacts
-  ./runner/save_artifacts.sh
+  ./runner/save_artifacts.sh "$ARTIFACTS_DIR" "$WORKDIR"
 fi
 
 exit "$retval"

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -19,7 +19,6 @@ CLUSTER_SCRIPTS_DIR="$WORKDIR/cluster0_${CLUSTER_ERA}"
 STEP1_BIN="$WORKDIR/step1-bin"
 
 # init reports dir before each step
-export REPORTS_DIR="${REPORTS_DIR:-".reports"}"
 rm -rf "${REPORTS_DIR:?}"
 mkdir -p "$REPORTS_DIR"
 
@@ -89,7 +88,7 @@ if [ "$1" = "step1" ]; then
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$REPORTS_DIR" \
-    --html=testrun-report-step1.html \
+    --html="$WORKDIR/testrun-report-step1.html" \
     --self-contained-html \
     || retval="$?"
 
@@ -97,8 +96,8 @@ if [ "$1" = "step1" ]; then
   [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
 
   # create results archive for step1
-  ./runner/create_results.sh .
-  mv allure-results.tar.xz allure-results-step1.tar.xz
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
+  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step1.tar.xz"
 
   printf "STEP1 finish: %(%H:%M:%S)T\n" -1
 
@@ -232,7 +231,7 @@ elif [ "$1" = "step2" ]; then
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$REPORTS_DIR" \
-    --html=testrun-report-step2.html \
+    --html="$WORKDIR/testrun-report-step2.html" \
     --self-contained-html \
     ||retval="$?"
 
@@ -240,8 +239,8 @@ elif [ "$1" = "step2" ]; then
   [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
 
   # create results archive for step2
-  ./runner/create_results.sh .
-  mv allure-results.tar.xz allure-results-step2.tar.xz
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
+  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step2.tar.xz"
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 
@@ -387,13 +386,13 @@ elif [ "$1" = "step3" ]; then
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$REPORTS_DIR" \
-    --html=testrun-report-step3.html \
+    --html="$WORKDIR/testrun-report-step3.html" \
     --self-contained-html \
     ||retval="$?"
 
   # create results archive for step3
-  ./runner/create_results.sh .
-  mv allure-results.tar.xz allure-results-step3.tar.xz
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
+  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step3.tar.xz"
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 
@@ -408,7 +407,7 @@ elif [ "$1" = "finish" ]; then
   "$CLUSTER_SCRIPTS_DIR/stop-cluster"
 
   # generate CLI coverage reports
-  ./runner/cli_coverage.sh .
+  ./runner/cli_coverage.sh "$COVERAGE_DIR" "${WORKDIR}/cli_coverage.json"
 
   retval=0
 fi

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -47,10 +47,11 @@ export PYTHONPYCACHEPREFIX="${WORKDIR}/__pycache__"
 export TMPDIR="$WORKDIR/tmp"
 mkdir -p "$TMPDIR"
 
-export ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
-rm -rf "${ARTIFACTS_DIR:?}"
+export ARTIFACTS_DIR="${WORKDIR}/artifacts"
+export COVERAGE_DIR="${WORKDIR}/cli_coverage"
+export REPORTS_DIR="${WORKDIR}/reports"
 
-export SCHEDULING_LOG=scheduling.log
+export SCHEDULING_LOG="${WORKDIR}/scheduling.log"
 : > "$SCHEDULING_LOG"
 
 MARKEXPR="${MARKEXPR:-}"
@@ -239,7 +240,8 @@ monitor_system() {
     exec {LOCK_FD}>&-
   fi
 
-  : > monitor.log
+  monitor_log="${WORKDIR}/monitor.log"
+  : > "$monitor_log"
 
   set +e  # don't exit on error in this monitoring loop, just log the error and keep going
   trap - ERR EXIT SIGINT # reset traps in this subshell so they don't interfere with the main script's traps
@@ -254,7 +256,7 @@ monitor_system() {
       echo "--- DISK ---"
       df -h .
       echo
-    } >> monitor.log 2>&1
+    } >> "$monitor_log" 2>&1
 
     sleep 600 # 10 minutes
   done
@@ -303,13 +305,13 @@ nix develop --accept-flake-config .#testenv --command bash -c '
 
   echo "::group::Collect artifacts & teardown cluster"
   printf "start: %(%H:%M:%S)T\n" -1
-  ./runner/cli_coverage.sh || :
-  ./runner/reqs_coverage.sh || :
+  ./runner/cli_coverage.sh "$COVERAGE_DIR" "${WORKDIR}/cli_coverage.json" || :
+  ./runner/reqs_coverage.sh "$ARTIFACTS_DIR" "${WORKDIR}/requirements_coverage.json" || :
   exit "$retval"
 ' || retval="$?"
 
 # grep testing artifacts for errors
-./runner/grep_errors.sh
+./runner/grep_errors.sh "$ARTIFACTS_DIR" "${WORKDIR}/errors_all.log"
 
 # Don't stop cluster instances just yet if KEEP_CLUSTERS_RUNNING is set to 1.
 # After any key is pressed, resume this script and stop all running cluster instances.
@@ -322,19 +324,17 @@ fi
 
 _last_cleanup
 
-# prepare artifacts for upload in GitHub Actions
-if [ -n "${GITHUB_ACTIONS:-}" ]; then
+# Prepare artifacts
 
-  # move reports to root dir
-  if [ -e .reports/testrun-report.html ]; then
-    mv .reports/testrun-report.* ./
-  fi
-
-  # create results archive
-  ./runner/create_results.sh || :
-
-  # save testing artifacts
-  ./runner/save_artifacts.sh || :
+# Move reports to workdir
+if [ -e "${REPORTS_DIR}/testrun-report.html" ]; then
+  mv "${REPORTS_DIR}"/testrun-report.* "$WORKDIR/"
 fi
+
+# Create results archive
+./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" || :
+
+# Save testing artifacts
+./runner/save_artifacts.sh "$ARTIFACTS_DIR" "$WORKDIR" || :
 
 exit "$retval"

--- a/runner/reqs_coverage.sh
+++ b/runner/reqs_coverage.sh
@@ -2,22 +2,28 @@
 
 set -euo pipefail
 
-ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <artifacts_dir> <output_file>" >&2
+  exit 1
+fi
+
+artifacts_dir="$1"
+output_file="$2"
 
 tests_repo="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine tests repo dir, exiting." >&2; exit 1; }
 
 get_coverage() {
-  if [ ! -e "$ARTIFACTS_DIR" ]; then
+  if [ ! -e "$artifacts_dir" ]; then
     return 1
   fi
   oldpwd="$PWD"
   cd "$tests_repo"
   retval=0
   PYTHONPATH="$PWD:${PYTHONPATH:-}" cardano_node_tests/dump_requirements_coverage.py \
-    -a "$ARTIFACTS_DIR" -m "src_docs/requirements_mapping.json" -o "$1" || retval=1
+    -a "$artifacts_dir" -m "src_docs/requirements_mapping.json" -o "$1" || retval=1
   cd "$oldpwd"
   return "$retval"
 }
 
-echo "Generating requirements coverage report to $tests_repo/requirements_coverage.json"
-get_coverage "$tests_repo/requirements_coverage.json" || : > "$tests_repo/requirements_coverage.json"
+echo "Generating requirements coverage report to $output_file"
+get_coverage "$output_file" || : > "$output_file"

--- a/runner/run_tests.sh
+++ b/runner/run_tests.sh
@@ -10,9 +10,9 @@
 #
 # Env vars:
 #   TESTS_DIR: directory with tests to run (default: cardano_node_tests/)
-#   ARTIFACTS_DIR: directory to save artifacts into (default: .artifacts)
-#   COVERAGE_DIR: directory to save CLI coverage data into (default: .cli_coverage)
-#   REPORTS_DIR: directory to save Allure test reports into (default: .reports)
+#   ARTIFACTS_DIR: directory to save artifacts into (default: run_workdir/artifacts)
+#   COVERAGE_DIR: directory to save CLI coverage data into (default: run_workdir/cli_coverage)
+#   REPORTS_DIR: directory to save Allure test reports into (default: run_workdir/reports)
 #   MARKEXPR: pytest mark expression to filter tests, without the `-m` flag
 #   NO_ARTIFACTS: if set to true, do not save artifacts
 #   PYTEST_ARGS: additional args to pass to pytest
@@ -33,9 +33,9 @@ set -Eeuo pipefail
 
 # Defaults
 TESTS_DIR="${TESTS_DIR:-cardano_node_tests/}"
-ARTIFACTS_DIR="${ARTIFACTS_DIR:-.artifacts}"
-COVERAGE_DIR="${COVERAGE_DIR:-.cli_coverage}"
-REPORTS_DIR="${REPORTS_DIR:-.reports}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-run_workdir/artifacts}"
+COVERAGE_DIR="${COVERAGE_DIR:-run_workdir/cli_coverage}"
+REPORTS_DIR="${REPORTS_DIR:-run_workdir/reports}"
 
 _TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091

--- a/runner/save_artifacts.sh
+++ b/runner/save_artifacts.sh
@@ -2,20 +2,26 @@
 
 set -euo pipefail
 
-ARTIFACTS_TAR="${PWD}/testing_artifacts.tar.xz"
-ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
-if [ "$(echo "$ARTIFACTS_DIR"/*)" = "$ARTIFACTS_DIR/*" ]; then
-  echo "No artifacts found in $ARTIFACTS_DIR" >&2
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <artifacts_dir> <output_dir>" >&2
   exit 1
 fi
 
-NEW_DIR="artifacts_$(date +%Y%m%d%H%M%S)"
-mv "$ARTIFACTS_DIR" "$NEW_DIR" || { echo "Cannot move $ARTIFACTS_DIR to $NEW_DIR" >&2; exit 1; }
+artifacts_dir="$1"
+output_dir="$2"
 
-# Predictable symlink so post-testrun consumers (e.g. failure analysis) can
-# find the artifacts without having to untar the archive we just created.
-ln -snf "$NEW_DIR" latest_artifacts
+if [ "$(echo "$artifacts_dir"/*)" = "$artifacts_dir/*" ]; then
+  echo "No artifacts found in $artifacts_dir" >&2
+  exit 1
+fi
 
-echo "Creating artifacts archive $ARTIFACTS_TAR"
-rm -f "$ARTIFACTS_TAR"
-tar -cJf "$ARTIFACTS_TAR" "$NEW_DIR"
+mkdir -p "$output_dir" || { echo "Cannot create $output_dir" >&2; exit 1; }
+
+new_dir="${output_dir}/testing_artifacts"
+rm -rf "${new_dir:?}"
+mv "$artifacts_dir" "$new_dir" || { echo "Cannot move $artifacts_dir to $new_dir" >&2; exit 1; }
+
+artifacts_tar="${output_dir}/testing_artifacts.tar.xz"
+echo "Creating artifacts archive $artifacts_tar"
+rm -f "$artifacts_tar"
+tar -C "$output_dir" -cJf "$artifacts_tar" testing_artifacts


### PR DESCRIPTION
Move all testrun outputs (artifacts, coverage, reports, logs, archives) under ${WORKDIR}/ instead of the repo root, so a testrun no longer litters the top-level directory. Helper scripts now take artifacts and output dirs as explicit args. CI workflows updated to upload from run_workdir/.