### PR TITLE
refactor(ci): extract failure-analysis prompt for reuse

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -123,6 +123,15 @@ jobs:
           echo "::group::Script setup"
           runner/regression.sh
           echo "::endgroup::"
+      - name: Load failure-analysis prompt
+        id: load-analysis-prompt
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        run: |
+          {
+            echo 'ANALYSIS_PROMPT<<__EOF_PROMPT42__'
+            sed 's|{RUN_DIR}|run_workdir|g' agent_docs/failure_analysis_prompt.md
+            printf '\n__EOF_PROMPT42__\n'
+          } >> "$GITHUB_ENV"
       - name: 🤖 Analyze test failures with Claude
         id: analyze-failures
         if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
@@ -133,35 +142,7 @@ jobs:
           model: sonnet
           max_turns: "40"
           allowed_tools: "Read,Write,Glob,Grep,Bash(ls:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(find:*),Bash(cut:*),Bash(sort:*),Bash(uniq:*),Bash(awk:*),Bash(jq:*)"
-          prompt: |
-            You are triaging a failed cardano-node-tests regression run. Produce a concise preliminary failure analysis.
-
-            Inputs available under `run_workdir/` (use only what exists):
-              - `run_workdir/allure-results/`         — one JSON per test (status, statusDetails.message, statusDetails.trace, stdout/stderr attachments listed by name)
-              - `run_workdir/testing_artifacts/`      — per-test artifact dirs with cluster logs, node stdouts, etc.
-              - `run_workdir/errors_all.log`          — output of `runner/grep_errors.sh` over cluster logs
-              - `run_workdir/scheduling.log`          — cluster instance manager log
-              - `run_workdir/testrun-report.xml`      — junit XML
-              - `run_workdir/monitor.log`             — system resource snapshots every 10 min
-
-            Steps:
-              1. Enumerate failed/broken tests:
-                 `grep -E '"status": "(failed|broken)"' run_workdir/allure-results/*result.json | cut -c1-200`.
-                 (`broken` = pytest error in setup/teardown; `failed` = assertion failure.)
-              2. Group failures by likely root cause (same exception class + message head, same node crash, same infra symptom). Treat one node crash that flunks many tests as a single group.
-              3. For each group: list affected tests (truncate to ~10 with a "+N more" tail), give the most informative 1–3 lines of error context, and classify as one of `node-bug | test-bug | infra-flake | env-issue | unknown` with a short justification.
-              4. Skim `run_workdir/errors_all.log` and `run_workdir/monitor.log` for anything corroborating (OOM, disk pressure, repeated tracebacks).
-
-            Known patterns:
-              - `All cluster instances are dead.` — no cluster instance could start; usually caused by a `cardano-cli` argument change or a `cardano-node` configuration change.
-
-            Constraints:
-              - Output a single markdown file at: `run_workdir/failure_analysis.md`.
-              - Keep it under ~300 lines. No full stack traces — only the most informative line(s).
-              - If a source file is missing, note it once and move on; do not fail.
-              - Do not modify any other files.
-
-            Start now.
+          prompt: ${{ env.ANALYSIS_PROMPT }}
       - name: Read failure analysis into env
         id: read-analysis
         if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
@@ -181,9 +162,7 @@ jobs:
             cat run_workdir/failure_analysis.md
             echo
             echo "::endgroup::"
-            {
-              cat run_workdir/failure_analysis.md
-            } >> "$GITHUB_STEP_SUMMARY"
+            cat run_workdir/failure_analysis.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "FAILURE_ANALYSIS=(no analysis produced)" >> "$GITHUB_ENV"
             echo "::warning::No run_workdir/failure_analysis.md produced by the analyze step."

--- a/agent_docs/failure_analysis_prompt.md
+++ b/agent_docs/failure_analysis_prompt.md
@@ -1,0 +1,36 @@
+# Preliminary Failure Analysis Prompt
+
+You are triaging a failed cardano-node-tests regression run. Produce a concise preliminary failure analysis.
+
+The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). All input paths below are under that directory.
+
+Inputs available under `{RUN_DIR}/` (use only what exists):
+
+- `{RUN_DIR}/allure-results/` — one JSON per test (status, statusDetails.message, statusDetails.trace, stdout/stderr attachments listed by name)
+- `{RUN_DIR}/testing_artifacts/` — per-test artifact dirs with cluster logs, node stdouts, etc.
+- `{RUN_DIR}/errors_all.log` — output of `runner/grep_errors.sh` over cluster logs
+- `{RUN_DIR}/scheduling.log` — cluster instance manager log
+- `{RUN_DIR}/testrun-report.xml` — junit XML
+- `{RUN_DIR}/monitor.log` — system resource snapshots every 10 min
+
+Steps:
+
+1. Enumerate failed/broken tests:
+   `grep -E '"status": "(failed|broken)"' {RUN_DIR}/allure-results/*result.json | cut -c1-200`.
+   (`broken` = pytest error in setup/teardown; `failed` = assertion failure.)
+2. Group failures by likely root cause (same exception class + message head, same node crash, same infra symptom). Treat one node crash that flunks many tests as a single group.
+3. For each group: list affected tests (truncate to ~10 with a "+N more" tail), give the most informative 1–3 lines of error context, and classify as one of `node-bug | test-bug | infra-flake | env-issue | unknown` with a short justification.
+4. Skim `{RUN_DIR}/errors_all.log` and `{RUN_DIR}/monitor.log` for anything corroborating (OOM, disk pressure, repeated tracebacks).
+
+Known patterns:
+
+- `All cluster instances are dead.` — no cluster instance could start; usually caused by a `cardano-cli` argument change or a `cardano-node` configuration change.
+
+Constraints:
+
+- Output a single markdown file at: `{RUN_DIR}/failure_analysis.md`.
+- Keep it under ~300 lines. No full stack traces — only the most informative line(s).
+- If a source file is missing, note it once and move on; do not fail.
+- Do not modify any other files.
+
+Start now.

--- a/scripts/analyze_failures.sh
+++ b/scripts/analyze_failures.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run preliminary failure analysis on a regression-run directory using any
+# coding-agent CLI that accepts a prompt on stdin (or via -p/--prompt).
+#
+# Usage:
+#   scripts/analyze_failures.sh [RUN_DIR]
+#
+# RUN_DIR defaults to ./run_workdir. It can point at a fresh run produced by
+# `runner/regression.sh` or at any saved historical run directory (relative
+# or absolute path). The agent writes ${RUN_DIR}/failure_analysis.md per the
+# prompt contract.
+#
+# Env vars:
+#   AGENT_CMD   Command used to invoke the agent. Default: "claude -p".
+#               Examples:
+#                 AGENT_CMD="claude -p"
+#                 AGENT_CMD="gemini"
+#                 AGENT_CMD="codex exec"
+#               The prompt is piped to the command on stdin.
+
+set -euo pipefail
+
+RUN_DIR="${1:-run_workdir}"
+AGENT_CMD="${AGENT_CMD:-claude -p}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROMPT_FILE="${REPO_ROOT}/agent_docs/failure_analysis_prompt.md"
+
+if [ ! -f "${PROMPT_FILE}" ]; then
+  echo "Prompt file not found: ${PROMPT_FILE}" >&2
+  exit 1
+fi
+if [ ! -d "${RUN_DIR}" ]; then
+  echo "Run directory not found: ${RUN_DIR}" >&2
+  exit 1
+fi
+
+# Substitute {RUN_DIR} in the prompt template, then pipe to the agent.
+prompt_content="$(cat "${PROMPT_FILE}")"
+prompt_content="${prompt_content//\{RUN_DIR\}/${RUN_DIR}}"
+
+# shellcheck disable=SC2086
+printf '%s\n' "${prompt_content}" | exec $AGENT_CMD


### PR DESCRIPTION
Move the preliminary failure-analysis prompt out of the regression workflow into `agent_docs/failure_analysis_prompt.md`, using a `{RUN_DIR}` placeholder so the same template works for both fresh runs and saved historical run directories.

The workflow now loads the template and substitutes `run_workdir` before passing it to the Claude action. Add
`scripts/analyze_failures.sh` for agent-agnostic local invocation: takes a run directory argument and pipes the rendered prompt to any agent CLI via `AGENT_CMD` (defaults to `claude -p`; works with `gemini`, `codex exec`, etc.).