### PR TITLE
fix(ci): render failure-mail body as HTML

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -226,11 +226,12 @@ jobs:
           to: ${{secrets.CI_FAIL_MAILS}}
           from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
           convert_markdown: true
-          body: |
+          body: &mail_body |
             Run URL: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
 
             ── Preliminary failure analysis ──
 
             ${{ env.FAILURE_ANALYSIS }}
+          html_body: *mail_body
           reply_to: noreply@github.com
           attachments: run_workdir/testrun-report.html


### PR DESCRIPTION
`convert_markdown` only applies to `html_body`, so the mail was sent as plain text and markdown syntax leaked through. Set `html_body` to the same content via a YAML anchor so the mail is multipart with a rendered HTML part.