### PR TITLE
feat(ci): AI failure analysis for upgrade tests

### DIFF
--- a/.github/workflows/nightly_upgrade.yaml
+++ b/.github/workflows/nightly_upgrade.yaml
@@ -17,3 +17,4 @@ jobs:
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -35,9 +35,12 @@ on:
         required: false
       GMAIL_PASSWORD:
         required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
 
 env:
   CI_FAIL_MAILS: ${{ secrets.CI_FAIL_MAILS }}
+  CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
 jobs:
   reusable_run:
@@ -77,6 +80,50 @@ jobs:
           echo "::group::Script setup"
           ./runner/node_upgrade.sh
           echo "::endgroup::"
+      - name: Load failure-analysis prompt
+        id: load-analysis-prompt
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        run: |
+          {
+            echo 'ANALYSIS_PROMPT<<__EOF_PROMPT42__'
+            sed 's|{RUN_DIR}|run_workdir|g' agent_docs/upgrade_failure_analysis_prompt.md
+            printf '\n__EOF_PROMPT42__\n'
+          } >> "$GITHUB_ENV"
+      - name: 🤖 Analyze test failures with Claude
+        id: analyze-failures
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        continue-on-error: true
+        uses: anthropics/claude-code-base-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: sonnet
+          max_turns: "40"
+          allowed_tools: "Read,Write,Glob,Grep,Bash(ls:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(find:*),Bash(cut:*),Bash(sort:*),Bash(uniq:*),Bash(awk:*),Bash(jq:*)"
+          prompt: ${{ env.ANALYSIS_PROMPT }}
+      - name: Read failure analysis into env
+        id: read-analysis
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CLAUDE_CODE_OAUTH_TOKEN
+        run: |
+          if [ -s run_workdir/failure_analysis.md ]; then
+            {
+              echo 'FAILURE_ANALYSIS<<__EOF_ANALYSIS42__'
+              cat run_workdir/failure_analysis.md
+              # ensure delimiter is on its own line even if the file lacks a trailing newline
+              printf '\n__EOF_ANALYSIS42__\n'
+            } >> "$GITHUB_ENV"
+
+            # Surface the analysis in the workflow run UI itself: full content
+            # in a foldable log group, and a copy in the run summary so it's
+            # reachable without downloading the testrun-files artifact.
+            echo "::group::Preliminary failure analysis"
+            cat run_workdir/failure_analysis.md
+            echo
+            echo "::endgroup::"
+            cat run_workdir/failure_analysis.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "FAILURE_ANALYSIS=(no analysis produced)" >> "$GITHUB_ENV"
+            echo "::warning::No run_workdir/failure_analysis.md produced by the analyze step."
+          fi
       - name: ↟ Upload testing artifacts on failure
         uses: actions/upload-artifact@v7
         if: failure()
@@ -120,6 +167,7 @@ jobs:
           path: |
             run_workdir/scheduling.log
             run_workdir/errors_all.log
+            run_workdir/failure_analysis.md
       - name: ↟ Upload CLI coverage
         uses: actions/upload-artifact@v7
         if: success() || failure()
@@ -138,6 +186,13 @@ jobs:
           subject: "Status: ${{ steps.testing-step.outcome }}; workflow: ${{ github.workflow }}"
           to: ${{secrets.CI_FAIL_MAILS}}
           from: 'Cardano GitHub Actions <${{secrets.GMAIL_USERNAME}}>'
-          body: "Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          convert_markdown: true
+          body: &mail_body |
+            Run URL: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+
+            ── Preliminary failure analysis ──
+
+            ${{ env.FAILURE_ANALYSIS }}
+          html_body: *mail_body
           reply_to: noreply@github.com
           attachments: run_workdir/testrun-report-step1.html,run_workdir/testrun-report-step2.html,run_workdir/testrun-report-step3.html

--- a/agent_docs/upgrade_failure_analysis_prompt.md
+++ b/agent_docs/upgrade_failure_analysis_prompt.md
@@ -1,0 +1,47 @@
+# Preliminary Failure Analysis Prompt — Node Upgrade
+
+You are triaging a failed cardano-node-tests **node upgrade** run. Produce a concise preliminary failure analysis.
+
+The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). All input paths below are under that directory.
+
+A node upgrade run executes the same smoke-test suite three times against an evolving cluster:
+
+- **step1** — cluster built from the **base** node revision; pre-upgrade baseline.
+- **step2** — cluster partially upgraded (pool3 still on base binary, other nodes on upgrade binary, old config).
+- **step3** — all nodes on upgrade binary, new config + hard fork to the new protocol version.
+
+Inputs available under `{RUN_DIR}/` (use only what exists):
+
+- `{RUN_DIR}/allure-results-step1/`, `{RUN_DIR}/allure-results-step2/`, `{RUN_DIR}/allure-results-step3/` — one JSON per test per step (`status`, `statusDetails.message`, `statusDetails.trace`, stdout/stderr attachments listed by name)
+- `{RUN_DIR}/testrun-report-step1.html`, `…-step2.html`, `…-step3.html` — self-contained HTML reports (large; prefer the per-step allure JSON above)
+- `{RUN_DIR}/testing_artifacts/` — per-test artifact dirs with cluster logs, node stdouts, etc. (shared across all steps)
+- `{RUN_DIR}/errors_all.log` — output of `runner/grep_errors.sh` over cluster logs (covers all steps)
+- `{RUN_DIR}/scheduling.log` — cluster instance manager log
+
+Steps:
+
+1. Enumerate failed/broken tests per step:
+   `for s in step1 step2 step3; do grep -l -E '"status": "(failed|broken)"' {RUN_DIR}/allure-results-$s/*result.json 2>/dev/null | sed "s|^|$s: |"; done`
+   (`broken` = pytest error in setup/teardown; `failed` = assertion failure.)
+2. For each failing test, extract `statusDetails.message` head with:
+   `grep -E '"status": "(failed|broken)"' {RUN_DIR}/allure-results-step*/*result.json | cut -c1-200`.
+3. Group failures by likely root cause (same exception class + message head, same node crash, same infra symptom). **Note which step(s) each group hits** — a failure that appears only in step2 or step3 is much more interesting than one that already fails in step1. Treat one node crash that flunks many tests as a single group.
+4. For each group: list affected tests (truncate to ~10 with a "+N more" tail), give the most informative 1–3 lines of error context, mark the step(s) affected, and classify as one of `node-bug | test-bug | infra-flake | env-issue | upgrade-regression | unknown` with a short justification. Use `upgrade-regression` when a test passes in step1 but fails in step2 or step3 — that is the signal this workflow exists to catch.
+5. Skim `{RUN_DIR}/errors_all.log` and `{RUN_DIR}/scheduling.log` for anything corroborating (node crash on restart, hard-fork failure, supervisord errors, OOM, repeated tracebacks).
+6. If a whole step is missing its `allure-results-stepN/` dir, that step likely failed before pytest ran — call this out explicitly and check `errors_all.log` / the workflow log group output for the cause (commonly a `start-cluster` / `supervisord` / hard-fork failure).
+
+Known patterns:
+
+- **Step2 node failed to start** — typically a config-rewrite mismatch (genesis hashes, topology, `ExperimentalHardForksEnabled`) or pool3 still using `cardano-node-step1` against an incompatible config.
+- **Step3 hard-fork test failure** — `test_hardfork` fails or never raises the protocol version; later tests in step3 all then fail with stale protocol params.
+- **Sync stalls after restart** — `Failed to sync node` in workflow log; check whether pool1/pool3 PIDs are 0 or whether `syncProgress` never reaches `100.00`.
+- **`All cluster instances are dead.`** — no cluster instance could start; usually caused by a `cardano-cli` argument change or a `cardano-node` configuration change.
+
+Constraints:
+
+- Output a single markdown file at: `{RUN_DIR}/failure_analysis.md`.
+- Keep it under ~300 lines. No full stack traces — only the most informative line(s).
+- If a source file is missing, note it once and move on; do not fail.
+- Do not modify any other files.
+
+Start now.

--- a/runner/create_results.sh
+++ b/runner/create_results.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <reports_dir> <output_dir>" >&2
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <reports_dir> <output_dir> [basename]" >&2
   exit 1
 fi
 
 reports_dir="$1"
 output_dir="$2"
+basename="${3:-allure-results}"
 
 if [ "$(echo "$reports_dir"/*.json)" = "$reports_dir/*.json" ]; then
   echo "No reports found in $reports_dir" >&2
@@ -17,8 +18,8 @@ fi
 
 mkdir -p "$output_dir" || { echo "Cannot create $output_dir" >&2; exit 1; }
 
-results_tar="${output_dir}/allure-results.tar.xz"
-allure_results_dir="${output_dir}/allure-results"
+results_tar="${output_dir}/${basename}.tar.xz"
+allure_results_dir="${output_dir}/${basename}"
 
 rm -rf "${allure_results_dir:?}"
 mkdir -p "$allure_results_dir"
@@ -28,6 +29,6 @@ find "$reports_dir" -maxdepth 1 -type f \
 
 echo "Creating results archive $results_tar"
 rm -f "$results_tar"
-tar -C "$output_dir" -cJf "$results_tar" allure-results
+tar -C "$output_dir" -cJf "$results_tar" "$basename"
 # Keep $allure_results_dir around so post-testrun consumers (e.g. failure
 # analysis) can read it without having to untar the archive.

--- a/runner/node_upgrade.sh
+++ b/runner/node_upgrade.sh
@@ -82,8 +82,6 @@ mkdir -p "$ARTIFACTS_DIR"
 export COVERAGE_DIR="${WORKDIR}/cli_coverage"
 mkdir -p "$COVERAGE_DIR"
 
-export REPORTS_DIR="${WORKDIR}/reports"
-
 export SCHEDULING_LOG="${WORKDIR}/scheduling.log"
 : > "$SCHEDULING_LOG"
 

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -18,10 +18,6 @@ CLUSTER_SCRIPTS_DIR="$WORKDIR/cluster0_${CLUSTER_ERA}"
 # init dir for step1 binaries
 STEP1_BIN="$WORKDIR/step1-bin"
 
-# init reports dir before each step
-rm -rf "${REPORTS_DIR:?}"
-mkdir -p "$REPORTS_DIR"
-
 # shellcheck disable=SC1091
 . scripts/common.sh
 
@@ -33,6 +29,9 @@ if [ "$1" = "step1" ]; then
   printf "STEP1 start: %(%H:%M:%S)T\n" -1
 
   export UPGRADE_TESTS_STEP=1
+
+  REPORTS_DIR="${WORKDIR}/reports-step1"
+  mkdir -p "$REPORTS_DIR"
 
   if [ -n "${BASE_TAR_URL:-""}" ]; then
     # download and extract base revision binaries
@@ -96,8 +95,7 @@ if [ "$1" = "step1" ]; then
   [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
 
   # create results archive for step1
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
-  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step1.tar.xz"
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step1
 
   printf "STEP1 finish: %(%H:%M:%S)T\n" -1
 
@@ -110,6 +108,9 @@ elif [ "$1" = "step2" ]; then
   printf "STEP2 start: %(%H:%M:%S)T\n" -1
 
   export UPGRADE_TESTS_STEP=2
+
+  REPORTS_DIR="${WORKDIR}/reports-step2"
+  mkdir -p "$REPORTS_DIR"
 
   NETWORK_MAGIC="$(jq -r '.networkMagic' "$STATE_CLUSTER/shelley/genesis.json")"
   export NETWORK_MAGIC
@@ -239,8 +240,7 @@ elif [ "$1" = "step2" ]; then
   [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
 
   # create results archive for step2
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
-  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step2.tar.xz"
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step2
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 
@@ -255,6 +255,9 @@ elif [ "$1" = "step3" ]; then
   printf "STEP3 start: %(%H:%M:%S)T\n" -1
 
   export UPGRADE_TESTS_STEP=3
+
+  REPORTS_DIR="${WORKDIR}/reports-step3"
+  mkdir -p "$REPORTS_DIR"
 
   NETWORK_MAGIC="$(jq -r '.networkMagic' "$STATE_CLUSTER/shelley/genesis.json")"
   export NETWORK_MAGIC
@@ -391,8 +394,7 @@ elif [ "$1" = "step3" ]; then
     ||retval="$?"
 
   # create results archive for step3
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR"
-  mv "$WORKDIR/allure-results.tar.xz" "$WORKDIR/allure-results-step3.tar.xz"
+  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step3
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 

--- a/scripts/analyze_failures.sh
+++ b/scripts/analyze_failures.sh
@@ -11,12 +11,14 @@
 # prompt contract.
 #
 # Env vars:
-#   AGENT_CMD   Command used to invoke the agent. Default: "claude -p".
-#               Examples:
-#                 AGENT_CMD="claude -p"
-#                 AGENT_CMD="gemini"
-#                 AGENT_CMD="codex exec"
-#               The prompt is piped to the command on stdin.
+#   AGENT_CMD     Command used to invoke the agent. Default: "claude -p".
+#                 Examples:
+#                   AGENT_CMD="claude -p"
+#                   AGENT_CMD="gemini"
+#                   AGENT_CMD="codex exec"
+#                 The prompt is piped to the command on stdin.
+#   PROMPT_FILE   Override prompt auto-detection. Path to a prompt template
+#                 containing {RUN_DIR} placeholders.
 
 set -euo pipefail
 
@@ -25,14 +27,27 @@ AGENT_CMD="${AGENT_CMD:-claude -p}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PROMPT_FILE="${REPO_ROOT}/agent_docs/failure_analysis_prompt.md"
+
+if [ ! -d "${RUN_DIR}" ]; then
+  echo "Run directory not found: ${RUN_DIR}" >&2
+  exit 1
+fi
+
+# Auto-detect testsuite from RUN_DIR contents unless PROMPT_FILE is set.
+# Upgrade runs produce per-step allure result dirs/tarballs; regression runs
+# produce a single allure-results dir/tarball.
+if [ -z "${PROMPT_FILE:-}" ]; then
+  if compgen -G "${RUN_DIR}/allure-results-step*" > /dev/null; then
+    PROMPT_FILE="${REPO_ROOT}/agent_docs/upgrade_failure_analysis_prompt.md"
+    echo "Detected node-upgrade run; using upgrade prompt." >&2
+  else
+    PROMPT_FILE="${REPO_ROOT}/agent_docs/failure_analysis_prompt.md"
+    echo "Detected regression run; using regression prompt." >&2
+  fi
+fi
 
 if [ ! -f "${PROMPT_FILE}" ]; then
   echo "Prompt file not found: ${PROMPT_FILE}" >&2
-  exit 1
-fi
-if [ ! -d "${RUN_DIR}" ]; then
-  echo "Run directory not found: ${RUN_DIR}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Mirror the regression workflow's Claude-based preliminary failure analysis into upgrade_reusable.yaml, with a dedicated prompt that understands the three-step upgrade layout (base / partial / hard-fork) and the upgrade-regression classification.

Allow create_results.sh to take an optional basename so each upgrade step can preserve its own allure-results-stepN/ dir and tarball instead of being overwritten by the next step. analyze_failures.sh auto-detects upgrade vs regression runs from the RUN_DIR layout and picks the matching prompt, with a PROMPT_FILE override for manual use.

Propagate CLAUDE_CODE_OAUTH_TOKEN through nightly_upgrade.yaml so scheduled runs can produce and mail the analysis.