### PR TITLE
feat(utils): add support for loading pool relay IPv6 address

### DIFF
--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -562,6 +562,7 @@ def load_registered_pool_data(
         pool_metadata_url=metadata.get("url") or "",
         pool_metadata_hash=metadata.get("hash") or "",
         pool_relay_ipv4=relay.get("IPv4") or "",
+        pool_relay_ipv6=relay.get("IPv6") or "",
         pool_relay_port=relay.get("port") or 0,
     )
 


### PR DESCRIPTION
Added extraction of the "IPv6" field from relay metadata in `load_registered_pool_data`, enabling support for pool relays with IPv6 addresses.