### PR TITLE
feat(tx_view): allow empty tx view on Dijkstra

### DIFF
--- a/cardano_node_tests/tests/test_tx_metadata.py
+++ b/cardano_node_tests/tests/test_tx_metadata.py
@@ -527,7 +527,7 @@ class TestMetadata:
 
         # Check `transaction view` command
         tx_view_out = tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_raw_output)
-        assert json_body_metadata == tx_view_out["metadata"]
+        assert tx_view_out and json_body_metadata == tx_view_out["metadata"]
 
         # Check TX and metadata in db-sync if available
         tx_db_record = dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
@@ -596,7 +596,7 @@ class TestMetadata:
 
         # Check `transaction view` command
         tx_view_out = tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output)
-        assert json_body_metadata == tx_view_out["metadata"]
+        assert tx_view_out and json_body_metadata == tx_view_out["metadata"]
 
         # Check TX and metadata in db-sync if available
         tx_db_record = dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -378,9 +378,12 @@ class TestCollateralOutput:
 
         # Check "transaction view"
         tx_view_out = tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
-        policyid, asset_name = token[0].token.split(".")
-        tx_view_policy_key = f"policy {policyid}"
-        tx_view_token_rec = tx_view_out["return collateral"]["amount"][tx_view_policy_key]
-        tx_view_asset_key = next(iter(tx_view_token_rec))
-        assert asset_name in tx_view_asset_key, "Token is missing from tx view return collateral"
-        assert tx_view_token_rec[tx_view_asset_key] == token_amount, "Incorrect token amount"
+        if tx_view_out:
+            policyid, asset_name = token[0].token.split(".")
+            tx_view_policy_key = f"policy {policyid}"
+            tx_view_token_rec = tx_view_out["return collateral"]["amount"][tx_view_policy_key]
+            tx_view_asset_key = next(iter(tx_view_token_rec))
+            assert asset_name in tx_view_asset_key, (
+                "Token is missing from tx view return collateral"
+            )
+            assert tx_view_token_rec[tx_view_asset_key] == token_amount, "Incorrect token amount"

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -363,9 +363,12 @@ class TestCollateralOutput:
 
         # Check "transaction view"
         tx_view_out = tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
-        policyid, asset_name = token[0].token.split(".")
-        tx_view_policy_key = f"policy {policyid}"
-        tx_view_token_rec = tx_view_out["return collateral"]["amount"][tx_view_policy_key]
-        tx_view_asset_key = next(iter(tx_view_token_rec))
-        assert asset_name in tx_view_asset_key, "Token is missing from tx view return collateral"
-        assert tx_view_token_rec[tx_view_asset_key] == token_amount, "Incorrect token amount"
+        if tx_view_out:
+            policyid, asset_name = token[0].token.split(".")
+            tx_view_policy_key = f"policy {policyid}"
+            tx_view_token_rec = tx_view_out["return collateral"]["amount"][tx_view_policy_key]
+            tx_view_asset_key = next(iter(tx_view_token_rec))
+            assert asset_name in tx_view_asset_key, (
+                "Token is missing from tx view return collateral"
+            )
+            assert tx_view_token_rec[tx_view_asset_key] == token_amount, "Incorrect token amount"

--- a/cardano_node_tests/utils/tx_view.py
+++ b/cardano_node_tests/utils/tx_view.py
@@ -240,7 +240,14 @@ def check_tx_view(  # noqa: C901
     *, cluster_obj: clusterlib.ClusterLib, tx_raw_output: clusterlib.TxRawOutput
 ) -> dict[str, tp.Any]:
     """Check output of the `transaction view` command."""
-    tx_loaded = load_tx_view(cluster_obj=cluster_obj, tx_body_file=tx_raw_output.out_file)
+    try:
+        tx_loaded = load_tx_view(cluster_obj=cluster_obj, tx_body_file=tx_raw_output.out_file)
+    except clusterlib.CLIError as exc:
+        # `transaction view` is not yet implemented on Dijkstra; return empty dict so callers
+        # skip the view checks instead of failing.
+        if "TODO Dijkstra" in str(exc):
+            return {}
+        raise
 
     # Check inputs
     loaded_txins = set(tx_loaded.get("inputs") or [])


### PR DESCRIPTION
`transaction view` is not yet implemented on Dijkstra and fails with a "TODO Dijkstra" CLIError. Return an empty dict from check_tx_view in that case so callers skip the view checks instead of failing, and guard the callers that index into the result.