### PR TITLE
refactor(tests): derive era skips from version MAP

### DIFF
--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -168,7 +168,7 @@ class TestSetup:
         on step 3 of upgrade testing sequence.
 
         * Get current protocol version and calculate target version (current + 1)
-        * Skip if already at LAST_KNOWN_PROTOCOL_VERSION
+        * Skip if already at last supported protocol version
         * Check that ExperimentalHardForksEnabled is true in node config
         * Get default governance data (DReps, committee members, pools)
         * Wait for any delayed ratification to complete
@@ -185,10 +185,11 @@ class TestSetup:
         prot_ver_init = clusterlib_utils.get_protocol_version(cluster_obj=cluster)
         prot_ver_target = prot_ver_init + 1
 
-        if prot_ver_init >= VERSIONS.LAST_KNOWN_PROTOCOL_VERSION:
+        if VERSIONS.MAP.get(prot_ver_target) is None:
             pytest.skip(
-                "The major protocol version needs to be at most "
-                f"{VERSIONS.LAST_KNOWN_PROTOCOL_VERSION - 1}."
+                "The target protocol version needs to be known. "
+                f"Current protocol version: {prot_ver_init}, "
+                f"target protocol version: {prot_ver_target}."
             )
 
         with open(

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -35,24 +35,26 @@ class TestNegative:
     """Transaction tests that are expected to fail."""
 
     @pytest.fixture(scope="class")
-    def skip_on_last_era(self) -> None:
-        last_known_era_name = VERSIONS.MAP[VERSIONS.LAST_KNOWN_PROTOCOL_VERSION]
-        if VERSIONS.cluster_era_name == last_known_era_name:
+    def skip_on_wrong_future_era(self) -> None:
+        future_era_name = VERSIONS.MAP.get(VERSIONS.cluster_era + 1)
+        if future_era_name is None:
             pytest.skip(
-                f"doesn't run with the latest cluster era ({VERSIONS.cluster_era_name})",
+                "no known era with higher protocol version than the current cluster era "
+                f"({VERSIONS.cluster_era_name})"
             )
-
-    @pytest.fixture(scope="class")
-    def skip_unknown_last_era(self) -> None:
-        last_known_era_name = VERSIONS.MAP[VERSIONS.LAST_KNOWN_PROTOCOL_VERSION]
-        if not clusterlib_utils.cli_has(last_known_era_name):
-            pytest.skip(f"`{last_known_era_name} transaction build-raw` command is not available")
+        current_era_name = VERSIONS.MAP[VERSIONS.cluster_era]
+        if current_era_name == future_era_name:
+            pytest.skip(
+                f"current cluster era ({current_era_name}) "
+                f"is the same as the future era ({future_era_name})"
+            )
+        if not clusterlib_utils.cli_has(future_era_name):
+            pytest.skip(f"`{future_era_name} transaction build-raw` command is not available")
 
     @pytest.fixture
     def cluster_wrong_tx_era(
         self,
-        skip_on_last_era: None,  # noqa: ARG002
-        skip_unknown_last_era: None,  # noqa: ARG002
+        skip_on_wrong_future_era: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,  # noqa: ARG002
     ) -> clusterlib.ClusterLib:
         # The `cluster` argument (representing the `cluster` fixture) needs to be present

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -71,10 +71,11 @@ class TestHardfork:
         prot_ver_init = clusterlib_utils.get_protocol_version(cluster_obj=cluster)
         prot_ver_target = prot_ver_init + 1
 
-        if prot_ver_init >= VERSIONS.LAST_KNOWN_PROTOCOL_VERSION:
+        if VERSIONS.MAP.get(prot_ver_target) is None:
             pytest.skip(
-                "The major protocol version needs to be at most "
-                f"{VERSIONS.LAST_KNOWN_PROTOCOL_VERSION - 1}."
+                "The target protocol version needs to be known. "
+                f"Current protocol version: {prot_ver_init}, "
+                f"target protocol version: {prot_ver_target}."
             )
 
         with open(

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -31,8 +31,6 @@ class Versions:
 
     DEFAULT_CLUSTER_ERA: tp.Final[int] = CONWAY
     DEFAULT_TX_ERA: tp.Final[int] = DEFAULT_CLUSTER_ERA
-    # Latest protocol version supported by the node
-    LAST_KNOWN_PROTOCOL_VERSION: tp.Final[int] = 11
 
     # Map protocol versions to era names
     MAP: tp.ClassVar[dict[int, str]] = {


### PR DESCRIPTION
Drop hardcoded LAST_KNOWN_PROTOCOL_VERSION and instead determine skip conditions dynamically from VERSIONS.MAP. This lets the upgrade and hardfork tests target the next known protocol version (Dijkstra) and lets the negative tx tests detect a valid future era regardless of the current cluster era.