### PR TITLE
chore: lowercase non-exported shell variables

### DIFF
--- a/cabal_build_tests/install-node.sh
+++ b/cabal_build_tests/install-node.sh
@@ -11,8 +11,8 @@
 # Please note: 'source ~/.bashrc' cmd is not used because Docker runs this script as subscript
 
 # Versions
-GHC_VERSION="9.6.7"
-CABAL_VERSION="3.12.1.0"
+readonly GHC_VERSION="9.6.7"
+readonly CABAL_VERSION="3.12.1.0"
 
 echo ""
 
@@ -82,8 +82,8 @@ elif [[ "$distro" == "ubuntu" ]]; then
 fi
 
 # Version of iohk-nix
-IOHKNIX_VERSION="$(curl "https://raw.githubusercontent.com/IntersectMBO/cardano-node/$GIT_OBJECT/flake.lock" | jq -r '.nodes.iohkNix.locked.rev')"
-echo "iohk-nix version: $IOHKNIX_VERSION"
+iohknix_version="$(curl "https://raw.githubusercontent.com/IntersectMBO/cardano-node/$GIT_OBJECT/flake.lock" | jq -r '.nodes.iohkNix.locked.rev')"
+echo "iohk-nix version: $iohknix_version"
 
 # Install GHCup - the main installer for Haskell
 echo "Install GHCup"
@@ -118,12 +118,12 @@ echo "Install Libsodium"
 mkdir -p ~/src || exit 1
 cd ~/src || exit 1
 
-LIBSODIUM_VERSION="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$IOHKNIX_VERSION/flake.lock" | jq -r '.nodes.sodium.original.rev')"
-echo "Using sodium version: $LIBSODIUM_VERSION"
+libsodium_version="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$iohknix_version/flake.lock" | jq -r '.nodes.sodium.original.rev')"
+echo "Using sodium version: $libsodium_version"
 
 git clone https://github.com/IntersectMBO/libsodium
 cd libsodium || exit 1
-git checkout "$LIBSODIUM_VERSION"
+git checkout "$libsodium_version"
 ./autogen.sh
 ./configure
 make
@@ -141,10 +141,10 @@ echo "Install Secp256k1"
 mkdir -p ~/src || exit 1
 cd ~/src || exit 1
 
-SECP256K1_VERSION="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$IOHKNIX_VERSION/flake.lock" | jq -r '.nodes.secp256k1.original.ref')"
-echo "Using secp256k1 version: ${SECP256K1_VERSION}"
+secp256k1_version="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$iohknix_version/flake.lock" | jq -r '.nodes.secp256k1.original.ref')"
+echo "Using secp256k1 version: ${secp256k1_version}"
 
-git clone --depth 1 --branch "${SECP256K1_VERSION}" https://github.com/bitcoin-core/secp256k1
+git clone --depth 1 --branch "${secp256k1_version}" https://github.com/bitcoin-core/secp256k1
 cd secp256k1 || exit 1
 ./autogen.sh
 ./configure --enable-module-schnorrsig --enable-experimental
@@ -158,10 +158,10 @@ echo "Install BLST"
 mkdir -p ~/src || exit 1
 cd ~/src || exit 1
 
-BLST_VERSION="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$IOHKNIX_VERSION/flake.lock" | jq -r '.nodes.blst.original.ref')"
-echo "Using blst version: ${BLST_VERSION}"
+blst_version="$(curl "https://raw.githubusercontent.com/input-output-hk/iohk-nix/$iohknix_version/flake.lock" | jq -r '.nodes.blst.original.ref')"
+echo "Using blst version: ${blst_version}"
 
-git clone --depth 1 --branch "${BLST_VERSION}" https://github.com/supranational/blst
+git clone --depth 1 --branch "${blst_version}" https://github.com/supranational/blst
 cd blst || exit 1
 ./build.sh
 cat > libblst.pc << EOF
@@ -173,7 +173,7 @@ includedir=\${prefix}/include
 Name: libblst
 Description: Multilingual BLS12-381 signature library
 URL: https://github.com/supranational/blst
-Version: ${BLST_VERSION#v}
+Version: ${blst_version#v}
 Cflags: -I\${includedir}
 Libs: -L\${libdir} -lblst
 EOF
@@ -192,14 +192,14 @@ cd cardano-node || exit 1
 git fetch --all --recurse-submodules --tags
 
 # Checkout with prechecks for git object and git object type
-OBJ_TYPE="$(git cat-file -t "$GIT_OBJECT")"
-if [[ "$OBJ_TYPE" != "commit" && "$OBJ_TYPE" != "tag" ]]; then
-  >&2 echo "'$OBJ_TYPE' does not refer to a commit/tag."
+obj_type="$(git cat-file -t "$GIT_OBJECT")"
+if [[ "$obj_type" != "commit" && "$obj_type" != "tag" ]]; then
+  >&2 echo "'$obj_type' does not refer to a commit/tag."
   exit 1
 fi
 
 git checkout "$GIT_OBJECT"
-GIT_REV=$(git rev-parse HEAD)
+git_rev=$(git rev-parse HEAD)
 
 # Configure build options
 echo "Configure build options"
@@ -216,13 +216,13 @@ cp -p "$(cabal list-bin cardano-cli)" ~/.local/bin/
 
 # Verify installation
 echo "Verify 'cardano-cli' is installed"
-if ! [[ "$(cardano-cli --version | tail -n 1)" == *"$GIT_REV"* ]]; then
+if ! [[ "$(cardano-cli --version | tail -n 1)" == *"$git_rev"* ]]; then
   >&2 echo "'$(cardano-cli --version)' failed"
   exit 1
 fi
 
 echo "Verify 'cardano-node' is installed"
-if ! [[ "$(cardano-node --version | tail -n 1)" == *"$GIT_REV"* ]]; then
+if ! [[ "$(cardano-node --version | tail -n 1)" == *"$git_rev"* ]]; then
   >&2 echo "'$(cardano-node --version)' failed"
   exit 1
 fi

--- a/cabal_build_tests/run.sh
+++ b/cabal_build_tests/run.sh
@@ -10,12 +10,12 @@ else
 fi
 
 GIT_OBJECT=""
-DISTRO=""
+distro=""
 
 while getopts "o:d:" flag; do
   case "${flag}" in
     o) GIT_OBJECT=${OPTARG};;
-    d) DISTRO=${OPTARG};;
+    d) distro=${OPTARG};;
     *) echo "Error in command line parsing" >&2
        exit 1
        ;;
@@ -28,36 +28,36 @@ if [ -z "$GIT_OBJECT" ]; then
   exit 1
 fi
 
-# Validate that DISTRO was provided
-if [ -z "$DISTRO" ]; then
+# Validate that distro was provided
+if [ -z "$distro" ]; then
   echo "Error: Missing required -d flag for distro." >&2
   exit 1
 fi
 
 # Determine correct base image and tag
-case "$DISTRO" in
+case "$distro" in
   fedora)
     BASE_IMAGE="docker.io/library/fedora:latest"
-    TAG="cardano-node-fedora"
+    tag="cardano-node-fedora"
     ;;
   ubuntu)
     BASE_IMAGE="docker.io/library/ubuntu:latest"
-    TAG="cardano-node-ubuntu"
+    tag="cardano-node-ubuntu"
     ;;
   *)
-    echo "Unsupported distro: $DISTRO. Use 'ubuntu' or 'fedora'." >&2
+    echo "Unsupported distro: $distro. Use 'ubuntu' or 'fedora'." >&2
     exit 1
     ;;
 esac
 
 echo "Using base image: $BASE_IMAGE"
-echo "Building image: $TAG"
+echo "Building image: $tag"
 
 $container_manager build . \
   --pull \
   -f Dockerfile \
   --build-arg BASE_IMAGE="$BASE_IMAGE" \
-  -t "$TAG" \
+  -t "$tag" \
   || exit 1
 
 $container_manager run \
@@ -66,4 +66,4 @@ $container_manager run \
   -it \
   -e GIT_OBJECT="$GIT_OBJECT" \
   -e KEEP_RUNNING="${KEEP_RUNNING:-1}" \
-  "$TAG"
+  "$tag"

--- a/cardano_node_tests/cluster_scripts/testnets/dbsync_block_no.sh
+++ b/cardano_node_tests/cluster_scripts/testnets/dbsync_block_no.sh
@@ -3,13 +3,13 @@
 
 set -euo pipefail
 
-SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
-STATE_CLUSTER="${SOCKET_PATH%/*}"
-INSTANCE_NUM="${STATE_CLUSTER#*state-cluster}"
-DATABASE_NAME="dbsync${INSTANCE_NUM}"
+socket_path="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
+state_cluster="${socket_path%/*}"
+instance_num="${state_cluster#*state-cluster}"
+database_name="dbsync${instance_num}"
 
 export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-psql -A -t -d "$DATABASE_NAME" -c "SELECT block_no FROM block ORDER BY ID DESC LIMIT 1;"
+psql -A -t -d "$database_name" -c "SELECT block_no FROM block ORDER BY ID DESC LIMIT 1;"

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -6,17 +6,17 @@ trap 'echo "Error at line $LINENO"' ERR
 retval=0
 
 export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
-STATE_CLUSTER="${CARDANO_NODE_SOCKET_PATH_CI%/*}"
+state_cluster="${CARDANO_NODE_SOCKET_PATH_CI%/*}"
 
 # default era to use, can be overridden in each step if needed
-CLUSTER_ERA="conway"
-export COMMAND_ERA="${COMMAND_ERA:-"$CLUSTER_ERA"}"
+cluster_era="conway"
+export COMMAND_ERA="${COMMAND_ERA:-"$cluster_era"}"
 
 : "${WORKDIR:?WORKDIR environment variable must be set}"
-CLUSTER_SCRIPTS_DIR="$WORKDIR/cluster0_${CLUSTER_ERA}"
+cluster_scripts_dir="$WORKDIR/cluster0_${cluster_era}"
 
 # init dir for step1 binaries
-STEP1_BIN="$WORKDIR/step1-bin"
+readonly STEP1_BIN="$WORKDIR/step1-bin"
 
 # shellcheck disable=SC1091
 . scripts/common.sh
@@ -30,26 +30,26 @@ if [ "$1" = "step1" ]; then
 
   export UPGRADE_TESTS_STEP=1
 
-  REPORTS_DIR="${WORKDIR}/reports-step1"
-  mkdir -p "$REPORTS_DIR"
+  reports_dir="${WORKDIR}/reports-step1"
+  mkdir -p "$reports_dir"
 
   if [ -n "${BASE_TAR_URL:-""}" ]; then
     # download and extract base revision binaries
-    BASE_TAR_FILE="$WORKDIR/base_rev.tar.gz"
-    curl -sSL "$BASE_TAR_URL" > "$BASE_TAR_FILE" || exit 6
+    base_tar_file="$WORKDIR/base_rev.tar.gz"
+    curl -sSL "$BASE_TAR_URL" > "$base_tar_file" || exit 6
     mkdir -p "$WORKDIR/base_rev"
-    tar -C "$WORKDIR/base_rev" -xzf "$BASE_TAR_FILE" || exit 6
-    rm -f "$BASE_TAR_FILE"
+    tar -C "$WORKDIR/base_rev" -xzf "$base_tar_file" || exit 6
+    rm -f "$base_tar_file"
     # add base revision binaries to the PATH
-    BASE_REV_BIN="$WORKDIR/base_rev/bin"
-    mkdir -p "$BASE_REV_BIN"
+    base_rev_bin="$WORKDIR/base_rev/bin"
+    mkdir -p "$base_rev_bin"
     # TODO: there seems to be a change of layout of the archive. Since 10.2.0, there is already a `bin`
     # dir and the binaries are already placed there.
-    if [ ! -e "$BASE_REV_BIN/cardano-node" ]; then
-      ln -s "$WORKDIR/base_rev/cardano-node" "$BASE_REV_BIN/cardano-node"
-      ln -s "$WORKDIR/base_rev/cardano-cli" "$BASE_REV_BIN/cardano-cli"
+    if [ ! -e "$base_rev_bin/cardano-node" ]; then
+      ln -s "$WORKDIR/base_rev/cardano-node" "$base_rev_bin/cardano-node"
+      ln -s "$WORKDIR/base_rev/cardano-cli" "$base_rev_bin/cardano-cli"
     fi
-    export PATH="${BASE_REV_BIN}:${PATH}"
+    export PATH="${base_rev_bin}:${PATH}"
   fi
 
   if is_truthy "${CI_BYRON_CLUSTER:-}"; then
@@ -61,13 +61,13 @@ if [ "$1" = "step1" ]; then
 
   # generate local cluster scripts
   prepare-cluster-scripts \
-    -d "$CLUSTER_SCRIPTS_DIR" \
+    -d "$cluster_scripts_dir" \
     -t "$TESTNET_VARIANT"
 
   # try to stop local cluster
-  "$CLUSTER_SCRIPTS_DIR/stop-cluster"
+  "$cluster_scripts_dir/stop-cluster"
   # start local cluster
-  "$CLUSTER_SCRIPTS_DIR/start-cluster" || exit 6
+  "$cluster_scripts_dir/start-cluster" || exit 6
 
   # backup the original cardano binaries
   mkdir -p "$STEP1_BIN"
@@ -75,7 +75,7 @@ if [ "$1" = "step1" ]; then
   ln -s "$(command -v cardano-cli)" "$STEP1_BIN/cardano-cli-step1"
 
   # backup the original config file
-  cp -f "$STATE_CLUSTER/config-pool3.json" "$STATE_CLUSTER/config-pool3.step1.json"
+  cp -f "$state_cluster/config-pool3.json" "$state_cluster/config-pool3.step1.json"
 
   # run smoke tests
   printf "STEP1 tests: %(%H:%M:%S)T\n" -1
@@ -86,16 +86,16 @@ if [ "$1" = "step1" ]; then
     -m "smoke or upgrade_step1" \
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
-    --alluredir="$REPORTS_DIR" \
+    --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step1.html" \
     --self-contained-html \
     || retval="$?"
 
   # stop local cluster if tests failed unexpectedly
-  [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
+  [ "$retval" -le 1 ] || "$cluster_scripts_dir/stop-cluster"
 
   # create results archive for step1
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step1
+  ./runner/create_results.sh "$reports_dir" "$WORKDIR" allure-results-step1
 
   printf "STEP1 finish: %(%H:%M:%S)T\n" -1
 
@@ -109,10 +109,10 @@ elif [ "$1" = "step2" ]; then
 
   export UPGRADE_TESTS_STEP=2
 
-  REPORTS_DIR="${WORKDIR}/reports-step2"
-  mkdir -p "$REPORTS_DIR"
+  reports_dir="${WORKDIR}/reports-step2"
+  mkdir -p "$reports_dir"
 
-  NETWORK_MAGIC="$(jq -r '.networkMagic' "$STATE_CLUSTER/shelley/genesis.json")"
+  NETWORK_MAGIC="$(jq -r '.networkMagic' "$state_cluster/shelley/genesis.json")"
   export NETWORK_MAGIC
 
   # add binaries saved in step1 to the PATH
@@ -122,14 +122,14 @@ elif [ "$1" = "step2" ]; then
   CARDANO_NODE_SOCKET_PATH="$WORKDIR/dry_config_step2/state-cluster0/bft1.socket" \
     PROTOCOL_VERSION=11 \
     DRY_RUN=true \
-    "$CLUSTER_SCRIPTS_DIR/start-cluster"
+    "$cluster_scripts_dir/start-cluster"
 
 
   # use the original genesis files
-  BYRON_GENESIS_HASH="$(jq -r '.ByronGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  SHELLEY_GENESIS_HASH="$(jq -r '.ShelleyGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  ALONZO_GENESIS_HASH="$(jq -r '.AlonzoGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  CONWAY_GENESIS_HASH="$(jq -r '.ConwayGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
+  byron_genesis_hash="$(jq -r '.ByronGenesisHash' "$state_cluster/config-bft1.json")"
+  shelley_genesis_hash="$(jq -r '.ShelleyGenesisHash' "$state_cluster/config-bft1.json")"
+  alonzo_genesis_hash="$(jq -r '.AlonzoGenesisHash' "$state_cluster/config-bft1.json")"
+  conway_genesis_hash="$(jq -r '.ConwayGenesisHash' "$state_cluster/config-bft1.json")"
 
   # copy newly generated config files to the cluster state dir
   for conf in "$WORKDIR"/dry_config_step2/state-cluster0/config-*.json; do
@@ -140,12 +140,12 @@ elif [ "$1" = "step2" ]; then
     # use new config on upgraded nodes
     if [ "$fname" != "config-pool3.json" ]; then
       jq \
-        --arg byron_hash "$BYRON_GENESIS_HASH" \
-        --arg shelley_hash "$SHELLEY_GENESIS_HASH" \
+        --arg byron_hash "$byron_genesis_hash" \
+        --arg shelley_hash "$shelley_genesis_hash" \
         --arg alonzo_file "shelley/genesis.alonzo.json" \
-        --arg alonzo_hash "$ALONZO_GENESIS_HASH" \
+        --arg alonzo_hash "$alonzo_genesis_hash" \
         --arg conway_file "shelley/genesis.conway.json" \
-        --arg conway_hash "$CONWAY_GENESIS_HASH" '
+        --arg conway_hash "$conway_genesis_hash" '
         .ByronGenesisHash = $byron_hash
         | .ShelleyGenesisHash = $shelley_hash
         | .AlonzoGenesisFile = $alonzo_file
@@ -153,35 +153,35 @@ elif [ "$1" = "step2" ]; then
         | .ConwayGenesisFile = $conway_file
         | .ConwayGenesisHash = $conway_hash
         | .ExperimentalHardForksEnabled = false
-        ' "$conf" > "$STATE_CLUSTER/$fname"
+        ' "$conf" > "$state_cluster/$fname"
     fi
 
     # copy newly generated topology files to the cluster state dir
-    cp -f "${WORKDIR}/dry_config_step2/state-cluster0/topology-${nodename}.json" "$STATE_CLUSTER"
+    cp -f "${WORKDIR}/dry_config_step2/state-cluster0/topology-${nodename}.json" "$state_cluster"
   done
 
   # run the pool3 with the original cardano-node binary
-  cp -f "$STATE_CLUSTER/cardano-node-pool3" "$STATE_CLUSTER/cardano-node-pool3.orig"
-  sed -i 's/cardano-node run/cardano-node-step1 run/' "$STATE_CLUSTER/cardano-node-pool3"
+  cp -f "$state_cluster/cardano-node-pool3" "$state_cluster/cardano-node-pool3.orig"
+  sed -i 's/cardano-node run/cardano-node-step1 run/' "$state_cluster/cardano-node-pool3"
 
   # Restart local cluster nodes with binaries from new cluster-node version.
   # It is necessary to restart supervisord with new environment.
-  "$STATE_CLUSTER/supervisorctl_local" stop all
+  "$state_cluster/supervisorctl_local" stop all
   sleep 5
-  "$STATE_CLUSTER/stop-cluster"
+  "$state_cluster/stop-cluster"
   sleep 3
-  "$STATE_CLUSTER/supervisord_start" || exit 6
+  "$state_cluster/supervisord_start" || exit 6
   sleep 5
-  "$STATE_CLUSTER/supervisorctl_local" start all
+  "$state_cluster/supervisorctl_local" start all
   sleep 5
-  "$STATE_CLUSTER/supervisorctl_local" status
+  "$state_cluster/supervisorctl_local" status
 
   # print path to cardano-node binaries
   echo "pool1 node binary:"
-  pool1_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool1)"
+  pool1_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool1)"
   readlink -f "/proc/$pool1_pid/exe"
   echo "pool3 node binary:"
-  pool3_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool3)"
+  pool3_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool3)"
   readlink -f "/proc/$pool3_pid/exe"
 
   # check that nodes are running
@@ -214,10 +214,10 @@ elif [ "$1" = "step2" ]; then
   # generate ledger peer snapshot using old node version
   cardano-cli-step1 query ledger-peer-snapshot \
     --testnet-magic "$NETWORK_MAGIC" \
-    --socket-path "$STATE_CLUSTER/pool3.socket" \
+    --socket-path "$state_cluster/pool3.socket" \
     --output-json \
-    --out-file "$STATE_CLUSTER/peer-snapshot-base.json"
-  if [ ! -e "$STATE_CLUSTER/peer-snapshot-base.json" ]; then
+    --out-file "$state_cluster/peer-snapshot-base.json"
+  if [ ! -e "$state_cluster/peer-snapshot-base.json" ]; then
     echo "Failed to get peer snapshot from pool3" >&2
     exit 6
   fi
@@ -231,16 +231,16 @@ elif [ "$1" = "step2" ]; then
     -m "smoke or upgrade_step2" \
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
-    --alluredir="$REPORTS_DIR" \
+    --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step2.html" \
     --self-contained-html \
     ||retval="$?"
 
   # stop local cluster if tests failed unexpectedly
-  [ "$retval" -le 1 ] || "$CLUSTER_SCRIPTS_DIR/stop-cluster"
+  [ "$retval" -le 1 ] || "$cluster_scripts_dir/stop-cluster"
 
   # create results archive for step2
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step2
+  ./runner/create_results.sh "$reports_dir" "$WORKDIR" allure-results-step2
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 
@@ -256,61 +256,61 @@ elif [ "$1" = "step3" ]; then
 
   export UPGRADE_TESTS_STEP=3
 
-  REPORTS_DIR="${WORKDIR}/reports-step3"
-  mkdir -p "$REPORTS_DIR"
+  reports_dir="${WORKDIR}/reports-step3"
+  mkdir -p "$reports_dir"
 
-  NETWORK_MAGIC="$(jq -r '.networkMagic' "$STATE_CLUSTER/shelley/genesis.json")"
+  NETWORK_MAGIC="$(jq -r '.networkMagic' "$state_cluster/shelley/genesis.json")"
   export NETWORK_MAGIC
 
   # re-generate config and topology files
   CARDANO_NODE_SOCKET_PATH="$WORKDIR/dry_config_step3/state-cluster0/bft1.socket" \
     PROTOCOL_VERSION=11 \
     DRY_RUN=true \
-    "$CLUSTER_SCRIPTS_DIR/start-cluster"
+    "$cluster_scripts_dir/start-cluster"
 
   # copy newly generated topology files to the cluster state dir
-  cp -f "$WORKDIR"/dry_config_step3/state-cluster0/topology-*.json "$STATE_CLUSTER"
+  cp -f "$WORKDIR"/dry_config_step3/state-cluster0/topology-*.json "$state_cluster"
 
   # Copy newly generated config files to the cluster state dir, but use the original genesis files
-  BYRON_GENESIS_HASH="$(jq -r '.ByronGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  SHELLEY_GENESIS_HASH="$(jq -r '.ShelleyGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  ALONZO_GENESIS_HASH="$(jq -r '.AlonzoGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  CONWAY_GENESIS_HASH="$(jq -r '.ConwayGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  DIJKSTRA_GENESIS_HASH="$(jq -r '.DijkstraGenesisHash' "$STATE_CLUSTER/config-bft1.json")"
-  if [ -z "$DIJKSTRA_GENESIS_HASH" ] || [ "$DIJKSTRA_GENESIS_HASH" = "null" ]; then
-    cp -f "$WORKDIR/dry_config_step3/state-cluster0/shelley/genesis.dijkstra.json" "$STATE_CLUSTER/shelley"
-    DIJKSTRA_GENESIS_HASH="$(cardano-cli latest genesis hash --genesis \
-      "$STATE_CLUSTER/shelley/genesis.dijkstra.json")"
+  byron_genesis_hash="$(jq -r '.ByronGenesisHash' "$state_cluster/config-bft1.json")"
+  shelley_genesis_hash="$(jq -r '.ShelleyGenesisHash' "$state_cluster/config-bft1.json")"
+  alonzo_genesis_hash="$(jq -r '.AlonzoGenesisHash' "$state_cluster/config-bft1.json")"
+  conway_genesis_hash="$(jq -r '.ConwayGenesisHash' "$state_cluster/config-bft1.json")"
+  dijkstra_genesis_hash="$(jq -r '.DijkstraGenesisHash' "$state_cluster/config-bft1.json")"
+  if [ -z "$dijkstra_genesis_hash" ] || [ "$dijkstra_genesis_hash" = "null" ]; then
+    cp -f "$WORKDIR/dry_config_step3/state-cluster0/shelley/genesis.dijkstra.json" "$state_cluster/shelley"
+    dijkstra_genesis_hash="$(cardano-cli latest genesis hash --genesis \
+      "$state_cluster/shelley/genesis.dijkstra.json")"
   fi
-  NODE_VER="$(version_parse "$(get_node_version)")"
-  NODE_V11="$(version_parse 11.0.0)"
+  node_ver="$(version_parse "$(get_node_version)")"
+  node_v11="$(version_parse 11.0.0)"
 
   for conf in "$WORKDIR"/dry_config_step3/state-cluster0/config-*.json; do
     fname="${conf##*/}"
     jq \
-      --arg byron_hash "$BYRON_GENESIS_HASH" \
-      --arg shelley_hash "$SHELLEY_GENESIS_HASH" \
-      --arg alonzo_hash "$ALONZO_GENESIS_HASH" \
-      --arg conway_hash "$CONWAY_GENESIS_HASH" \
-      --arg dijkstra_hash "$DIJKSTRA_GENESIS_HASH" \
-      --argjson node_ver "$NODE_VER" \
-      --argjson node_v11 "$NODE_V11" '
+      --arg byron_hash "$byron_genesis_hash" \
+      --arg shelley_hash "$shelley_genesis_hash" \
+      --arg alonzo_hash "$alonzo_genesis_hash" \
+      --arg conway_hash "$conway_genesis_hash" \
+      --arg dijkstra_hash "$dijkstra_genesis_hash" \
+      --argjson node_ver "$node_ver" \
+      --argjson node_v11 "$node_v11" '
       .ByronGenesisHash = $byron_hash
       | .ShelleyGenesisHash = $shelley_hash
       | .AlonzoGenesisHash = $alonzo_hash
       | .ConwayGenesisHash = $conway_hash
       | .DijkstraGenesisHash = $dijkstra_hash
       | .ExperimentalProtocolsEnabled = ($node_ver < $node_v11)
-      ' "$conf" > "$STATE_CLUSTER/$fname"
+      ' "$conf" > "$state_cluster/$fname"
   done
 
   # generate ledger peer snapshot using new node version
   cardano-cli query ledger-peer-snapshot \
     --testnet-magic "$NETWORK_MAGIC" \
-    --socket-path "$STATE_CLUSTER/pool1.socket" \
+    --socket-path "$state_cluster/pool1.socket" \
     --output-json \
-    --out-file "$STATE_CLUSTER/peer-snapshot-upgrade.json"
-  if [ ! -e "$STATE_CLUSTER/peer-snapshot-upgrade.json" ]; then
+    --out-file "$state_cluster/peer-snapshot-upgrade.json"
+  if [ ! -e "$state_cluster/peer-snapshot-upgrade.json" ]; then
     echo "Failed to get peer snapshot from pool1" >&2
     exit 6
   fi
@@ -319,35 +319,35 @@ elif [ "$1" = "step3" ]; then
   jq '
     .localRoots[] += {"trustable": true}
     | .peerSnapshotFile = "peer-snapshot-base.json"
-    ' "$STATE_CLUSTER/topology-pool1.json" > "$STATE_CLUSTER/topology-pool1.tmp.json"
-  mv -f "$STATE_CLUSTER/topology-pool1.tmp.json" "$STATE_CLUSTER/topology-pool1.json"
+    ' "$state_cluster/topology-pool1.json" > "$state_cluster/topology-pool1.tmp.json"
+  mv -f "$state_cluster/topology-pool1.tmp.json" "$state_cluster/topology-pool1.json"
   jq '
     .localRoots[] += {"trustable": true}
     | .peerSnapshotFile = "peer-snapshot-upgrade.json"
-    ' "$STATE_CLUSTER/topology-pool3.json" > "$STATE_CLUSTER/topology-pool3.tmp.json"
-  mv -f "$STATE_CLUSTER/topology-pool3.tmp.json" "$STATE_CLUSTER/topology-pool3.json"
+    ' "$state_cluster/topology-pool3.json" > "$state_cluster/topology-pool3.tmp.json"
+  mv -f "$state_cluster/topology-pool3.tmp.json" "$state_cluster/topology-pool3.json"
 
   # set `GenesisMode` for nodes that will use the ledger peer snapshot
   for pool in pool1 pool3; do
     jq '.ConsensusMode = "GenesisMode"' \
-      "$STATE_CLUSTER/config-${pool}.json" > "$STATE_CLUSTER/config-${pool}.tmp.json"
-    mv -f "$STATE_CLUSTER/config-${pool}.tmp.json" "$STATE_CLUSTER/config-${pool}.json"
+      "$state_cluster/config-${pool}.json" > "$state_cluster/config-${pool}.tmp.json"
+    mv -f "$state_cluster/config-${pool}.tmp.json" "$state_cluster/config-${pool}.json"
   done
 
   # use the upgraded cardano-node binary for pool3
-  cp -f "$STATE_CLUSTER/cardano-node-pool3.orig" "$STATE_CLUSTER/cardano-node-pool3"
+  cp -f "$state_cluster/cardano-node-pool3.orig" "$state_cluster/cardano-node-pool3"
 
   # restart all nodes
-  "$STATE_CLUSTER/supervisorctl_local" restart nodes:
+  "$state_cluster/supervisorctl_local" restart nodes:
   sleep 10
-  "$STATE_CLUSTER/supervisorctl_local" status
+  "$state_cluster/supervisorctl_local" status
 
   # print path to cardano-node binaries
   echo "pool1 node binary:"
-  pool1_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool1)"
+  pool1_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool1)"
   readlink -f "/proc/$pool1_pid/exe"
   echo "pool3 node binary:"
-  pool3_pid="$("$STATE_CLUSTER/supervisorctl_local" pid nodes:pool3)"
+  pool3_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool3)"
   readlink -f "/proc/$pool3_pid/exe"
 
   # check that nodes are running
@@ -363,7 +363,7 @@ elif [ "$1" = "step3" ]; then
   for _ in {1..10}; do
     sync_progress="$(cardano-cli latest query tip \
       --testnet-magic "$NETWORK_MAGIC" \
-      --socket-path "${STATE_CLUSTER}/pool3.socket" | jq -r '.syncProgress')"
+      --socket-path "${state_cluster}/pool3.socket" | jq -r '.syncProgress')"
     if [ "$sync_progress" = "100.00" ]; then
       break
     fi
@@ -388,13 +388,13 @@ elif [ "$1" = "step3" ]; then
     -m "smoke or upgrade_step3" \
     --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
-    --alluredir="$REPORTS_DIR" \
+    --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step3.html" \
     --self-contained-html \
     ||retval="$?"
 
   # create results archive for step3
-  ./runner/create_results.sh "$REPORTS_DIR" "$WORKDIR" allure-results-step3
+  ./runner/create_results.sh "$reports_dir" "$WORKDIR" allure-results-step3
 
   [ "$err_retval" -gt "$retval" ] && retval=1
 
@@ -406,7 +406,7 @@ elif [ "$1" = "step3" ]; then
 
 elif [ "$1" = "finish" ]; then
   # stop local cluster
-  "$CLUSTER_SCRIPTS_DIR/stop-cluster"
+  "$cluster_scripts_dir/stop-cluster"
 
   # generate CLI coverage reports
   ./runner/cli_coverage.sh "$COVERAGE_DIR" "${WORKDIR}/cli_coverage.json"

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -14,6 +14,7 @@ df -h .
 retval=0
 
 REPODIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
+readonly REPODIR
 cd "$REPODIR"
 
 export WORKDIR="$REPODIR/run_workdir"
@@ -28,9 +29,9 @@ if is_venv_active; then
 fi
 
 # Refuse to start if another testrun is already using this workdir.
-# `LOCK_FD` is set so background processes (e.g. monitor_system) can drop the
+# `lock_fd` is set so background processes (e.g. monitor_system) can drop the
 # inherited lock FD and not keep the lock alive if they outlive this script.
-acquire_workdir_lock "$WORKDIR" LOCK_FD || exit 1
+acquire_workdir_lock "$WORKDIR" lock_fd || exit 1
 
 # shellcheck disable=SC1091
 . runner/stop_cluster_instances.sh
@@ -237,8 +238,8 @@ fi
 monitor_system() {
   # Drop the inherited workdir lock FD so this background subshell does not
   # keep the lock held if it outlives the parent script.
-  if [ -n "${LOCK_FD:-}" ]; then
-    exec {LOCK_FD}>&-
+  if [ -n "${lock_fd:-}" ]; then
+    exec {lock_fd}>&-
   fi
 
   monitor_log="${WORKDIR}/monitor.log"
@@ -265,17 +266,17 @@ monitor_system() {
 
 # start monitor in background
 monitor_system &
-MON_PID=$!
+mon_pid=$!
 
 # Kill the sleep child first via pkill -P; otherwise the bash subshell stays blocked
 # in the foreground sleep and SIGTERM is only handled after sleep returns.
 # shellcheck disable=SC2329
 kill_monitor() {
-  if [ -n "${MON_PID:-}" ]; then
-    echo "Stopping monitor with PID $MON_PID"
-    pkill -P "$MON_PID" 2>/dev/null || true
-    kill_and_wait "$MON_PID" || true
-    unset MON_PID
+  if [ -n "${mon_pid:-}" ]; then
+    echo "Stopping monitor with PID $mon_pid"
+    pkill -P "$mon_pid" 2>/dev/null || true
+    kill_and_wait "$mon_pid" || true
+    unset mon_pid
   fi
 }
 

--- a/runner/run_tests.sh
+++ b/runner/run_tests.sh
@@ -37,9 +37,9 @@ ARTIFACTS_DIR="${ARTIFACTS_DIR:-run_workdir/artifacts}"
 COVERAGE_DIR="${COVERAGE_DIR:-run_workdir/cli_coverage}"
 REPORTS_DIR="${REPORTS_DIR:-run_workdir/reports}"
 
-_TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+_top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
-. "$_TOP_DIR/scripts/common.sh"
+. "$_top_dir/scripts/common.sh"
 
 # Helpers
 usage() {
@@ -90,41 +90,44 @@ set_common_env() {
   if [[ -n "${CI_ARGS:-}" ]]; then
     export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:+$PYTEST_ADDOPTS }${CI_ARGS}"
   fi
+
+  readonly CLEANUP
+  readonly RUN_SKIPS
 }
 
 # Compute args that depend on current environment.
 compute_common_args() {
   # MARKEXPR handling
   if [[ -n "${MARKEXPR:-}" ]]; then
-    MARKEXPR_ARR=( -m "$MARKEXPR" )
+    markexpr_arr=( -m "$MARKEXPR" )
   else
-    MARKEXPR_ARR=()
+    markexpr_arr=()
   fi
 
   # It may not be always necessary to save artifacts, e.g. when running tests on local cluster
   # on local machine.
   if is_truthy "${NO_ARTIFACTS:-}"; then
-    ARTIFACTS_ARR=()
+    artifacts_arr=()
   else
-    ARTIFACTS_ARR=( "--artifacts-base-dir=$ARTIFACTS_DIR" )
+    artifacts_arr=( "--artifacts-base-dir=$ARTIFACTS_DIR" )
   fi
 
   # Test run report args only when PYTEST_ARGS is unset.
   if [[ -z "${PYTEST_ARGS:-}" ]]; then
-    TESTRUN_REPORT_ARR=(
+    testrun_report_arr=(
       "--html=$REPORTS_DIR/testrun-report.html"
       "--self-contained-html"
       "--junitxml=$REPORTS_DIR/testrun-report.xml"
     )
   else
-    TESTRUN_REPORT_ARR=()
+    testrun_report_arr=()
   fi
 
   # Deselect-from-file
   if [[ -n "${DESELECT_FROM_FILE:-}" ]]; then
-    DESELECT_FROM_FILE_ARR=( "--deselect-from-file=$DESELECT_FROM_FILE" )
+    deselect_from_file_arr=( "--deselect-from-file=$DESELECT_FROM_FILE" )
   else
-    DESELECT_FROM_FILE_ARR=()
+    deselect_from_file_arr=()
   fi
 }
 
@@ -139,20 +142,20 @@ cleanup_previous_run() {
 initial_skip_pass() {
   if [[ "$RUN_SKIPS" == "yes" ]]; then
     echo "Initial pass: skipping all tests to register them with Allure"
-    pytest -s "$TESTS_DIR" "${MARKEXPR_ARR[@]}" --skipall --alluredir="$REPORTS_DIR" >/dev/null
+    pytest -s "$TESTS_DIR" "${markexpr_arr[@]}" --skipall --alluredir="$REPORTS_DIR" >/dev/null
   fi
 }
 
 run_real_tests() {
   run_pytest \
     "$TESTS_DIR" \
-    "${MARKEXPR_ARR[@]}" \
-    "${DESELECT_FROM_FILE_ARR[@]}" \
+    "${markexpr_arr[@]}" \
+    "${deselect_from_file_arr[@]}" \
     -n "${TEST_THREADS}" \
-    "${ARTIFACTS_ARR[@]}" \
+    "${artifacts_arr[@]}" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$REPORTS_DIR" \
-    "${TESTRUN_REPORT_ARR[@]}" \
+    "${testrun_report_arr[@]}" \
     "$@"
 }
 

--- a/runner/runc.sh
+++ b/runner/runc.sh
@@ -10,10 +10,10 @@
 
 set -Eeuo pipefail
 
-CONTAINER_TYPE=""     # empty = auto-detect
-CONTAINER_VERSION="latest"
-MINT_VERSION="22.3"
-EXTRA_MOUNTS=()
+container_type=""     # empty = auto-detect
+container_version="latest"
+mint_version="22.3"
+extra_mounts=()
 
 usage() {
   local script_name
@@ -57,15 +57,15 @@ USAGE
 while [ $# -gt 0 ]; do
   case "$1" in
     -h|--help)            usage; exit 0 ;;
-    --nixos-container)    CONTAINER_TYPE="nixos";  shift ;;
-    --nixos-container=*)  CONTAINER_TYPE="nixos";  CONTAINER_VERSION="${1#*=}"; shift ;;
-    --ubuntu-container)   CONTAINER_TYPE="ubuntu"; shift ;;
-    --ubuntu-container=*) CONTAINER_TYPE="ubuntu"; CONTAINER_VERSION="${1#*=}"; shift ;;
-    --debian-container)   CONTAINER_TYPE="debian"; CONTAINER_VERSION="stable"; shift ;;
-    --debian-container=*) CONTAINER_TYPE="debian"; CONTAINER_VERSION="${1#*=}"; shift ;;
-    --mint-container)     CONTAINER_TYPE="mint";   shift ;;
-    --mint-container=*)   CONTAINER_TYPE="mint";   MINT_VERSION="${1#*=}";      shift ;;
-    --extra-mount=*)      EXTRA_MOUNTS+=("-v" "${1#*=}"); shift ;;
+    --nixos-container)    container_type="nixos";  shift ;;
+    --nixos-container=*)  container_type="nixos";  container_version="${1#*=}"; shift ;;
+    --ubuntu-container)   container_type="ubuntu"; shift ;;
+    --ubuntu-container=*) container_type="ubuntu"; container_version="${1#*=}"; shift ;;
+    --debian-container)   container_type="debian"; container_version="stable"; shift ;;
+    --debian-container=*) container_type="debian"; container_version="${1#*=}"; shift ;;
+    --mint-container)     container_type="mint";   shift ;;
+    --mint-container=*)   container_type="mint";   mint_version="${1#*=}";      shift ;;
+    --extra-mount=*)      extra_mounts+=("-v" "${1#*=}"); shift ;;
     --) shift; break ;;
     -*) echo "Error: Unknown option '$1'. Use -h for help." >&2; exit 2 ;;
     *) break ;;
@@ -78,12 +78,12 @@ if [ $# -eq 0 ]; then
   exit 2
 fi
 
-if [ -z "$CONTAINER_TYPE" ]; then
+if [ -z "$container_type" ]; then
   # Auto-detect: Alpine with bind-mounted /nix when available, NixOS otherwise.
   if [ -d "/nix" ]; then
-    CONTAINER_TYPE="alpine"
+    container_type="alpine"
   else
-    CONTAINER_TYPE="nixos"
+    container_type="nixos"
   fi
 fi
 
@@ -96,13 +96,14 @@ else
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$script_dir/.." && pwd)"
+readonly REPO_DIR
 
 # When running from a git worktree, .git is a file referencing the main repo's
 # .git directory.  The path it points to won't exist inside the container unless
 # we also mount the main .git directory at the same absolute path.
-# Appends to the global EXTRA_MOUNTS array when a main .git dir must be mounted.
+# Appends to the global extra_mounts array when a main .git dir must be mounted.
 add_worktree_git_mount() {
   local repo_dir="$1"
   local gitdir main_git_dir
@@ -117,7 +118,7 @@ add_worktree_git_mount() {
   main_git_dir="${gitdir%%/worktrees/*}"
   [ -d "$main_git_dir" ] || return 0
   echo "Git worktree detected; mounting main .git: $main_git_dir"
-  EXTRA_MOUNTS+=("-v" "$main_git_dir:$main_git_dir")
+  extra_mounts+=("-v" "$main_git_dir:$main_git_dir")
 }
 
 add_worktree_git_mount "$REPO_DIR"
@@ -182,10 +183,10 @@ validate_bin_dir() {
   fi
 }
 
-validate_bin_dir "$REPO_DIR/.bin" "$CONTAINER_TYPE" || exit 1
+validate_bin_dir "$REPO_DIR/.bin" "$container_type" || exit 1
 
 # Select base image, tag, and runtime options based on the container type.
-# Sets globals BASE_IMAGE, TAG, and appends to NIX_MOUNTS.
+# Sets globals BASE_IMAGE, tag, and appends to nix_mounts.
 select_image() {
   local container_type="$1"
   local container_version="$2"
@@ -194,22 +195,22 @@ select_image() {
   case "$container_type" in
     nixos)
       BASE_IMAGE="docker.io/nixos/nix:${container_version}"
-      TAG="cardano-tests-nixos"
+      tag="cardano-tests-nixos"
       echo "NixOS container selected; /nix will be created inside the container."
       ;;
     alpine)
       echo "Host /nix found; mounting into Alpine container."
       BASE_IMAGE="docker.io/library/alpine:${container_version}"
-      TAG="cardano-tests-alpine"
-      NIX_MOUNTS+=("-v" "/nix:/nix")
+      tag="cardano-tests-alpine"
+      nix_mounts+=("-v" "/nix:/nix")
       ;;
     ubuntu|debian|mint)
       if [ ! -d "/nix" ]; then
         echo "Error: Host /nix not found; --${container_type}-container requires /nix on the host." >&2
         return 1
       fi
-      NIX_MOUNTS+=("-v" "/nix:/nix")
-      TAG="cardano-tests-${container_type}"
+      nix_mounts+=("-v" "/nix:/nix")
+      tag="cardano-tests-${container_type}"
       case "$container_type" in
         ubuntu) BASE_IMAGE="docker.io/library/ubuntu:${container_version}" ;;
         debian) BASE_IMAGE="docker.io/library/debian:${container_version}" ;;
@@ -224,25 +225,25 @@ select_image() {
   esac
 }
 
-NIX_MOUNTS=()
-select_image "$CONTAINER_TYPE" "$CONTAINER_VERSION" "$MINT_VERSION" || exit 1
+nix_mounts=()
+select_image "$container_type" "$container_version" "$mint_version" || exit 1
 
 echo "Using base image:  $BASE_IMAGE"
-echo "Building image:    $TAG"
+echo "Building image:    $tag"
 echo "Repository:        $REPO_DIR"
 echo "Command:           $*"
 echo
 
-$container_manager build "$SCRIPT_DIR" \
+$container_manager build "$script_dir" \
   --pull \
-  -f "$SCRIPT_DIR/Dockerfile" \
+  -f "$script_dir/Dockerfile" \
   --build-arg BASE_IMAGE="$BASE_IMAGE" \
-  -t "$TAG" \
+  -t "$tag" \
   || exit 1
 
-TTY_FLAG=()
+tty_flag=()
 if [ -t 0 ] && [ -t 1 ]; then
-  TTY_FLAG=("-t")
+  tty_flag=("-t")
 fi
 
 # `seccomp=unconfined` is needed so GHC's RTS can call io_uring_setup
@@ -251,10 +252,10 @@ $container_manager run \
   --security-opt label=disable \
   --security-opt seccomp=unconfined \
   -i \
-  "${TTY_FLAG[@]}" \
-  "${NIX_MOUNTS[@]}" \
+  "${tty_flag[@]}" \
+  "${nix_mounts[@]}" \
   -v "$REPO_DIR":"$REPO_DIR" \
-  "${EXTRA_MOUNTS[@]}" \
+  "${extra_mounts[@]}" \
   -e REPO_DIR="$REPO_DIR" \
-  "$TAG" \
+  "$tag" \
   "$@"

--- a/runner/setup_venv.sh
+++ b/runner/setup_venv.sh
@@ -6,28 +6,28 @@
 }
 
 _VENV_DIR="${_VENV_DIR:-"${WORKDIR:?}/.venv"}"
-_TOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || { echo "Cannot determine top dir, returning." >&2; return 1; }
+_top_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || { echo "Cannot determine top dir, returning." >&2; return 1; }
 
 if [ "${1:-""}" = "clean" ]; then
   rm -rf "$_VENV_DIR"
 fi
 
-_REQS_INSTALLED="true"
+_reqs_installed="true"
 if [ ! -e "$_VENV_DIR" ]; then
-  _REQS_INSTALLED=""
+  _reqs_installed=""
   python3 -m venv "$_VENV_DIR" --prompt tests-venv
 fi
 
 # shellcheck disable=SC1091
-. "$_TOP_DIR/scripts/common.sh"
+. "$_top_dir/scripts/common.sh"
 
 filter_out_nix
 
 # shellcheck disable=SC1091
 . "$_VENV_DIR/bin/activate"
 
-if [ -z "$_REQS_INSTALLED" ]; then
+if [ -z "$_reqs_installed" ]; then
   uv sync --active --no-dev
 fi
 
-unset _VENV_DIR _REQS_INSTALLED _TOP_DIR
+unset _VENV_DIR _reqs_installed _top_dir

--- a/runner/source_cardano_cli.sh
+++ b/runner/source_cardano_cli.sh
@@ -2,6 +2,7 @@
 
 # Build cardano-cli from the standalone repo into $WORKDIR/cardano-cli-build<postfix>
 cardano_cli_build() {
+  : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local cli_rev="${1:?}"
   local node_bindir_postfix="${2:-}"
   local origpwd="$PWD"
@@ -27,6 +28,7 @@ cardano_cli_build() {
 
 # Print PATH to prepend for the standalone cardano-cli build output.
 cardano_cli_print_path_prepend() {
+  : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local node_bindir_postfix="${1:-}"
   local origpwd="$PWD"
 

--- a/runner/source_cardano_node.sh
+++ b/runner/source_cardano_node.sh
@@ -2,6 +2,7 @@
 
 # Build all required binaries into $WORKDIR/*-build<postfix>
 cardano_bins_build_all() {
+  : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local node_rev="${1:?}"
   local cli_rev="${2:-}"
   local node_bindir_postfix="${3:-}"
@@ -42,6 +43,7 @@ cardano_bins_build_all() {
 
 # Print PATH to prepend based on previously built outputs
 cardano_bins_print_path_prepend() {
+  : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local cli_rev="${1:-}"
   local node_bindir_postfix="${2:-}"
   local origpwd="$PWD"

--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+: "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
+: "${REPODIR:?"REPODIR must be set to the root of the cardano-node repository"}"
 TEST_THREADS="${TEST_THREADS:-15}"
 CLUSTERS_COUNT="${CLUSTERS_COUNT:-4}"
 export TEST_THREADS CLUSTERS_COUNT
@@ -59,12 +61,12 @@ fi
 
 if [ -n "${DBSYNC_TAR_URL:-}" ]; then
   # Download db-sync
-  DBSYNC_TAR_FILE="${WORKDIR}/dbsync_bins.tar.gz"
-  curl -sSL "$DBSYNC_TAR_URL" > "$DBSYNC_TAR_FILE" || exit 1
+  dbsync_tar_file="${WORKDIR}/dbsync_bins.tar.gz"
+  curl -sSL "$DBSYNC_TAR_URL" > "$dbsync_tar_file" || exit 1
   rm -rf dbsync_download
   mkdir -p dbsync_download
-  tar -C dbsync_download -xzf "$DBSYNC_TAR_FILE" || exit 1
-  rm -f "$DBSYNC_TAR_FILE"
+  tar -C dbsync_download -xzf "$dbsync_tar_file" || exit 1
+  rm -f "$dbsync_tar_file"
   rm -f db-sync-node
   ln -s dbsync_download db-sync-node || exit 1
   DBSYNC_SCHEMA_DIR="${WORKDIR}/db-sync-node/schema"

--- a/scripts/analyze_failures.sh
+++ b/scripts/analyze_failures.sh
@@ -3,11 +3,11 @@
 # coding-agent CLI that accepts a prompt on stdin (or via -p/--prompt).
 #
 # Usage:
-#   scripts/analyze_failures.sh [RUN_DIR]
+#   scripts/analyze_failures.sh [run_dir]
 #
-# RUN_DIR defaults to ./run_workdir. It can point at a fresh run produced by
+# run_dir defaults to ./run_workdir. It can point at a fresh run produced by
 # `runner/regression.sh` or at any saved historical run directory (relative
-# or absolute path). The agent writes ${RUN_DIR}/failure_analysis.md per the
+# or absolute path). The agent writes ${run_dir}/failure_analysis.md per the
 # prompt contract.
 #
 # Env vars:
@@ -22,26 +22,26 @@
 
 set -euo pipefail
 
-RUN_DIR="${1:-run_workdir}"
+run_dir="${1:-run_workdir}"
 AGENT_CMD="${AGENT_CMD:-claude -p}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
 
-if [ ! -d "${RUN_DIR}" ]; then
-  echo "Run directory not found: ${RUN_DIR}" >&2
+if [ ! -d "${run_dir}" ]; then
+  echo "Run directory not found: ${run_dir}" >&2
   exit 1
 fi
 
-# Auto-detect testsuite from RUN_DIR contents unless PROMPT_FILE is set.
+# Auto-detect testsuite from run_dir contents unless PROMPT_FILE is set.
 # Upgrade runs produce per-step allure result dirs/tarballs; regression runs
 # produce a single allure-results dir/tarball.
 if [ -z "${PROMPT_FILE:-}" ]; then
-  if compgen -G "${RUN_DIR}/allure-results-step*" > /dev/null; then
-    PROMPT_FILE="${REPO_ROOT}/agent_docs/upgrade_failure_analysis_prompt.md"
+  if compgen -G "${run_dir}/allure-results-step*" > /dev/null; then
+    PROMPT_FILE="${repo_root}/agent_docs/upgrade_failure_analysis_prompt.md"
     echo "Detected node-upgrade run; using upgrade prompt." >&2
   else
-    PROMPT_FILE="${REPO_ROOT}/agent_docs/failure_analysis_prompt.md"
+    PROMPT_FILE="${repo_root}/agent_docs/failure_analysis_prompt.md"
     echo "Detected regression run; using regression prompt." >&2
   fi
 fi
@@ -53,7 +53,7 @@ fi
 
 # Substitute {RUN_DIR} in the prompt template, then pipe to the agent.
 prompt_content="$(cat "${PROMPT_FILE}")"
-prompt_content="${prompt_content//\{RUN_DIR\}/${RUN_DIR}}"
+prompt_content="${prompt_content//\{RUN_DIR\}/${run_dir}}"
 
 # shellcheck disable=SC2086
 printf '%s\n' "${prompt_content}" | exec $AGENT_CMD

--- a/scripts/build_and_link_node_bins.sh
+++ b/scripts/build_and_link_node_bins.sh
@@ -22,46 +22,46 @@ if [ $# -ne 3 ]; then
   exit 2
 fi
 
-REPO_PATH="$(readlink -m "$1")"
-BUILD_OUTPUT_DIR="$(readlink -m "$2")"
-BIN_DIR="$(readlink -m "$3")"
+repo_path="$(readlink -m "$1")"
+build_output_dir="$(readlink -m "$2")"
+bin_dir="$(readlink -m "$3")"
 
 # Validate repo path
-if [ ! -d "$REPO_PATH" ]; then
-  err "Repo path not found: $REPO_PATH"
+if [ ! -d "$repo_path" ]; then
+  err "Repo path not found: $repo_path"
   exit 1
 fi
-if [[ ! -d "$REPO_PATH/cardano-node" && ! -d "$REPO_PATH/cardano-cli" ]]; then
+if [[ ! -d "$repo_path/cardano-node" && ! -d "$repo_path/cardano-cli" ]]; then
   err "Given path doesn't look like the cardano-node repo."
   exit 1
 fi
 
 # Build binaries
-cd "$REPO_PATH" >/dev/null
-mkdir -p "$BUILD_OUTPUT_DIR"
+cd "$repo_path" >/dev/null
+mkdir -p "$build_output_dir"
 
-echo "👉  Building node binaries in repo: $REPO_PATH"
-nix build .#cardano-node -o "$BUILD_OUTPUT_DIR/node"
-echo "👉  Building cli binaries in repo: $REPO_PATH"
-nix build .#cardano-cli -o "$BUILD_OUTPUT_DIR/cli"
-echo "👉  Building submit-api binaries in repo: $REPO_PATH"
-nix build .#cardano-submit-api -o "$BUILD_OUTPUT_DIR/submit-api"
-echo "👉  Building bech32 binaries in repo: $REPO_PATH"
-nix build .#bech32 -o "$BUILD_OUTPUT_DIR/bech32"
-echo "👉  Building tx-generator binaries in repo: $REPO_PATH"
-nix build .#tx-generator -o "$BUILD_OUTPUT_DIR/tx-generator"
+echo "👉  Building node binaries in repo: $repo_path"
+nix build .#cardano-node -o "$build_output_dir/node"
+echo "👉  Building cli binaries in repo: $repo_path"
+nix build .#cardano-cli -o "$build_output_dir/cli"
+echo "👉  Building submit-api binaries in repo: $repo_path"
+nix build .#cardano-submit-api -o "$build_output_dir/submit-api"
+echo "👉  Building bech32 binaries in repo: $repo_path"
+nix build .#bech32 -o "$build_output_dir/bech32"
+echo "👉  Building tx-generator binaries in repo: $repo_path"
+nix build .#tx-generator -o "$build_output_dir/tx-generator"
 
 # Create symlinks
-echo "👉  Updating symlinks to built binaries in: $BIN_DIR"
-mkdir -p "$BIN_DIR"
+echo "👉  Updating symlinks to built binaries in: $bin_dir"
+mkdir -p "$bin_dir"
 
-rm -f "$BIN_DIR"/cardano-node
-rm -f "$BIN_DIR"/cardano-cli
-rm -f "$BIN_DIR"/cardano-submit-api
-rm -f "$BIN_DIR"/bech32
-rm -f "$BIN_DIR"/tx-generator
-ln -s "$BUILD_OUTPUT_DIR/node/bin/cardano-node" "$BIN_DIR/cardano-node"
-ln -s "$BUILD_OUTPUT_DIR/cli/bin/cardano-cli" "$BIN_DIR/cardano-cli"
-ln -s "$BUILD_OUTPUT_DIR/submit-api/bin/cardano-submit-api" "$BIN_DIR/cardano-submit-api"
-ln -s "$BUILD_OUTPUT_DIR/bech32/bin/bech32" "$BIN_DIR/bech32"
-ln -s "$BUILD_OUTPUT_DIR/tx-generator/bin/tx-generator" "$BIN_DIR/tx-generator"
+rm -f "$bin_dir"/cardano-node
+rm -f "$bin_dir"/cardano-cli
+rm -f "$bin_dir"/cardano-submit-api
+rm -f "$bin_dir"/bech32
+rm -f "$bin_dir"/tx-generator
+ln -s "$build_output_dir/node/bin/cardano-node" "$bin_dir/cardano-node"
+ln -s "$build_output_dir/cli/bin/cardano-cli" "$bin_dir/cardano-cli"
+ln -s "$build_output_dir/submit-api/bin/cardano-submit-api" "$bin_dir/cardano-submit-api"
+ln -s "$build_output_dir/bech32/bin/bech32" "$bin_dir/bech32"
+ln -s "$build_output_dir/tx-generator/bin/tx-generator" "$bin_dir/tx-generator"

--- a/scripts/check_dev_env.sh
+++ b/scripts/check_dev_env.sh
@@ -4,9 +4,9 @@
 
 set -uo pipefail
 
-_TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+_top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
-. "$_TOP_DIR/scripts/common.sh"
+. "$_top_dir/scripts/common.sh"
 
 exit_code=0
 
@@ -22,105 +22,106 @@ get_rev() {
     echo "${revision#* }"
 }
 
-true="$(printf '\033[0;32m\u2714\033[0m' | iconv -f UTF-8)"
-false="$(printf '\u274c' | iconv -f UTF-8)"
+TRUE="$(printf '\033[0;32m\u2714\033[0m' | iconv -f UTF-8)"
+FALSE="$(printf '\u274c' | iconv -f UTF-8)"
+readonly TRUE FALSE
 
 process_result() {
     local result="$?"
     local optional="${1:-""}"
 
     if [ "$result" -eq 0 ]; then
-        echo "$true"
+        echo "$TRUE"
     elif [ -n "$optional" ]; then
         echo "-"
     else
-        echo "$false"
+        echo "$FALSE"
         return 1
     fi
 }
 
-HAS_NODE="$([ -n "$(command -v cardano-node)" ]; process_result)" || exit_code=1
-HAS_CLI="$([ -n "$(command -v cardano-cli)" ]; process_result)" || exit_code=1
-HAS_SUBMIT_API="$([ -n "$(command -v cardano-submit-api)" ]; process_result "optional")" || exit_code=1
-HAS_BECH32="$([ -n "$(command -v bech32)" ]; process_result)" || exit_code=1
-HAS_TX_GENERATOR="$([ -n "$(command -v tx-generator)" ]; process_result "optional")" || exit_code=1
-HAS_PYTHON="$([ -n "$(command -v python)" ]; process_result)" || exit_code=1
-HAS_PYTEST="$([ -n "$(command -v pytest)" ]; process_result)" || exit_code=1
-HAS_NIX="$([ -n "$(command -v nix)" ]; process_result)" || exit_code=1
-HAS_JQ="$([ -n "$(command -v jq)" ]; process_result)" || exit_code=1
-HAS_SUPERVISORD="$([ -n "$(command -v supervisord)" ]; process_result)" || exit_code=1
-HAS_SUPERVISORCTL="$([ -n "$(command -v supervisorctl)" ]; process_result)" || exit_code=1
+has_node="$([ -n "$(command -v cardano-node)" ]; process_result)" || exit_code=1
+has_cli="$([ -n "$(command -v cardano-cli)" ]; process_result)" || exit_code=1
+has_submit_api="$([ -n "$(command -v cardano-submit-api)" ]; process_result "optional")" || exit_code=1
+has_bech32="$([ -n "$(command -v bech32)" ]; process_result)" || exit_code=1
+has_tx_generator="$([ -n "$(command -v tx-generator)" ]; process_result "optional")" || exit_code=1
+has_python="$([ -n "$(command -v python)" ]; process_result)" || exit_code=1
+has_pytest="$([ -n "$(command -v pytest)" ]; process_result)" || exit_code=1
+has_nix="$([ -n "$(command -v nix)" ]; process_result)" || exit_code=1
+has_jq="$([ -n "$(command -v jq)" ]; process_result)" || exit_code=1
+has_supervisord="$([ -n "$(command -v supervisord)" ]; process_result)" || exit_code=1
+has_supervisorctl="$([ -n "$(command -v supervisorctl)" ]; process_result)" || exit_code=1
 
-IN_ROOT_DIR="$([ -d "cardano_node_tests" ]; process_result)" || exit_code=1
-DEV_CLUSTER="$(is_truthy "${DEV_CLUSTER_RUNNING:-}"; process_result)" || exit_code=1
-SOCKET_PATH_SET="$([ -n "${CARDANO_NODE_SOCKET_PATH:-}" ]; process_result)" || exit_code=1
-USE_DBSYNC="$([ -n "${DBSYNC_SCHEMA_DIR:-}" ]; process_result "optional")" || exit_code=1
+in_root_dir="$([ -d "cardano_node_tests" ]; process_result)" || exit_code=1
+dev_cluster="$(is_truthy "${DEV_CLUSTER_RUNNING:-}"; process_result)" || exit_code=1
+socket_path_set="$([ -n "${CARDANO_NODE_SOCKET_PATH:-}" ]; process_result)" || exit_code=1
+use_dbsync="$([ -n "${DBSYNC_SCHEMA_DIR:-}" ]; process_result "optional")" || exit_code=1
 
 
-printf "'cardano-node' available: $HAS_NODE\n"
-printf "'cardano-cli' available: $HAS_CLI\n"
-printf "'cardano-submit-api' available (optional): $HAS_SUBMIT_API\n"
-printf "'bech32' available: $HAS_BECH32\n"
-printf "'tx-generator' available (optional): $HAS_TX_GENERATOR\n"
-printf "'python' available: $HAS_PYTHON\n"
-printf "'pytest' available: $HAS_PYTEST\n"
-printf "'nix' available: $HAS_NIX\n"
-printf "'jq' available: $HAS_JQ\n"
-printf "'supervisord' available: $HAS_SUPERVISORD\n"
-printf "'supervisorctl' available: $HAS_SUPERVISORCTL\n"
+printf "'cardano-node' available: $has_node\n"
+printf "'cardano-cli' available: $has_cli\n"
+printf "'cardano-submit-api' available (optional): $has_submit_api\n"
+printf "'bech32' available: $has_bech32\n"
+printf "'tx-generator' available (optional): $has_tx_generator\n"
+printf "'python' available: $has_python\n"
+printf "'pytest' available: $has_pytest\n"
+printf "'nix' available: $has_nix\n"
+printf "'jq' available: $has_jq\n"
+printf "'supervisord' available: $has_supervisord\n"
+printf "'supervisorctl' available: $has_supervisorctl\n"
 
-printf "in repo root: $IN_ROOT_DIR\n"
-printf "DEV cluster: $DEV_CLUSTER\n"
+printf "in repo root: $in_root_dir\n"
+printf "DEV cluster: $dev_cluster\n"
 
-if [ "$HAS_PYTHON" = "$true" ]; then
-  PYTHON_WORKS="$(get_version python >/dev/null; process_result)" || exit_code=1
-  printf "python works: $PYTHON_WORKS\n"
+if [ "$has_python" = "$TRUE" ]; then
+  python_works="$(get_version python >/dev/null; process_result)" || exit_code=1
+  printf "python works: $python_works\n"
 
-  if [ "$PYTHON_WORKS" = "$true" ]; then
-    IN_VENV="$([ -n "${VIRTUAL_ENV:-}" ]; process_result)" || exit_code=1
-    printf "in python venv: $IN_VENV\n"
+  if [ "$python_works" = "$TRUE" ]; then
+    in_venv="$([ -n "${VIRTUAL_ENV:-}" ]; process_result)" || exit_code=1
+    printf "in python venv: $in_venv\n"
 
-    if [ "$IN_VENV" = "$true" ]; then
-      NIX_NOT_IN_PYTHONPATH="$([[ "${PYTHONPATH:-"empty__"}" != */nix/store/* ]]; process_result)" || exit_code=1
-      printf "nix not in PYTHONPATH: $NIX_NOT_IN_PYTHONPATH\n"
+    if [ "$in_venv" = "$TRUE" ]; then
+      nix_not_in_pythonpath="$([[ "${PYTHONPATH:-"empty__"}" != */nix/store/* ]]; process_result)" || exit_code=1
+      printf "nix not in PYTHONPATH: $nix_not_in_pythonpath\n"
     fi
 
     pushd "$HOME" > /dev/null || exit 1
-    TESTS_INSTALLED="$(python -c 'import cardano_node_tests' 2>/dev/null; process_result)" || exit_code=1
+    tests_installed="$(python -c 'import cardano_node_tests' 2>/dev/null; process_result)" || exit_code=1
     popd > /dev/null || exit 1
-    printf "cardano-node-tests installed: $TESTS_INSTALLED\n"
+    printf "cardano-node-tests installed: $tests_installed\n"
 
-    if [ "$HAS_PYTEST" = "$true" ]; then
-      PYTEST_WORKS="$(get_version pytest >/dev/null; process_result)" || exit_code=1
-      printf "pytest works: $PYTEST_WORKS\n"
+    if [ "$has_pytest" = "$TRUE" ]; then
+      pytest_works="$(get_version pytest >/dev/null; process_result)" || exit_code=1
+      printf "pytest works: $pytest_works\n"
     fi
   fi
 fi
 
-if [ "$HAS_NODE" = "$true" ] && [ "$HAS_CLI" = "$true" ]; then
-  NODE_VERSION="$(get_rev cardano-node)"
-  CLI_VERSION="$(get_rev cardano-cli)"
-  SAME_VERSION="$([ "$NODE_VERSION" = "$CLI_VERSION" ]; process_result)" || exit_code=1
-  printf "same version of node and cli: $SAME_VERSION\n"
+if [ "$has_node" = "$TRUE" ] && [ "$has_cli" = "$TRUE" ]; then
+  node_version="$(get_rev cardano-node)"
+  cli_version="$(get_rev cardano-cli)"
+  same_version="$([ "$node_version" = "$cli_version" ]; process_result)" || exit_code=1
+  printf "same version of node and cli: $same_version\n"
 fi
 
-printf "socket path set: $SOCKET_PATH_SET\n"
-if [ "$SOCKET_PATH_SET" = "$true" ]; then
-  CORRECT_SOCKET_PATH="$([[ "${CARDANO_NODE_SOCKET_PATH:-}" == */state-cluster* ]]; process_result)" || exit_code=1
-  printf "socket path correct: $CORRECT_SOCKET_PATH\n"
+printf "socket path set: $socket_path_set\n"
+if [ "$socket_path_set" = "$TRUE" ]; then
+  correct_socket_path="$([[ "${CARDANO_NODE_SOCKET_PATH:-}" == */state-cluster* ]]; process_result)" || exit_code=1
+  printf "socket path correct: $correct_socket_path\n"
 
-  IS_SOCKET="$([ -S "${CARDANO_NODE_SOCKET_PATH:-}" ]; process_result)" || exit_code=1
-  printf "socket path exists: $IS_SOCKET\n"
+  is_socket="$([ -S "${CARDANO_NODE_SOCKET_PATH:-}" ]; process_result)" || exit_code=1
+  printf "socket path exists: $is_socket\n"
 fi
 
 printf "command era: %s\n" "${COMMAND_ERA:-"latest"}"
 
-printf "using dbsync (optional): $USE_DBSYNC\n"
-if [ "$USE_DBSYNC" = "$true" ]; then
-  HAS_DBSYNC="$(command -v cardano-db-sync >/dev/null 2>&1; process_result)" || exit_code=1
-  printf "dbsync available: $HAS_DBSYNC\n"
-  HAS_PSQL="$([ -n "$(command -v psql)" ]; process_result)" || exit_code=1
-  printf "'psql' available: $HAS_PSQL\n"
+printf "using dbsync (optional): $use_dbsync\n"
+if [ "$use_dbsync" = "$TRUE" ]; then
+  has_dbsync="$(command -v cardano-db-sync >/dev/null 2>&1; process_result)" || exit_code=1
+  printf "dbsync available: $has_dbsync\n"
+  has_psql="$([ -n "$(command -v psql)" ]; process_result)" || exit_code=1
+  printf "'psql' available: $has_psql\n"
 fi
 
 exit "$exit_code"

--- a/scripts/deploy_doc.sh
+++ b/scripts/deploy_doc.sh
@@ -2,24 +2,24 @@
 
 set -euo pipefail
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
-cd "$TOP_DIR"
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+cd "$top_dir"
 
-DOC_SRC="src_docs"
+doc_src="src_docs"
 
 unset GITHUB_TOKEN
 
-# check that "$DOC_SRC" dir exists
-if [ ! -d "$DOC_SRC" ]; then
-    echo "The '$DOC_SRC' dir doesn't exist, are you in the right directory?"
+# check that "$doc_src" dir exists
+if [ ! -d "$doc_src" ]; then
+    echo "The '$doc_src' dir doesn't exist, are you in the right directory?"
     exit 1
 fi
 
 # shellcheck disable=SC1091
-. "$TOP_DIR/scripts/common.sh"
+. "$top_dir/scripts/common.sh"
 
 # check that correct virtual env is activated
-assert_correct_venv "$TOP_DIR"
+assert_correct_venv "$top_dir"
 
 # check that current branch is "master"
 cur_branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -38,8 +38,8 @@ fi
 make build-doc
 
 # drop changes made automatically by `make build-doc`
-if ! git diff-index --quiet HEAD -- "$DOC_SRC"; then
-  git stash -- "$DOC_SRC"
+if ! git diff-index --quiet HEAD -- "$doc_src"; then
+  git stash -- "$doc_src"
   git stash drop
 fi
 
@@ -51,7 +51,7 @@ git reset --hard upstream/master
 
 # copy generated documention to 'docs' dir
 rm -rf docs/*
-cp -aT "$DOC_SRC"/build/html docs
+cp -aT "$doc_src"/build/html docs
 
 # stage changes
 git add docs

--- a/scripts/postgres-start-nix.sh
+++ b/scripts/postgres-start-nix.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env -S nix develop --accept-flake-config .#postgres -i -k PGHOST -k PGPORT -k PGUSER -c bash
 # shellcheck shell=bash
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec "$SCRIPT_DIR/postgres-start.sh" "$@"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+exec "$script_dir/postgres-start.sh" "$@"

--- a/scripts/postgres-start.sh
+++ b/scripts/postgres-start.sh
@@ -4,12 +4,12 @@ set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
 usage() {
-  echo "Usage: $(basename "$0") [-k|--kill] [-h|--help] POSTGRES_DIR"
+  echo "Usage: $(basename "$0") [-k|--kill] [-h|--help] postgres_dir"
   echo ""
   echo "Start a PostgreSQL instance in the given directory."
   echo ""
   echo "Arguments:"
-  echo "  POSTGRES_DIR  Path to the postgres data directory"
+  echo "  postgres_dir  Path to the postgres data directory"
   echo ""
   echo "Options:"
   echo "  -k, --kill  Kill running postgres on PGPORT and clear data before starting"
@@ -117,52 +117,52 @@ kill_postgres() {
   rm -f "$pg_dir"/.*.lock
 }
 
-KILL_EXISTING=""
-POSTGRES_DIR=""
+kill_existing=""
+postgres_dir=""
 
 for arg in "$@"; do
   case "$arg" in
-    -k|--kill) KILL_EXISTING=1 ;;
+    -k|--kill) kill_existing=1 ;;
     -h|--help) usage 0 ;;
     -*)
       echo "Error: Unknown option '$arg'" >&2
       usage 2
       ;;
     *)
-      if [ -n "$POSTGRES_DIR" ]; then
+      if [ -n "$postgres_dir" ]; then
         echo "Error: Unexpected argument '$arg'" >&2
         usage 2
       fi
-      POSTGRES_DIR="$arg"
+      postgres_dir="$arg"
       ;;
   esac
 done
 
-if [ -z "$POSTGRES_DIR" ]; then
-  echo "Error: POSTGRES_DIR is required" >&2
+if [ -z "$postgres_dir" ]; then
+  echo "Error: postgres_dir is required" >&2
   usage 2
 fi
 
-POSTGRES_DIR="$(readlink -m "$POSTGRES_DIR")"
+postgres_dir="$(readlink -m "$postgres_dir")"
 
-# validate POSTGRES_DIR basename matches expected postgres directory naming
-pg_basename="$(basename "$POSTGRES_DIR")"
+# validate postgres_dir basename matches expected postgres directory naming
+pg_basename="$(basename "$postgres_dir")"
 if [[ ! "$pg_basename" =~ postgres ]]; then
-  echo "Error: POSTGRES_DIR basename '$pg_basename' must match '*postgres*'" >&2
+  echo "Error: postgres_dir basename '$pg_basename' must match '*postgres*'" >&2
   exit 1
 fi
 
-parent_dir="$(dirname "$POSTGRES_DIR")"
+parent_dir="$(dirname "$postgres_dir")"
 if [ ! -d "$parent_dir" ]; then
   echo "Error: parent directory '$parent_dir' does not exist" >&2
   exit 1
 fi
-if [ ! -w "$parent_dir" ] && [ ! -d "$POSTGRES_DIR" ]; then
+if [ ! -w "$parent_dir" ] && [ ! -d "$postgres_dir" ]; then
   echo "Error: parent directory '$parent_dir' is not writable" >&2
   exit 1
 fi
-if [ -d "$POSTGRES_DIR" ] && [ ! -w "$POSTGRES_DIR" ]; then
-  echo "Error: POSTGRES_DIR '$POSTGRES_DIR' is not writable" >&2
+if [ -d "$postgres_dir" ] && [ ! -w "$postgres_dir" ]; then
+  echo "Error: postgres_dir '$postgres_dir' is not writable" >&2
   exit 1
 fi
 
@@ -172,22 +172,22 @@ export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
 # kill running postgres and clear its data
-if [ -n "$KILL_EXISTING" ]; then
-  kill_postgres "$POSTGRES_DIR" "$PGPORT"
+if [ -n "$kill_existing" ]; then
+  kill_postgres "$postgres_dir" "$PGPORT"
 fi
 
 # setup db
-if [ ! -e "$POSTGRES_DIR/data" ]; then
-  mkdir -p "$POSTGRES_DIR/data"
-  initdb -D "$POSTGRES_DIR/data" --encoding=UTF8 --locale=en_US.UTF-8 -A trust -U "$PGUSER"
+if [ ! -e "$postgres_dir/data" ]; then
+  mkdir -p "$postgres_dir/data"
+  initdb -D "$postgres_dir/data" --encoding=UTF8 --locale=en_US.UTF-8 -A trust -U "$PGUSER"
 fi
 
 # start postgres
-postgres -D "$POSTGRES_DIR/data" -k "$POSTGRES_DIR" > "$POSTGRES_DIR/postgres.log" 2>&1 &
-PSQL_PID="$!"
-echo "$PSQL_PID" > "$POSTGRES_DIR/postgres.pid"
+postgres -D "$postgres_dir/data" -k "$postgres_dir" > "$postgres_dir/postgres.log" 2>&1 &
+psql_pid="$!"
+echo "$psql_pid" > "$postgres_dir/postgres.pid"
 
 sleep 5
-cat "$POSTGRES_DIR/postgres.log"
+cat "$postgres_dir/postgres.log"
 echo
-ps -fp "$PSQL_PID"
+ps -fp "$psql_pid"

--- a/scripts/reinstall_editable.sh
+++ b/scripts/reinstall_editable.sh
@@ -9,26 +9,26 @@ if [ $# -ne 1 ]; then
   usage >&2
   exit 2
 fi
-REPO_PATH="$(readlink -f "$1")"
+repo_path="$(readlink -f "$1")"
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
-cd "$TOP_DIR"
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+cd "$top_dir"
 
 # shellcheck disable=SC1091
-. "$TOP_DIR/scripts/common.sh"
+. "$top_dir/scripts/common.sh"
 
 # Activate python virtual environment
 if ! is_venv_active; then
-  if [ ! -e "$TOP_DIR/.venv/bin/activate" ]; then
-    err "Virtual environment not found at: $TOP_DIR/.venv"
+  if [ ! -e "$top_dir/.venv/bin/activate" ]; then
+    err "Virtual environment not found at: $top_dir/.venv"
     exit 1
   fi
   # shellcheck disable=SC1091
-  . "$TOP_DIR/.venv/bin/activate"
+  . "$top_dir/.venv/bin/activate"
 fi
 
 # check that correct virtual env is activated
-assert_correct_venv "$TOP_DIR"
+assert_correct_venv "$top_dir"
 
 filter_out_nix
 
@@ -43,15 +43,15 @@ then
 fi
 
 # Validate repo path
-if [ ! -d "$REPO_PATH" ]; then
-  err "Repo path not found: $REPO_PATH"
+if [ ! -d "$repo_path" ]; then
+  err "Repo path not found: $repo_path"
   exit 1
 fi
-if [[ ! -f "$REPO_PATH/pyproject.toml" && ! -f "$REPO_PATH/setup.cfg" && ! -f "$REPO_PATH/setup.py" ]]; then
+if [[ ! -f "$repo_path/pyproject.toml" && ! -f "$repo_path/setup.cfg" && ! -f "$repo_path/setup.py" ]]; then
   err "Given path doesn't look like python package."
   exit 1
 fi
 
-echo "Installing editable from: $REPO_PATH"
-cd "$REPO_PATH"
+echo "Installing editable from: $repo_path"
+cd "$repo_path"
 uv pip install -e . --config-setting editable_mode=compat

--- a/scripts/restart_dev_cluster.sh
+++ b/scripts/restart_dev_cluster.sh
@@ -2,37 +2,37 @@
 
 set -euo pipefail
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 # shellcheck disable=SC1091
-. "$TOP_DIR/scripts/common.sh"
+. "$top_dir/scripts/common.sh"
 
 if ! is_truthy "${DEV_CLUSTER_RUNNING:-}"; then
   echo "The 'DEV_CLUSTER_RUNNING' is not set. It is needed when running dev cluster, exiting." >&2
   exit 1
 fi
 
-SOCKET_PATH="$(readlink -m "${CARDANO_NODE_SOCKET_PATH:-}")"
-STATE_CLUSTER="${SOCKET_PATH%/*}"
+socket_path="$(readlink -m "${CARDANO_NODE_SOCKET_PATH:-}")"
+state_cluster="${socket_path%/*}"
 
-if [ ! -e "$STATE_CLUSTER" ]; then
-  echo "Cannot find state cluster dir at '$STATE_CLUSTER', exiting." >&2
+if [ ! -e "$state_cluster" ]; then
+  echo "Cannot find state cluster dir at '$state_cluster', exiting." >&2
   exit 1
 fi
 
-if [ ! -f "${STATE_CLUSTER}/stop-cluster" ]; then
-  echo "Cannot find '${STATE_CLUSTER}/stop-cluster', exiting." >&2
+if [ ! -f "${state_cluster}/stop-cluster" ]; then
+  echo "Cannot find '${state_cluster}/stop-cluster', exiting." >&2
   exit 1
 fi
 
-"$STATE_CLUSTER/stop-cluster"
+"$state_cluster/stop-cluster"
 sleep 2
 
-"$STATE_CLUSTER/supervisord_start"
+"$state_cluster/supervisord_start"
 sleep 2
 
-"$STATE_CLUSTER/supervisorctl_local" start all
+"$state_cluster/supervisorctl_local" start all
 sleep 1
 
 echo
 echo "Dev cluster restarted; current status:"
-"$STATE_CLUSTER/supervisorctl_local" status all
+"$state_cluster/supervisorctl_local" status all

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -25,21 +25,21 @@ case "${1:-}" in
     ;;
 esac
 
-ORIG_PWD="$PWD"
-REPODIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
-export WORKDIR="$REPODIR/dev_workdir"
+orig_pwd="$PWD"
+repodir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine repo dir, exiting." >&2; exit 1; }
+export WORKDIR="$repodir/dev_workdir"
 
-if [ "$ORIG_PWD" = "$WORKDIR" ]; then
+if [ "$orig_pwd" = "$WORKDIR" ]; then
   echo "Please run this script from outside of '$WORKDIR'" >&2
   exit 1
 fi
 
-cd "$REPODIR" || exit 1
+cd "$repodir" || exit 1
 rm -rf "${WORKDIR:?}"
 mkdir -p "${WORKDIR}/tmp"
 
 # shellcheck disable=SC1091
-. "$REPODIR/runner/setup_venv.sh"
+. "$repodir/runner/setup_venv.sh"
 
 cat > "$WORKDIR/activate" <<EoF
 if ! command -v cardano-node >/dev/null 2>&1; then
@@ -80,11 +80,11 @@ EoF
 source "$WORKDIR/activate"
 prepare-cluster-scripts -d "$WORKDIR/local_fast" -t "local_fast"
 
-# Compute a relative path only if WORKDIR is under ORIG_PWD
-if [[ "$WORKDIR" == "$ORIG_PWD"* ]]; then
-    REL_WORKDIR="./${WORKDIR#"$ORIG_PWD"/}"
+# Compute a relative path only if WORKDIR is under orig_pwd
+if [[ "$WORKDIR" == "$orig_pwd"* ]]; then
+    rel_workdir="./${WORKDIR#"$orig_pwd"/}"
 else
-    REL_WORKDIR="$WORKDIR"
+    rel_workdir="$WORKDIR"
 fi
 
 echo
@@ -93,8 +93,8 @@ echo "      🚀  Test Environment Ready"
 echo "========================================"
 echo
 echo "👉  Activate the environment:"
-echo "    source $REL_WORKDIR/activate"
+echo "    source $rel_workdir/activate"
 echo
 echo "👉  Start the local testnet:"
-echo "    $REL_WORKDIR/local_fast/start-cluster"
+echo "    $rel_workdir/local_fast/start-cluster"
 echo

--- a/scripts/test_block_production.sh
+++ b/scripts/test_block_production.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 # The database file will be created if missing
 if [ -z "${BLOCK_PRODUCTION_DB:-}" ]; then
@@ -28,4 +28,4 @@ export BLOCK_PRODUCTION_EPOCHS="${BLOCK_PRODUCTION_EPOCHS:-"100"}"
 
 export MIXED_UTXO_BACKENDS="mem disk" SESSION_TIMEOUT=10h CLUSTERS_COUNT=1 TEST_THREADS=0 PYTEST_ARGS="-k test_block_production"
 
-"$TOP_DIR/runner/regression.sh"
+"$top_dir/runner/regression.sh"

--- a/scripts/test_node_ipc_shutdown.sh
+++ b/scripts/test_node_ipc_shutdown.sh
@@ -7,8 +7,8 @@ if [ -z "$CARDANO_NODE_SOCKET_PATH" ]; then
   exit 1
 fi
 
-BOOTSRAP_DIR="${CARDANO_NODE_SOCKET_PATH%/*}"
-cd "$BOOTSRAP_DIR" || exit 1
+bootstrap_dir="${CARDANO_NODE_SOCKET_PATH%/*}"
+cd "$bootstrap_dir" || exit 1
 
 rm -f nodefifo
 mkfifo nodefifo

--- a/scripts/test_node_reconnect.sh
+++ b/scripts/test_node_reconnect.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 export \
   CLUSTERS_COUNT=1 \
@@ -14,4 +14,4 @@ export \
   TESTNET_VARIANT="mainnet_fast" \
   PYTEST_ARGS="-s -k TestNodeReconnect"
 
-"$TOP_DIR/runner/regression.sh"
+"$top_dir/runner/regression.sh"

--- a/scripts/test_rollbacks.sh
+++ b/scripts/test_rollbacks.sh
@@ -13,16 +13,16 @@
 
 set -euo pipefail
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
 
 export NUM_POOLS="${NUM_POOLS:-"10"}" CLUSTERS_COUNT=1 TEST_THREADS=0
 
 if [ -n "${INTERACTIVE:-""}" ]; then
   export ROLLBACK_PAUSE=1 TESTNET_VARIANT="mainnet_fast" PYTEST_ARGS="-s -k test_consensus_reached"
-  "$TOP_DIR/runner/regression.sh"
+  "$top_dir/runner/regression.sh"
 else
   export TESTNET_VARIANT="local_fast" PYTEST_ARGS="-k test_permanent_fork"
-  "$TOP_DIR/runner/regression.sh" || exit "$?"
+  "$top_dir/runner/regression.sh" || exit "$?"
   export TESTNET_VARIANT="mainnet_fast" PYTEST_ARGS="-k test_consensus_reached"
-  "$TOP_DIR/runner/regression.sh"
+  "$top_dir/runner/regression.sh"
 fi

--- a/scripts/update_node_bins.sh
+++ b/scripts/update_node_bins.sh
@@ -13,11 +13,11 @@ if [ $# -ne 1 ]; then
   usage >&2
   exit 2
 fi
-REPO_PATH="$(readlink -f "$1")"
+repo_path="$(readlink -f "$1")"
 
-TOP_DIR="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
-BUILD_OUTPUT_DIR="$REPO_PATH/.nix_tests_bins"
-BIN_DIR="$TOP_DIR/.bin_node"
+top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
+build_output_dir="$repo_path/.nix_tests_bins"
+bin_dir="$top_dir/.bin_node"
 
 # Call the generic build and link script
-"${0%/*}/build_and_link_node_bins.sh" "$REPO_PATH" "$BUILD_OUTPUT_DIR" "$BIN_DIR"
+"${0%/*}/build_and_link_node_bins.sh" "$repo_path" "$build_output_dir" "$bin_dir"

--- a/testnets_bootstrap_template/faucet_setup.sh
+++ b/testnets_bootstrap_template/faucet_setup.sh
@@ -13,12 +13,12 @@ if [ ! -e shelley/faucet.addr ]; then
 fi
 
 if [ -n "${APIKEY:-""}" ]; then
-  ADDR="$(<shelley/faucet.addr)"
-  echo "Fund the faucet address '$ADDR'? Press Ctrl+C to cancel."
+  addr="$(<shelley/faucet.addr)"
+  echo "Fund the faucet address '$addr'? Press Ctrl+C to cancel."
   read -r
 
-  curl -v -XPOST "https://faucet.${TESTNET_NAME}.dev.cardano.org/send-money/${ADDR}?apiKey=${APIKEY}"
+  curl -v -XPOST "https://faucet.${TESTNET_NAME}.dev.cardano.org/send-money/${addr}?apiKey=${APIKEY}"
   sleep 10
-  cardano-cli latest query utxo --out-file /dev/stdout --testnet-magic "$TESTNET_MAGIC" --address "$ADDR"
+  cardano-cli latest query utxo --out-file /dev/stdout --testnet-magic "$TESTNET_MAGIC" --address "$addr"
   echo
 fi

--- a/testnets_bootstrap_template/postgres-setup.sh
+++ b/testnets_bootstrap_template/postgres-setup.sh
@@ -3,19 +3,19 @@
 
 set -euo pipefail
 
-SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
-STATE_CLUSTER="${SOCKET_PATH%/*}"
-DATABASE_NAME="dbsync0"
+socket_path="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
+state_cluster="${socket_path%/*}"
+database_name="dbsync0"
 
-PGPASSFILE="$STATE_CLUSTER/pgpass"
+pgpassfile="$state_cluster/pgpass"
 export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-echo "Deleting db $DATABASE_NAME"
-dropdb --if-exists "$DATABASE_NAME" > /dev/null
-echo "Setting up db $DATABASE_NAME"
-createdb -T template0 --owner="$PGUSER" --encoding=UTF8 "$DATABASE_NAME"
+echo "Deleting db $database_name"
+dropdb --if-exists "$database_name" > /dev/null
+echo "Setting up db $database_name"
+createdb -T template0 --owner="$PGUSER" --encoding=UTF8 "$database_name"
 
-echo "${PGHOST}:${PGPORT}:${DATABASE_NAME}:${PGUSER}:secret" > "$PGPASSFILE"
-chmod 600 "$PGPASSFILE"
+echo "${PGHOST}:${PGPORT}:${database_name}:${PGUSER}:secret" > "$pgpassfile"
+chmod 600 "$pgpassfile"


### PR DESCRIPTION
Reserve uppercase for exported and environment variables; rename internal/computed globals to lowercase across the shell scripts to match the convention already used for function-local variables.

Promote fixed-value constants to readonly uppercase: the GHC and Cabal version pins in install-node.sh and the TRUE/FALSE display symbols in check_dev_env.sh.