### PR TITLE
test(dbsync): cover epoch view schema change (db-sync 13.7.2)

### DIFF
--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -18,6 +18,7 @@ from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_queries
+from cardano_node_tests.utils import dbsync_service_manager
 from cardano_node_tests.utils import dbsync_snapshot_service
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -108,6 +109,10 @@ class TestDBSync:
         "withdrawal",
     }
 
+    # Since db-sync 13.7.2 the `epoch` rollup is exposed through views, not a table.
+    # Derived from the `View` enum so the enum stays the single source of truth.
+    DBSYNC_VIEWS: tp.Final[set[str]] = {v.value for v in dbsync_service_manager.View}
+
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
         VERSIONS.dbsync < version.parse("13.7.2"),
@@ -126,6 +131,22 @@ class TestDBSync:
         """
         common.get_test_id(cluster)
         assert self.DBSYNC_TABLES.issubset(dbsync_queries.query_table_names())
+
+    @allure.link(helpers.get_vcs_link())
+    @pytest.mark.skipif(
+        VERSIONS.dbsync < version.parse("13.7.2"),
+        reason="needs db-sync version >= 13.7.2",
+    )
+    @pytest.mark.testnets
+    @pytest.mark.smoke
+    def test_view_names(self, cluster: clusterlib.ClusterLib):
+        """Check that the expected views are present in db-sync.
+
+        Since db-sync 13.7.2 `epoch` is a view, so `test_table_names` (which queries
+        `pg_tables`) does not cover it; assert the views exist here instead.
+        """
+        common.get_test_id(cluster)
+        assert self.DBSYNC_VIEWS.issubset(dbsync_queries.query_view_names())
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.order(-10)
@@ -395,12 +416,11 @@ class TestDBSync:
     def test_epoch(self, cluster: clusterlib.ClusterLib):
         """Check expected values in the `epoch` table in db-sync.
 
-        Test db-sync epoch table data consistency by comparing aggregated counts with
-        block table data. Skip if running in epoch 0.
+        Test db-sync epoch view data consistency by comparing aggregated counts with
+        block table data, using a finalized epoch (current - 1).
 
-        * Query current epoch from cluster
-        * Use previous epoch for validation (current - 1) if not in epoch 0
-        * Skip test if in epoch 0
+        * Wait for epoch 2 so a finalized epoch (current - 1 >= 1) is available
+        * Query current epoch from cluster and validate the previous epoch (current - 1)
         * Query all blocks for the target epoch from block table
         * Count blocks and transactions from block table records
         * Query epoch summary from epoch table for same epoch
@@ -410,11 +430,12 @@ class TestDBSync:
         """
         common.get_test_id(cluster)
 
-        current_epoch = cluster.g_query.get_epoch()
-        epoch = current_epoch - 1 if current_epoch >= 1 else current_epoch
+        # Ensure a finalized epoch is available to validate (need current >= 2 so that
+        # current - 1 >= 1). No-op on long-lived testnets (already far past epoch 2).
+        cluster.wait_for_epoch(epoch_no=2)
 
-        if epoch == 0:
-            pytest.skip("Not meant to run in epoch 0")
+        current_epoch = cluster.g_query.get_epoch()
+        epoch = current_epoch - 1
 
         blocks_data_blk_count = 0
         blocks_data_tx_count = 0
@@ -439,6 +460,57 @@ class TestDBSync:
 
         assert blocks_data_tx_count == epoch_data_tx_count, (
             f"Transactions count don't match between tables for epoch {epoch}"
+        )
+
+    @allure.link(helpers.get_vcs_link())
+    @pytest.mark.skipif(
+        VERSIONS.dbsync < version.parse("13.7.2"),
+        reason="needs db-sync version >= 13.7.2",
+    )
+    @pytest.mark.testnets
+    @pytest.mark.smoke
+    def test_epoch_current(self, cluster: clusterlib.ClusterLib):
+        """Check the live current-epoch branch via the `epoch_current` view.
+
+        Since db-sync 13.7.2 the in-progress epoch is served live by `epoch_current`,
+        unioned into the public `epoch` view; `test_epoch` only covers a finalized epoch.
+        This is a smoke test that the feature is wired up against a running chain: the live
+        branch is enabled (`epoch_sync_enabled`) and the current epoch is surfaced as exactly
+        one correctly-numbered row.
+
+        Count/sum correctness is not asserted here: the view derives its counts from the same
+        `block`/`tx` tables, so comparing it back against them is self-referential, and the
+        aggregation logic itself is covered by the db-sync repo's own unit tests.
+        """
+        common.get_test_id(cluster)
+
+        # Ensure the chain has progressed past the genesis epoch so the current epoch is
+        # actively producing blocks. No-op on long-lived testnets (already past epoch 1).
+        cluster.wait_for_epoch(epoch_no=1)
+
+        # The live branch must be enabled, otherwise `epoch_current` is empty by design.
+        assert dbsync_queries.query_epoch_sync_enabled(), (
+            "Live epoch sync (`epoch_sync_enabled`) is not enabled in db-sync"
+        )
+
+        current_epoch = cluster.g_query.get_epoch()
+
+        epoch_rows = list(
+            dbsync_queries.query_epoch_current(epoch_from=current_epoch, epoch_to=current_epoch)
+        )
+
+        if not epoch_rows:
+            pytest.skip(f"No `epoch_current` view row yet for the current epoch {current_epoch}")
+
+        assert len(epoch_rows) == 1, (
+            f"Expected a single `epoch_current` view row for epoch {current_epoch}, "
+            f"got {len(epoch_rows)}"
+        )
+
+        epoch_row = epoch_rows[0]
+        assert epoch_row.epoch_number == current_epoch, (
+            f"`epoch_current` view row has epoch_no {epoch_row.epoch_number}, "
+            f"expected {current_epoch}"
         )
 
 

--- a/cardano_node_tests/utils/dbsync_queries.py
+++ b/cardano_node_tests/utils/dbsync_queries.py
@@ -1196,6 +1196,21 @@ def query_table_names() -> list[str]:
         return table_names
 
 
+def query_view_names() -> list[str]:
+    """Query view names in db-sync."""
+    query = (
+        "SELECT viewname "
+        "FROM pg_catalog.pg_views "
+        "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema' "
+        "ORDER BY viewname ASC;"
+    )
+
+    with execute(query=query) as cur:
+        results: list[tuple[str]] = cur.fetchall()
+        view_names = [r[0] for r in results]
+        return view_names
+
+
 def query_datum(*, datum_hash: str) -> tp.Generator[DatumDBRow]:
     """Query datum record in db-sync."""
     query = "SELECT id, hash, tx_id, value, bytes FROM datum WHERE hash = %s;"
@@ -1306,6 +1321,42 @@ def query_epoch(*, epoch_from: int = 0, epoch_to: int = 99999999) -> tp.Generato
     with execute(query=query, vars=query_vars) as cur:
         while (result := cur.fetchone()) is not None:
             yield EpochDBRow(*result)
+
+
+def query_epoch_current(
+    *, epoch_from: int = 0, epoch_to: int = 99999999
+) -> tp.Generator[EpochDBRow]:
+    """Query the live `epoch_current` view in db-sync (since db-sync 13.7.2).
+
+    Unlike the public `epoch` view (finalized rows UNION the live aggregation), this reads the
+    in-progress current-epoch branch directly. It is empty unless live epoch sync is enabled
+    (see `query_epoch_sync_enabled`).
+    """
+    query_vars = (epoch_from, epoch_to)
+
+    query = (
+        "SELECT"
+        " epoch_current.id, epoch_current.out_sum, epoch_current.fees,"
+        " epoch_current.tx_count, epoch_current.blk_count, epoch_current.no "
+        "FROM epoch_current "
+        "WHERE (no BETWEEN %s AND %s);"
+    )
+
+    with execute(query=query, vars=query_vars) as cur:
+        while (result := cur.fetchone()) is not None:
+            yield EpochDBRow(*result)
+
+
+def query_epoch_sync_enabled() -> bool:
+    """Query whether live epoch sync is enabled in db-sync (since db-sync 13.7.2).
+
+    When disabled, both the `epoch_current` and `epoch` views return no rows by design.
+    """
+    query = "SELECT enabled FROM epoch_sync_enabled WHERE singleton = TRUE;"
+
+    with execute(query=query) as cur:
+        result = cur.fetchone()
+        return bool(result[0]) if result is not None else False
 
 
 def query_committee_registration(*, cold_key: str) -> tp.Generator[CommitteeRegistrationDBRow]:

--- a/cardano_node_tests/utils/dbsync_service_manager.py
+++ b/cardano_node_tests/utils/dbsync_service_manager.py
@@ -42,11 +42,13 @@ class Table(enum.StrEnum):
     DREP_DISTR = "drep_distr"
     DREP_HASH = "drep_hash"
     DREP_REGISTRATION = "drep_registration"
-    EPOCH = "epoch"
+    # `epoch` is a view since db-sync 13.7.2 (see the View enum), not a table.
+    EPOCH_FINALIZED = "epoch_finalized"
     EPOCH_PARAM = "epoch_param"
     EPOCH_STAKE = "epoch_stake"
     EPOCH_STAKE_PROGRESS = "epoch_stake_progress"
     EPOCH_STATE = "epoch_state"
+    EPOCH_SYNC_ENABLED = "epoch_sync_enabled"
     EPOCH_SYNC_TIME = "epoch_sync_time"
     EVENT_INFO = "event_info"
     EXTRA_KEY_WITNESS = "extra_key_witness"
@@ -98,6 +100,15 @@ class Table(enum.StrEnum):
     TX_OUT = "tx_out"
     VOTING_ANCHOR = "voting_anchor"
     VOTING_PROCEDURE = "voting_procedure"
+
+
+class View(enum.StrEnum):
+    """Enum representing the views in the Cardano db-sync database (since db-sync 13.7.2)."""
+
+    # Public epoch rollup: finalized rows UNION live current rows.
+    EPOCH = "epoch"
+    # Live aggregation of in-progress epochs from `block`/`tx`.
+    EPOCH_CURRENT = "epoch_current"
 
 
 class Column:

--- a/runner/env_nightly_dbsync
+++ b/runner/env_nightly_dbsync
@@ -1,6 +1,6 @@
 COMMAND_ERA=latest
 MARKEXPR=dbsync or smash
-DBSYNC_REV=13.7.0.4
-DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.7.0.4/cardano-db-sync-13.7.0.4-linux.tar.gz
+DBSYNC_REV=13.7.2.1
+DBSYNC_TAR_URL=https://github.com/IntersectMBO/cardano-db-sync/releases/download/13.7.2.1/cardano-db-sync-13.7.2.1-linux.tar.gz
 SMASH=true
 DBSYNC_SKIP_INDEXES=true


### PR DESCRIPTION
In db-sync 13.7.2 the `epoch` table is replaced by a view: finalized rows UNION a live current-epoch aggregation, backed by the new `epoch_finalized` and `epoch_sync_enabled` tables. Reads via `epoch` are unchanged.

`test_table_names` was already updated for the two new tables. This adds the coverage that was still missing at the integration level:

- `query_view_names()` + `test_view_names`: assert the `epoch` and `epoch_current` views exist. `test_table_names` only looks at pg_tables, so a dropped or renamed view would otherwise go unnoticed.
- `test_epoch_current`: exercises the live `epoch_current` view branch end to end against a running db-sync (enabled, populated, one sane row for the current epoch). `test_epoch` only covers a finalized epoch. The view is read before the block table so the bound is race-free mid-epoch.
- Table enum fix: `epoch` is now a view; added `epoch_finalized` / `epoch_sync_enabled` and a View enum.
- Bumped nightly db-sync to the latest release 13.7.2.1.

Scope note: this is integration-level coverage of schema shape and the live view branch. The out_sum/fees decoding correctness behind issue #2118 is covered hermetically by the db-sync repo's own unit tests (cardano-db
`EpochCalc`, added with the #2118 fix), so it is intentionally not duplicated here, where local-cluster values are too small to exercise the Word128 decoder path anyway.

All new tests are gated on dbsync >= 13.7.2. Verified against a local conway_fast cluster (db-sync 13.7.2.1): 4 passed.
