### PR TITLE
feat(tests): derive cost model proposals from live protocol params

### DIFF
--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -15,6 +15,7 @@ from cardano_node_tests.tests import common
 from cardano_node_tests.tests.tests_conway import conway_common
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
+from cardano_node_tests.utils import cost_model_utils
 from cardano_node_tests.utils import governance_setup
 from cardano_node_tests.utils import governance_utils
 from cardano_node_tests.utils import helpers
@@ -132,7 +133,7 @@ class TestSetup:
         Test updating Plutus cost models after node upgrade. Runs only on step 2 of upgrade
         testing sequence.
 
-        * Load cost model proposal from JSON file (PlutusV2 and PlutusV3 models)
+        * Generate cost model proposal from the running cluster's current protocol parameters
         * Get default governance data (DReps, committee members, pools)
         * Submit cost model update governance action
         * Vote and ratify the cost model update
@@ -141,7 +142,10 @@ class TestSetup:
         """
         cluster = cluster_singleton
         temp_template = common.get_test_id(cluster)
-        cost_proposal_file = DATA_DIR / "cost_models_list_185_297_v2_v3.json"
+        cost_proposal_file = cost_model_utils.write_cost_model_proposal(
+            cost_models=cost_model_utils.get_current_cost_models(cluster),
+            dest=temptools.get_basetemp() / f"{temp_template}_cost_models.json",
+        )
 
         governance_data = governance_setup.get_default_governance(
             cluster_manager=cluster_manager, cluster_obj=cluster

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -17,11 +17,13 @@ from cardano_node_tests.tests import reqs_conway as reqc
 from cardano_node_tests.tests.tests_conway import conway_common
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import cost_model_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import governance_utils
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import submit_api
 from cardano_node_tests.utils import submit_utils
+from cardano_node_tests.utils import temptools
 from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
@@ -280,6 +282,11 @@ class TestPParamUpdate:
 
         * Vote to disapprove the actions
         * Submit a "protocol parameters update" action that will be enacted
+
+            - Cost model proposal is generated dynamically from the running cluster's
+              current protocol parameters, so no static fixture file needs updating
+              when mainnet governance changes cost models.
+
         * Check that SPOs cannot vote on a "protocol parameters update" action that doesn't
           change security parameters
         * Vote to approve the action
@@ -293,7 +300,10 @@ class TestPParamUpdate:
         """
         cluster, governance_data = cluster_lock_governance_plutus
         temp_template = common.get_test_id(cluster)
-        cost_proposal_file = DATA_DIR / "cost_models_list_185_v2_v3.json"
+        cost_proposal_file = cost_model_utils.write_cost_model_proposal(
+            cost_models=cost_model_utils.get_current_cost_models(cluster),
+            dest=temptools.get_basetemp() / f"{temp_template}_cost_models.json",
+        )
         db_errors_final = []
         is_in_bootstrap = conway_common.is_in_bootstrap(cluster_obj=cluster)
 

--- a/cardano_node_tests/utils/cost_model_utils.py
+++ b/cardano_node_tests/utils/cost_model_utils.py
@@ -1,0 +1,29 @@
+"""Utilities for cost model proposal generation."""
+
+import json
+import pathlib as pl
+
+from cardano_clusterlib import clusterlib
+
+
+def get_current_cost_models(cluster_obj: clusterlib.ClusterLib) -> dict[str, list[int]]:
+    """Return the current cost models from live protocol parameters."""
+    return cluster_obj.g_query.get_protocol_params()["costModels"]
+
+
+def write_cost_model_proposal(
+    cost_models: dict[str, list[int]],
+    dest: pl.Path,
+) -> pl.Path:
+    """Write cost models to a JSON file suitable for --cost-model-file.
+
+    Args:
+        cost_models: Dict mapping Plutus version names to their cost model arrays.
+        dest: Destination path for the JSON file.
+
+    Returns:
+        The destination path.
+    """
+    with open(dest, "w", encoding="utf-8") as fp:
+        json.dump(cost_models, fp, indent=2)
+    return dest

--- a/cardano_node_tests/utils/cost_model_utils.py
+++ b/cardano_node_tests/utils/cost_model_utils.py
@@ -8,7 +8,8 @@ from cardano_clusterlib import clusterlib
 
 def get_current_cost_models(cluster_obj: clusterlib.ClusterLib) -> dict[str, list[int]]:
     """Return the current cost models from live protocol parameters."""
-    return cluster_obj.g_query.get_protocol_params()["costModels"]
+    cost_models: dict[str, list[int]] = cluster_obj.g_query.get_protocol_params()["costModels"]
+    return cost_models
 
 
 def write_cost_model_proposal(

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -32,7 +32,7 @@ class Versions:
     DEFAULT_CLUSTER_ERA: tp.Final[int] = CONWAY
     DEFAULT_TX_ERA: tp.Final[int] = DEFAULT_CLUSTER_ERA
 
-    # Map protocol versions to era names
+    # Map protocol versions to era names — add new entries here when a new era ships
     MAP: tp.ClassVar[dict[int, str]] = {
         0: "byron",
         1: "byron",
@@ -48,6 +48,9 @@ class Versions:
         11: "conway",
         12: "dijkstra",
     }
+
+    # Derived from MAP so it stays current when new eras are added above
+    LAST_KNOWN_PROTOCOL_VERSION: tp.Final[int] = max(MAP)
 
     def __init__(self) -> None:
         protocol_version = helpers.get_env_int("PROTOCOL_VERSION", self.DEFAULT_CLUSTER_ERA)


### PR DESCRIPTION
## Summary
- Governance and upgrade tests hardcoded fixture files with fixed PlutusV2/V3 cost model lengths (185/297, 185). Mainnet governance updates cost models over time, so these fixtures drift out of sync and get rejected by the node.
- Added `cost_model_utils.get_current_cost_models`/`write_cost_model_proposal` to build a governance proposal from the cluster's own live protocol parameters instead. `test_pparam_update.py` and `test_node_upgrade.py` now use this for their happy-path proposals; `test_incompatible_cost_models` keeps its static fixture since it intentionally tests format rejection.
- Derived `LAST_KNOWN_PROTOCOL_VERSION` from `Versions.MAP` instead of a hardcoded constant, so it no longer needs a manual bump on every new protocol version.

Companion infra fix: IntersectMBO/cardonnay#148 (syncs genesis cost model values with mainnet; this PR is what stays dynamic on the test side going forward).

## Test plan
- [ ] `./ai_run.sh make lint` passes
- [ ] `pytest -k test_update_cost_models` against a running cluster (both `test_pparam_update.py` and `test_node_upgrade.py` upgrade-step-2 variants)