### PR TITLE
fix: pin claude model id in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -99,7 +99,7 @@ jobs:
         uses: anthropics/claude-code-base-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: sonnet
+          model: claude-sonnet-5
           max_turns: "40"
           allowed_tools: "Read,Write,Glob,Grep,Bash(ls:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(find:*),Bash(cut:*),Bash(sort:*),Bash(uniq:*),Bash(awk:*),Bash(jq:*)"
           prompt: ${{ env.ANALYSIS_PROMPT }}


### PR DESCRIPTION
The 'sonnet' alias in claude-code-base-action resolved to the retired claude-sonnet-4-20250514 snapshot, causing a 404 not_found_error. Pin the explicit current claude-sonnet-5 id instead.