### PR TITLE
feat: split analysis prompts for interactive and CI use

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -142,6 +142,7 @@ jobs:
           {
             echo 'ANALYSIS_PROMPT<<__EOF_PROMPT42__'
             sed 's|{RUN_DIR}|run_workdir|g' agent_docs/failure_analysis_prompt.md
+            sed 's|{RUN_DIR}|run_workdir|g' agent_docs/ci_analysis_prompt.md
             printf '\n__EOF_PROMPT42__\n'
           } >> "$GITHUB_ENV"
       - name: 🤖 Analyze test failures with Claude

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -90,6 +90,7 @@ jobs:
           {
             echo 'ANALYSIS_PROMPT<<__EOF_PROMPT42__'
             sed 's|{RUN_DIR}|run_workdir|g' agent_docs/upgrade_failure_analysis_prompt.md
+            sed 's|{RUN_DIR}|run_workdir|g' agent_docs/ci_analysis_prompt.md
             printf '\n__EOF_PROMPT42__\n'
           } >> "$GITHUB_ENV"
       - name: 🤖 Analyze test failures with Claude

--- a/agent_docs/ci_analysis_prompt.md
+++ b/agent_docs/ci_analysis_prompt.md
@@ -1,0 +1,8 @@
+# CI Constraints
+
+Additional constraints for automated CI runs:
+
+- Output a single markdown file at: `{RUN_DIR}/failure_analysis.md`.
+- Keep it under ~300 lines.
+
+Start now.

--- a/agent_docs/failure_analysis_prompt.md
+++ b/agent_docs/failure_analysis_prompt.md
@@ -2,7 +2,7 @@
 
 You are triaging a failed cardano-node-tests regression run. Produce a concise preliminary failure analysis.
 
-The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). All input paths below are under that directory.
+The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). The default run directory is `run_workdir`. All input paths below are under that directory.
 
 Inputs available under `{RUN_DIR}/` (use only what exists):
 
@@ -46,9 +46,6 @@ Known patterns:
 
 Constraints:
 
-- Output a single markdown file at: `{RUN_DIR}/failure_analysis.md`.
-- Keep it under ~300 lines. No full stack traces — only the most informative line(s).
+- No full stack traces — only the most informative line(s).
 - If a source file is missing, note it once and move on; do not fail.
 - Do not modify any other files.
-
-Start now.

--- a/agent_docs/upgrade_failure_analysis_prompt.md
+++ b/agent_docs/upgrade_failure_analysis_prompt.md
@@ -2,7 +2,7 @@
 
 You are triaging a failed cardano-node-tests **node upgrade** run. Produce a concise preliminary failure analysis.
 
-The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). All input paths below are under that directory.
+The run directory is `{RUN_DIR}` (path is relative to the current working directory unless it is absolute). The default run directory is `run_workdir`. All input paths below are under that directory.
 
 A node upgrade run executes the same smoke-test suite three times against an evolving cluster:
 
@@ -39,9 +39,6 @@ Known patterns:
 
 Constraints:
 
-- Output a single markdown file at: `{RUN_DIR}/failure_analysis.md`.
-- Keep it under ~300 lines. No full stack traces — only the most informative line(s).
+- No full stack traces — only the most informative line(s).
 - If a source file is missing, note it once and move on; do not fail.
 - Do not modify any other files.
-
-Start now.

--- a/scripts/analyze_failures.sh
+++ b/scripts/analyze_failures.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
 # Run preliminary failure analysis on a regression-run directory using any
-# coding-agent CLI that accepts a prompt on stdin (or via -p/--prompt).
+# coding-agent CLI that accepts a prompt as its first positional argument.
 #
 # Usage:
 #   scripts/analyze_failures.sh [run_dir]
 #
 # run_dir defaults to ./run_workdir. It can point at a fresh run produced by
 # `runner/regression.sh` or at any saved historical run directory (relative
-# or absolute path). The agent writes ${run_dir}/failure_analysis.md per the
-# prompt contract.
+# or absolute path).
+#
+# By default the agent is started in interactive mode, seeded with the
+# analysis prompt, so you can read the findings and ask follow-up questions.
+# The CI-only constraints (write failure_analysis.md, length cap, "Start now.")
+# are intentionally NOT included here; those live in agent_docs/ci_analysis_prompt.md
+# and are appended only by the CI workflows.
 #
 # Env vars:
-#   AGENT_CMD     Command used to invoke the agent. Default: "claude -p".
+#   AGENT_CMD     Command used to invoke the agent. Default: "claude".
+#                 The prompt is passed as the last positional argument.
 #                 Examples:
-#                   AGENT_CMD="claude -p"
+#                   AGENT_CMD="claude"              # interactive (default)
+#                   AGENT_CMD="claude -p"           # non-interactive print mode
+#                   AGENT_CMD="claude --model opus" # interactive, model override
 #                   AGENT_CMD="gemini"
-#                   AGENT_CMD="codex exec"
-#                 The prompt is piped to the command on stdin.
+#                   AGENT_CMD="codex"
 #   PROMPT_FILE   Override prompt auto-detection. Path to a prompt template
 #                 containing {RUN_DIR} placeholders.
 
 set -euo pipefail
 
 run_dir="${1:-run_workdir}"
-AGENT_CMD="${AGENT_CMD:-claude -p}"
+AGENT_CMD="${AGENT_CMD:-claude}"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
@@ -51,9 +58,11 @@ if [ ! -f "${PROMPT_FILE}" ]; then
   exit 1
 fi
 
-# Substitute {RUN_DIR} in the prompt template, then pipe to the agent.
+# Substitute {RUN_DIR} in the prompt template, then seed the agent with it.
 prompt_content="$(cat "${PROMPT_FILE}")"
 prompt_content="${prompt_content//\{RUN_DIR\}/${run_dir}}"
 
+# Pass the prompt as the last positional argument so interactive agents start
+# seeded with it (stdin piping would put claude into non-interactive mode).
 # shellcheck disable=SC2086
-printf '%s\n' "${prompt_content}" | exec $AGENT_CMD
+exec $AGENT_CMD "${prompt_content}"


### PR DESCRIPTION
Move CI-only directives (write failure_analysis.md, length cap, "Start now.") out of the base failure-analysis prompts into a separate agent_docs/ci_analysis_prompt.md that the workflows append. The base prompts are now conversational, so analyze_failures.sh can seed an interactive agent session (prompt passed as positional arg instead of piped to stdin) and the user can ask follow-up questions.