### PR TITLE
Store DRep inline image data URI verbatim

### DIFF
--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -1332,8 +1332,6 @@ def check_off_chain_drep_registration(  # noqa: C901
     expected_metadata = metadata["body"]
 
     # For the image rules refer to: https://cips.cardano.org/cip/CIP-0119
-    # off_chain_drep_data.image_url includes the image base64 with the data uri
-    # header prefix stripped and the off_chain_drep_data.image_sha256 remains empty.
     def _check_image() -> None:
         if "image" not in expected_metadata:
             return
@@ -1349,10 +1347,10 @@ def check_off_chain_drep_registration(  # noqa: C901
                         "Invalid metadata: base64 encoded image should start with 'data:image/'"
                     )
                 if "base64" in content_url:
-                    base64_image_data = content_url.split("base64,")[1]
-                    if db_metadata.image_url != base64_image_data:
+                    # db-sync stores the data URI verbatim (cardano-db-sync #2138).
+                    if db_metadata.image_url != content_url:
                         errors.append(
-                            "'image_url' value is different than expected Base64 'contentUrl';"
+                            "'image_url' value is different than expected data-URI 'contentUrl';"
                         )
                 else:
                     errors.append("Invalid metadata: image is not Base64 encoded")


### PR DESCRIPTION
## What

`test_register_and_retire_drep` (the `drep_metadata_ipfs.json` variant, which uses an 
inline `data:image/png;base64,…` image) asserts the DRep off-chain image the old way.

cardano-db-sync [#2138](https://github.com/IntersectMBO/cardano-db-sync/pull/2138)
(fixes [#1966](https://github.com/IntersectMBO/cardano-db-sync/pull/1966) stops stripping the `data:<mime>;base64,` prefix: per CIP-119 it now stores
the full `contentUrl` verbatim in `off_chain_vote_drep_data.image_url`. The check in
`dbsync_utils.check_off_chain_drep_registration` still expected the stripped base64
payload, so it fails against db-sync with `#2138`.

This updates the base64 branch to assert the full data URI (`image_url == content_url`).
Regular URL images (which carry a sha256) are unchanged.

## ⚠️ Merge coordination

The released `13.7.2.1` binary does **not** contain [#2138](https://github.com/IntersectMBO/cardano-db-sync/pull/2138), and db-sync master still reports
version `13.7.2.1`, so the behavior can't be version-gated. After this merges,
`test_register_and_retire_drep` will fail against any db-sync **without** `#2138` - including
CI-nightly, which pins released `13.7.2.1`. **Merge alongside bumping the nightly
`DBSYNC_REV` to the release that includes `#2138`.**

## Testing

To verify once a `#2138` build exists:
`pytest -k "test_register_and_retire_drep" cardano_node_tests/tests/tests_conway/test_drep.py`