### PR TITLE
fix(plutus): base collateral on whole tx fee

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -1,5 +1,6 @@
 import dataclasses
 import itertools
+import math
 import pathlib as pl
 
 import pytest
@@ -657,7 +658,10 @@ def get_cost_per_unit(protocol_params: dict) -> ExecutionCost:
 
 
 def compute_cost(
-    execution_cost: ExecutionCost, protocol_params: dict, collateral_fraction_offset: float = 1.0
+    execution_cost: ExecutionCost,
+    protocol_params: dict,
+    base_fee: int | None = None,  # Fee without script cost; default = fee for tx of max size
+    collateral_fraction_offset: float = 1.0,
 ) -> ScriptCost:
     """Compute fee and collateral required for the Plutus script."""
     cost_per_unit = get_cost_per_unit(protocol_params=protocol_params)
@@ -668,11 +672,34 @@ def compute_cost(
         )
         + execution_cost.fixed_cost
     )
+    if base_fee is None:
+        base_fee = (
+            protocol_params["txFeeFixed"]
+            + protocol_params["txFeePerByte"] * protocol_params["maxTxSize"]
+        )
 
     collateral_fraction = protocol_params["collateralPercentage"] / 100
-    min_collateral = int(fee_redeem * collateral_fraction * collateral_fraction_offset)
-    # Eventual return collateral UTxO value must be bigger than min UTxO value
-    collateral_amount = max(min_collateral + 1_000_000, 2_000_000)
+    # The ledger requires collateral to cover `collateralPercentage` of the WHOLE
+    # transaction fee, not just the Plutus script execution cost. The exact fee is
+    # unknown before the transaction is built (chicken-and-egg), so `base_fee` is
+    # a pessimistic estimate of the non-script part of the fee. Overestimating is
+    # harmless: collateral is not spent for valid scripts, and any excess over
+    # `total_collateral` comes back in the return collateral output.
+    # Ceiling matches the ledger's rounding (see `validateInsufficientCollateral`
+    # in cardano-ledger and `calcReturnAndTotalCollateral` in cardano-api).
+    # The `collateral_fraction_offset` scales only the script part of the fee, so
+    # tests that use a large offset to inflate collateral for a cheap script don't
+    # multiply the size-based fee estimate as well.
+    min_collateral = math.ceil(
+        (base_fee + fee_redeem * collateral_fraction_offset) * collateral_fraction
+    )
+    # The eventual return collateral txout must itself satisfy the min UTxO value:
+    # (160 + serialized txout size) * `utxoCostPerByte` (see `babbageMinUTxOValue`
+    # in cardano-ledger). An ada-only txout with payment and staking credentials
+    # is 67 bytes, so add the corresponding min UTxO value as a buffer on top of
+    # `min_collateral` to keep the return collateral output above the limit.
+    min_utxo_value = (160 + 67) * protocol_params["utxoCostPerByte"]
+    collateral_amount = max(min_collateral + min_utxo_value, 2_000_000)
 
     return ScriptCost(fee=fee_redeem, collateral=collateral_amount, min_collateral=min_collateral)
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
@@ -64,7 +64,6 @@ class TestNegativeCollateralOutput:
         issuer_addr = payment_addrs[1]
 
         lovelace_amount = 2_000_000
-        collateral_amount = 2_000_000
         token_amount = 5
 
         plutus_v_record = plutus_common.MINTING_PLUTUS[plutus_version]
@@ -73,6 +72,8 @@ class TestNegativeCollateralOutput:
             execution_cost=plutus_v_record.execution_cost,
             protocol_params=cluster.g_query.get_protocol_params(),
         )
+        # The amount of the collateral UTxO created by `_fund_issuer`
+        collateral_amount = minting_cost.collateral
 
         # Step 1: fund the token issuer
 
@@ -122,8 +123,10 @@ class TestNegativeCollateralOutput:
             *mint_txouts,
         ]
 
-        # Limit the amount of collateral that can be used and balance the return collateral txout
-        total_collateral_amount = minting_cost.min_collateral // 2
+        # Limit the amount of collateral that can be used and balance the return collateral
+        # txout. Half of the tx fee is guaranteed to be insufficient, as the ledger requires
+        # collateral to cover `collateralPercentage` (>= 100) of the fee.
+        total_collateral_amount = (minting_cost.fee + mint_raw.FEE_MINT_TXSIZE) // 2
         return_collateral_txouts = [
             clusterlib.TxOut(
                 payment_addr.address, amount=collateral_amount - total_collateral_amount


### PR DESCRIPTION
## Description

Fix collateral computation in `plutus_common.compute_cost()` so it matches
what the ledger actually requires.

### Base collateral on the whole transaction fee

The ledger requires collateral to cover `collateralPercentage` of the **whole**
transaction fee, not just the Plutus script execution cost (see
`validateInsufficientCollateral` in cardano-ledger:
`balance ∗ 100 ≥ txfee ∗ collateralPercent`). The previous computation used
only the script cost, so the computed `min_collateral` underestimated the real
requirement.

Since the exact fee is unknown before the transaction is built, a new
`base_fee` parameter provides a pessimistic estimate of the non-script part of
the fee, defaulting to the fee for a transaction of maximum size
(`txFeeFixed + txFeePerByte * maxTxSize`). Overestimating is harmless:
collateral is not spent for valid scripts, and any excess over the total
collateral comes back in the return collateral output.

Rounding now uses ceiling, matching the ledger (`rationalToCoinViaCeiling` in
`validateInsufficientCollateral` and `calcReturnAndTotalCollateral` in
cardano-api).

The `collateral_fraction_offset` multiplier is applied only to the script part
of the fee, so tests that use a large offset to inflate collateral for a cheap
script (e.g. `test_collaterals` with offset 250 000) don't multiply the
size-based fee estimate as well.

### Derive the collateral buffer from min UTxO value

The return collateral txout must itself satisfy the min UTxO value:
`(160 + serialized txout size) * utxoCostPerByte` (see `babbageMinUTxOValue`
in cardano-ledger). Replace the arbitrary 1M lovelace buffer with the min UTxO
value for a 67-byte ada-only txout (payment + staking credentials) derived
from protocol parameters, so the buffer tracks `utxoCostPerByte` if the
parameter changes.

### Test fix

`test_minting_with_limited_collateral` hardcoded the funded collateral UTxO
amount to 2M lovelace, which only matched the old `compute_cost()` output.
It now uses `minting_cost.collateral`, and the deliberately insufficient
total collateral is derived from the actual transaction fee (half of it)
instead of `min_collateral`, which now includes the pessimistic base fee and
could exceed the required collateral, making the transaction unexpectedly
valid.