### PR TITLE
fix(runner): switch pool3 to old binary during upgrade test

### DIFF
--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -162,7 +162,11 @@ elif [ "$1" = "step2" ]; then
 
   # run the pool3 with the original cardano-node binary
   cp -f "$state_cluster/cardano-node-pool3" "$state_cluster/cardano-node-pool3.orig"
-  sed -i 's/cardano-node run/cardano-node-step1 run/' "$state_cluster/cardano-node-pool3"
+  sed -i 's/^exec cardano-node /exec cardano-node-step1 /' "$state_cluster/cardano-node-pool3"
+  grep -q '^exec cardano-node-step1 ' "$state_cluster/cardano-node-pool3" || {
+    echo "Failed to switch pool3 to the original cardano-node binary" >&2
+    exit 6
+  }
 
   # Restart local cluster nodes with binaries from new cluster-node version.
   # It is necessary to restart supervisord with new environment.
@@ -179,14 +183,22 @@ elif [ "$1" = "step2" ]; then
   # print path to cardano-node binaries
   echo "pool1 node binary:"
   pool1_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool1)"
-  readlink -f "/proc/$pool1_pid/exe"
+  pool1_bin="$(readlink -f "/proc/$pool1_pid/exe")"
+  echo "$pool1_bin"
   echo "pool3 node binary:"
   pool3_pid="$("$state_cluster/supervisorctl_local" pid nodes:pool3)"
-  readlink -f "/proc/$pool3_pid/exe"
+  pool3_bin="$(readlink -f "/proc/$pool3_pid/exe")"
+  echo "$pool3_bin"
 
   # check that nodes are running
   if [ "$pool1_pid" = 0 ] || [ "$pool3_pid" = 0 ]; then
     echo "Failed to start node" >&2
+    exit 6
+  fi
+
+  # check that pool3 is still running the original (base) binary, not the upgraded one
+  if [ "$pool1_bin" = "$pool3_bin" ]; then
+    echo "pool3 is running the same binary as pool1, expected it to stay on the base revision" >&2
     exit 6
   fi
 


### PR DESCRIPTION
## Summary

The real node upgrade test is supposed to keep pool3 on the old
cardano-node binary while the rest of the cluster upgrades, so the
test actually exercises old and new nodes running together. That
part was silently broken.

The script swaps pool3's startup script over to the old binary with
a sed command that looks for the text "cardano-node run". The
cardano-node-pool template builds its arguments in a bash array, so
that exact text does not appear in the file anymore. The sed matched
nothing, did not error, and pool3 kept running the same new binary
as everyone else. The test kept passing the whole time because it
never checked whether the swap actually worked, just whether the
rest of the smoke tests passed.

## Fix

- Corrected the sed to match the actual line, `exec cardano-node "${args[@]}"`.
- Added a check right after the sed that fails the script if the substitution did not take effect.
- Added a check after the step2 restart that fails the script if pool1 and pool3 end up running the same binary.

## Verification

Ran the full upgrade test end to end after the fix (base cardano-node
10.7.1, upgrade to master). Confirmed pool1 resolved to the new
master binary and pool3 resolved to the old 10.7.1 binary, both from
the script's own printed check and independently from the live
process list (`ps aux` showed pool3 running as `cardano-node-step1`,
not `cardano-node`). All three steps passed with zero failures,
including `test_update_cost_models` run for real across the two
different node versions.

## Test plan

- [x] `./ai_run.sh make lint` clean
- [x] Full `runner/node_upgrade.sh` run, all three steps green, pool1/pool3 binaries confirmed different