### PR TITLE
feat(plutus): test return collateral below min UTxO

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -11,6 +11,11 @@ api_829 = blockers.GH(
     fixed_in="10.5.0.0",
     message="Wrong autobalancing when there's no change.",
 )
+api_1261 = blockers.GH(
+    issue=1261,
+    repo="IntersectMBO/cardano-api",
+    message="`transaction build` does not validate min UTxO for the collateral return output.",
+)
 
 cli_49 = blockers.GH(
     issue=49,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
@@ -1,5 +1,6 @@
 """Negative tests for minting with Plutus V2 using `transaction build`."""
 
+import dataclasses
 import logging
 
 import allure
@@ -8,7 +9,9 @@ from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
+from cardano_node_tests.tests import issues
 from cardano_node_tests.tests import plutus_common
+from cardano_node_tests.tests import tx_common
 from cardano_node_tests.tests.tests_plutus_v2 import mint_build
 from cardano_node_tests.utils import helpers
 
@@ -137,3 +140,113 @@ class TestNegativeCollateralOutput:
         exc_value = str(excinfo.value)
         with common.allow_unstable_error_messages():
             assert "IncorrectTotalCollateralField" in exc_value, exc_value
+
+    @allure.link(helpers.get_vcs_link())
+    @pytest.mark.parametrize(
+        "with_total_collateral",
+        (True, False),
+        ids=("with_total_collateral", "without_total_collateral"),
+    )
+    @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
+    def test_minting_with_small_return_collateral(
+        self,
+        cluster: clusterlib.ClusterLib,
+        payment_addrs: list[clusterlib.AddressRecord],
+        with_total_collateral: bool,
+        plutus_version: str,
+    ):
+        """Test minting a token with a Plutus script with return collateral < min UTxO.
+
+        Expect failure.
+        """
+        temp_template = common.get_test_id(cluster)
+        payment_addr = payment_addrs[0]
+        issuer_addr = payment_addrs[1]
+
+        lovelace_amount = 2_000_000
+        token_amount = 5
+        script_fund = 200_000_000
+        collateral_diff = 200
+
+        plutus_v_record = plutus_common.MINTING_PLUTUS[plutus_version]
+
+        minting_cost_orig = plutus_common.compute_cost(
+            execution_cost=plutus_v_record.execution_cost,
+            protocol_params=cluster.g_query.get_protocol_params(),
+            base_fee=50_000,
+        )
+        # Make sure that the return collateral amount (what's left after collateral is taken)
+        # is below min UTxO value.
+        collateral_amount = minting_cost_orig.min_collateral - 100 + tx_common.MIN_UTXO_VALUE[1]
+        minting_cost = dataclasses.replace(minting_cost_orig, collateral=collateral_amount)
+
+        # Step 1: fund the token issuer
+
+        mint_utxos, collateral_utxos, *__ = mint_build._fund_issuer(
+            cluster_obj=cluster,
+            temp_template=temp_template,
+            payment_addr=payment_addr,
+            issuer_addr=issuer_addr,
+            minting_cost=minting_cost,
+            amount=script_fund,
+        )
+
+        # Step 2: mint the "qacoin"
+
+        policyid = cluster.g_transaction.get_policyid(plutus_v_record.script_file)
+        asset_name = f"qacoin{clusterlib.get_rand_str(4)}".encode().hex()
+        token = f"{policyid}.{asset_name}"
+        mint_txouts = [
+            clusterlib.TxOut(address=issuer_addr.address, amount=token_amount, coin=token)
+        ]
+
+        plutus_mint_data = [
+            clusterlib.Mint(
+                txouts=mint_txouts,
+                script_file=plutus_v_record.script_file,
+                collaterals=collateral_utxos,
+                redeemer_cbor_file=plutus_common.REDEEMER_42_CBOR,
+            )
+        ]
+
+        tx_files_step2 = clusterlib.TxFiles(signing_key_files=[issuer_addr.skey_file])
+        txouts_step2 = [
+            clusterlib.TxOut(address=issuer_addr.address, amount=lovelace_amount),
+            *mint_txouts,
+        ]
+
+        # TODO: `transaction build` will fail once
+        # https://github.com/IntersectMBO/cardano-api/issues/1261 is fixed.
+        tx_output_step2 = cluster.g_transaction.build_tx(
+            src_address=payment_addr.address,
+            tx_name=f"{temp_template}_step2",
+            tx_files=tx_files_step2,
+            txins=mint_utxos,
+            txouts=txouts_step2,
+            return_collateral_txouts=[
+                clusterlib.TxOut(payment_addr.address, amount=collateral_diff)
+            ]
+            if with_total_collateral
+            else (),
+            total_collateral_amount=minting_cost.collateral - collateral_diff
+            if with_total_collateral
+            else None,
+            mint=plutus_mint_data,
+        )
+        tx_signed_step2 = cluster.g_transaction.sign_tx(
+            tx_body_file=tx_output_step2.out_file,
+            signing_key_files=tx_files_step2.signing_key_files,
+            tx_name=f"{temp_template}_step2",
+        )
+
+        # It should NOT be possible to mint with return collateral < min UTxO
+        with pytest.raises(clusterlib.CLIError) as excinfo:
+            cluster.g_transaction.submit_tx(tx_file=tx_signed_step2, txins=mint_utxos)
+        exc_value = str(excinfo.value)
+        with common.allow_unstable_error_messages():
+            assert "BabbageOutputTooSmallUTxO" in exc_value, exc_value
+
+        # TODO: move to the `build_tx` check after the issue is fixed
+        issues.api_1261.finish_test()


### PR DESCRIPTION
Add `test_minting_with_small_return_collateral` that checks the ledger rejects a tx whose return collateral output is below the min UTxO value (`BabbageOutputTooSmallUTxO`).

Parametrized with `with_total_collateral`: either the total and return collateral are specified explicitly, or `transaction build` computes the return collateral output automatically.

`transaction build` should already fail when building such tx, but it doesn't validate min UTxO for the collateral return output. The test is expected to xfail until IntersectMBO/cardano-api#1261 is fixed.