### PR TITLE
refactor(plutus): use per-version execution units

### DIFF
--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
@@ -101,8 +101,8 @@ class TestNegativeCollateralOutput:
                 script_file=plutus_v_record.script_file,
                 collaterals=collateral_utxos,
                 execution_units=(
-                    plutus_common.MINTING_COST.per_time,
-                    plutus_common.MINTING_COST.per_space,
+                    plutus_v_record.execution_cost.per_time,
+                    plutus_v_record.execution_cost.per_space,
                 ),
                 redeemer_cbor_file=plutus_common.REDEEMER_42_CBOR,
             )
@@ -207,8 +207,8 @@ class TestNegativeCollateralOutput:
                 script_file=plutus_v_record.script_file,
                 collaterals=collateral_utxos,
                 execution_units=(
-                    plutus_common.MINTING_COST.per_time,
-                    plutus_common.MINTING_COST.per_space,
+                    plutus_v_record.execution_cost.per_time,
+                    plutus_v_record.execution_cost.per_space,
                 ),
                 redeemer_cbor_file=plutus_common.REDEEMER_42_CBOR,
             )


### PR DESCRIPTION
Replace the hardcoded V1 `MINTING_COST` constant with the execution cost of the Plutus script version under test in `Mint` execution units, so V2/V3 runs declare units matching their script.