### PR TITLE
refactor(era): era membership checks via *_FIRST constants and EraName enum

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -17,6 +17,7 @@ from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import pytest_utils
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +28,13 @@ COST_PROPOSAL_FILE = DATA_DIR / "cost_models_list_332_350_v2_v3.json"
 MAX_INT64 = (2**63) - 1
 MAX_UINT64 = (2**64) - 1
 
-COMPAT_ERAS = ("shelley", "allegra", "mary", "alonzo", "babbage")
+COMPAT_ERAS = (
+    EraName.SHELLEY,
+    EraName.ALLEGRA,
+    EraName.MARY,
+    EraName.ALONZO,
+    EraName.BABBAGE,
+)
 
 ADDR_ALPHABET = string.ascii_lowercase + string.digits
 

--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -118,12 +118,12 @@ SKIPIF_WRONG_ERA = pytest.mark.skipif(
 )
 
 SKIPIF_TOKENS_UNUSABLE = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.MARY,
+    VERSIONS.transaction_era < VERSIONS.MARY_FIRST,
     reason="native tokens are available only in Mary+ eras",
 )
 
 _PLUTUS_SKIP_REASON = ""
-if VERSIONS.transaction_era < VERSIONS.ALONZO:
+if VERSIONS.transaction_era < VERSIONS.ALONZO_FIRST:
     _PLUTUS_SKIP_REASON = "Plutus is available only in Alonzo+ eras"
 SKIPIF_PLUTUS_UNUSABLE = pytest.mark.skipif(
     bool(_PLUTUS_SKIP_REASON),
@@ -131,12 +131,12 @@ SKIPIF_PLUTUS_UNUSABLE = pytest.mark.skipif(
 )
 
 SKIPIF_PLUTUSV2_UNUSABLE = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.BABBAGE,
+    VERSIONS.transaction_era < VERSIONS.BABBAGE_FIRST,
     reason="Plutus V2 is available only in Babbage+ eras",
 )
 
 _PLUTUSV3_SKIP_REASON = ""
-if VERSIONS.transaction_era < VERSIONS.CONWAY:
+if VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST:
     _PLUTUSV3_SKIP_REASON = "Plutus V3 is available only in Conway+ eras"
 PLUTUSV3_UNUSABLE = bool(_PLUTUSV3_SKIP_REASON)
 SKIPIF_PLUTUSV3_UNUSABLE = pytest.mark.skipif(
@@ -431,7 +431,7 @@ def match_blocker(func: tp.Callable) -> tp.Any:
 def get_conway_address_deposit(cluster_obj: clusterlib.ClusterLib) -> int:
     """Get stake address deposit amount - is required in Conway+."""
     stake_deposit_amt = -1
-    if VERSIONS.transaction_era >= VERSIONS.CONWAY:
+    if VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST:
         stake_deposit_amt = cluster_obj.g_query.get_address_deposit()
 
     return stake_deposit_amt

--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -315,7 +315,7 @@ class TestRegisterAddr:
                 if VERSIONS.cluster_era in (9, 10, 11):
                     # The ledger issue 4566 will not be fixed in any Conway protocol version
                     issues.ledger_4566.finish_test(force_blocked=True)
-                if VERSIONS.cluster_era >= VERSIONS.DIJKSTRA:
+                if VERSIONS.cluster_era >= VERSIONS.DIJKSTRA_FIRST:
                     issues.ledger_4566.finish_test()
             if build_method == clusterlib_utils.BuildMethods.BUILD_EST and (
                 "The transaction balance is negative" in str_exc
@@ -330,7 +330,7 @@ class TestRegisterAddr:
             if VERSIONS.cluster_era in (9, 10, 11):
                 # The ledger issue 4566 will not be fixed in any Conway protocol version
                 issues.ledger_4566.finish_test(force_blocked=True)
-            if VERSIONS.cluster_era >= VERSIONS.DIJKSTRA:
+            if VERSIONS.cluster_era >= VERSIONS.DIJKSTRA_FIRST:
                 issues.ledger_4566.finish_test()
         assert stake_addr_info, f"Stake address is not registered: {user_registered.stake.address}"
 

--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -17,6 +17,7 @@ from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import submit_api
 from cardano_node_tests.utils import submit_utils
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 
@@ -832,7 +833,7 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
         pool_users_disposable: list[clusterlib.PoolUser],
-        era: str,
+        era: EraName,
     ):
         """Reject legacy stake address registration in Conway.
 

--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -195,7 +195,7 @@ class TestLeadershipSchedule:
             # Xfail if cardano-api GH-269 is still open
             if (
                 VERSIONS.node > version.parse("8.1.2")
-                and VERSIONS.cluster_era >= VERSIONS.BABBAGE
+                and VERSIONS.cluster_era >= VERSIONS.BABBAGE_FIRST
                 and issues.api_269.is_blocked()
             ):
                 issues.api_269.finish_test()

--- a/cardano_node_tests/tests/test_chain_transactions.py
+++ b/cardano_node_tests/tests/test_chain_transactions.py
@@ -152,7 +152,7 @@ class TestTxChaining:
             # Generate signed Txs
             invalid_hereafter = (
                 cluster.g_query.get_slot_no() + 4000
-                if VERSIONS.transaction_era < VERSIONS.ALLEGRA
+                if VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST
                 else None
             )
             generated_txs = []

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -26,6 +26,7 @@ from cardano_node_tests.utils import dbsync_queries
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent / "data"
@@ -390,7 +391,7 @@ class TestAddressInfo:
         addr_info = cluster.g_address.get_address_info(address=address)
 
         assert addr_info.address == address
-        assert addr_info.era == "shelley"
+        assert addr_info.era == EraName.SHELLEY
         assert addr_info.encoding == "bech32"
         assert addr_info.type == "payment"
         if addr_gen == "static":
@@ -425,7 +426,7 @@ class TestAddressInfo:
         addr_info = cluster.g_address.get_address_info(address=address)
 
         assert addr_info.address == address
-        assert addr_info.era == "shelley"
+        assert addr_info.era == EraName.SHELLEY
         assert addr_info.encoding == "bech32"
         assert addr_info.type == "stake"
         if addr_gen == "static":
@@ -471,7 +472,7 @@ class TestAddressInfo:
         addr_info = cluster.g_address.get_address_info(address=address)
 
         assert addr_info.address == address
-        assert addr_info.era == "shelley"
+        assert addr_info.era == EraName.SHELLEY
         assert addr_info.encoding == "bech32"
         assert addr_info.type == "payment"
 

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -17,6 +17,7 @@ from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1330,7 +1331,7 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
         pool_users_disposable: list[clusterlib.PoolUser],
-        era: str,
+        era: EraName,
     ):
         """Reject legacy stake address delegation in Conway.
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -560,7 +560,7 @@ class TestKES:
                 except AssertionError as exc:
                     if (
                         "forked blockchain" in str(exc)
-                        and VERSIONS.transaction_era >= VERSIONS.ALONZO
+                        and VERSIONS.transaction_era >= VERSIONS.ALONZO_FIRST
                     ):
                         pytest.xfail(str(exc))
                     raise
@@ -728,7 +728,7 @@ class TestKES:
                 except AssertionError as exc:
                     if (
                         "forked blockchain" in str(exc)
-                        and VERSIONS.transaction_era >= VERSIONS.ALONZO
+                        and VERSIONS.transaction_era >= VERSIONS.ALONZO_FIRST
                     ):
                         pytest.xfail(str(exc))
                     raise

--- a/cardano_node_tests/tests/test_mir_certs.py
+++ b/cardano_node_tests/tests/test_mir_certs.py
@@ -20,7 +20,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era >= VERSIONS.CONWAY,
+    VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era < Conway",
 )
 

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -1852,7 +1852,7 @@ class TestTransfer:
             # TODO: add ADA txout for change address - see node issue #3057
             txouts.append(clusterlib.TxOut(address=src_address, amount=2_000_000))
 
-            if VERSIONS.transaction_era == VERSIONS.ALONZO:
+            if VERSIONS.transaction_era_name == "alonzo":
                 err_str = ""
                 try:
                     cluster.g_transaction.build_tx(
@@ -2039,7 +2039,7 @@ class TestTransfer:
             txouts.append(clusterlib.TxOut(address=src_address, amount=4_000_000))
 
             # TODO: see node issue #4297
-            if VERSIONS.transaction_era == VERSIONS.ALONZO:
+            if VERSIONS.transaction_era_name == "alonzo":
                 err_str = ""
                 try:
                     cluster.g_transaction.build_tx(
@@ -2641,7 +2641,7 @@ class TestCLITxOutSyntax:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.BABBAGE,
+    VERSIONS.transaction_era < VERSIONS.BABBAGE_FIRST,
     reason="runs only with Babbage+ TX",
 )
 class TestReferenceUTxO:

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -33,6 +33,7 @@ from cardano_node_tests.utils import submit_api
 from cardano_node_tests.utils import submit_utils
 from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1852,7 +1853,7 @@ class TestTransfer:
             # TODO: add ADA txout for change address - see node issue #3057
             txouts.append(clusterlib.TxOut(address=src_address, amount=2_000_000))
 
-            if VERSIONS.transaction_era_name == "alonzo":
+            if VERSIONS.transaction_era_name == EraName.ALONZO:
                 err_str = ""
                 try:
                     cluster.g_transaction.build_tx(
@@ -2039,7 +2040,7 @@ class TestTransfer:
             txouts.append(clusterlib.TxOut(address=src_address, amount=4_000_000))
 
             # TODO: see node issue #4297
-            if VERSIONS.transaction_era_name == "alonzo":
+            if VERSIONS.transaction_era_name == EraName.ALONZO:
                 err_str = ""
                 try:
                     cluster.g_transaction.build_tx(

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -2694,7 +2694,7 @@ class TestNegative:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY, reason="runs only with Tx era >= Conway"
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST, reason="runs only with Tx era >= Conway"
 )
 class TestPoolVoteDeleg:
     """Tests for pool vote delegation to DRep."""

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -36,6 +36,7 @@ from cardano_node_tests.utils import temptools
 from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils import web
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 DATA_DIR = pl.Path(__file__).parent / "data"
 LOGGER = logging.getLogger(__name__)
@@ -2618,7 +2619,7 @@ class TestNegative:
         cluster: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
         testfile_temp_dir: pl.Path,
-        era: str,
+        era: EraName,
         request: FixtureRequest,
     ):
         """Reject legacy stake pool registration in Conway.

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -1078,7 +1078,7 @@ class TestNegative:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+    VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
     reason="runs only with Allegra+ TX",
 )
 class TestTimeLocking:
@@ -1825,7 +1825,7 @@ class TestTimeLocking:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+    VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
     reason="runs only with Allegra+ TX",
 )
 class TestAuxiliaryScripts:
@@ -2086,7 +2086,7 @@ class TestIncrementalSigning:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
@@ -2277,7 +2277,7 @@ class TestIncrementalSigning:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.ALONZO,
+    VERSIONS.transaction_era < VERSIONS.ALONZO_FIRST,
     reason="runs only with Alonzo+ TX",
 )
 class TestDatum:
@@ -2377,7 +2377,7 @@ class TestDatum:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.BABBAGE,
+    VERSIONS.transaction_era < VERSIONS.BABBAGE_FIRST,
     reason="runs only with Babbage+ TX",
 )
 class TestReferenceUTxO:
@@ -2686,7 +2686,7 @@ class TestReferenceUTxO:
 
 
 @pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+    VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
     reason="runs only with Allegra+ TX",
 )
 class TestNested:

--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -386,7 +386,7 @@ class TestRewards:
         )
 
         native_tokens: list[clusterlib_utils.NativeTokenRec] = []
-        if VERSIONS.transaction_era >= VERSIONS.MARY:
+        if VERSIONS.transaction_era >= VERSIONS.MARY_FIRST:
             # Create native tokens UTxOs for pool user
             native_tokens = clusterlib_utils.new_tokens(
                 *[f"couttscoin{token_rand}{i}".encode().hex() for i in range(5)],
@@ -1082,7 +1082,7 @@ class TestRewards:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="needs Allegra+ TX to run",
     )
     @pytest.mark.order(6)

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -1163,7 +1163,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALONZO,
+        VERSIONS.transaction_era < VERSIONS.ALONZO_FIRST,
         reason="doesn't run with TX era < Alonzo",
     )
     @submit_utils.PARAM_SUBMIT_METHOD

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -388,7 +388,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_BUILD_METHOD
@@ -448,7 +448,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_BUILD_METHOD
@@ -509,7 +509,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_BUILD_METHOD
@@ -552,7 +552,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @hypothesis.given(before_value=st.integers(min_value=1, max_value=common.MAX_INT64))
@@ -604,7 +604,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @hypothesis.given(
@@ -659,7 +659,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.ALLEGRA,
+        VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST,
         reason="runs only with Allegra+ TX",
     )
     @hypothesis.given(

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -458,7 +458,7 @@ class TestUnbalanced:
             "--out-file",
             out_file,
         ]
-        if VERSIONS.transaction_era < VERSIONS.ALLEGRA:
+        if VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST:
             build_args.extend(
                 ["--invalid-hereafter", str(cluster.g_transaction.calculate_tx_ttl())]
             )
@@ -585,7 +585,7 @@ class TestUnbalanced:
             "--out-file",
             out_file,
         ]
-        if VERSIONS.transaction_era < VERSIONS.ALLEGRA:
+        if VERSIONS.transaction_era < VERSIONS.ALLEGRA_FIRST:
             build_args.extend(
                 ["--invalid-hereafter", str(cluster.g_transaction.calculate_tx_ttl())]
             )

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -33,7 +33,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -28,7 +28,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_conway.py
+++ b/cardano_node_tests/tests/tests_conway/test_conway.py
@@ -15,6 +15,7 @@ from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import submit_api
 from cardano_node_tests.utils import submit_utils
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
@@ -218,7 +219,7 @@ class TestNegativeLegacyGovernance:
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        era: str,
+        era: EraName,
     ):
         """Reject mixed legacy governance action and Conway vote delegation.
 

--- a/cardano_node_tests/tests/tests_conway/test_conway.py
+++ b/cardano_node_tests/tests/tests_conway/test_conway.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -40,7 +40,7 @@ DATA_DIR = pl.Path(__file__).parent.parent / "data"
 MAINNET_DREP_DEPOSIT = 500_000_000
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -32,7 +32,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -21,7 +21,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_info.py
+++ b/cardano_node_tests/tests/tests_conway/test_info.py
@@ -24,7 +24,7 @@ DATA_DIR = pl.Path(__file__).parent.parent / "data"
 
 pytestmark = [
     pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.CONWAY,
+        VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
         reason="runs only with Tx era >= Conway",
     ),
     pytest.mark.dbsync_config,

--- a/cardano_node_tests/tests/tests_conway/test_no_confidence.py
+++ b/cardano_node_tests/tests/tests_conway/test_no_confidence.py
@@ -24,7 +24,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -23,6 +23,7 @@ from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import submit_api
 from cardano_node_tests.utils import submit_utils
 from cardano_node_tests.utils.versions import VERSIONS
+from cardano_node_tests.utils.versions import EraName
 
 LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
@@ -1497,7 +1498,7 @@ class TestLegacyProposals:
         cluster: clusterlib.ClusterLib,
         payment_addr: clusterlib.AddressRecord,
         submit_method: str,
-        era: str,
+        era: EraName,
     ):
         """Reject legacy update proposal submission in Conway.
 
@@ -1506,11 +1507,11 @@ class TestLegacyProposals:
         * Expect the transaction submission to fail with a TextEnvelope type error.
         """
         era_valid_pparam = {
-            "shelley": ("--max-block-body-size", 65536, "maxBlockBodySize"),
-            "allegra": ("--max-block-body-size", 65536, "maxBlockBodySize"),
-            "mary": ("--max-block-body-size", 65536, "maxBlockBodySize"),
-            "alonzo": ("--max-collateral-inputs", 4, "maxCollateralInputs"),
-            "babbage": ("--max-collateral-inputs", 4, "maxCollateralInputs"),
+            EraName.SHELLEY: ("--max-block-body-size", 65536, "maxBlockBodySize"),
+            EraName.ALLEGRA: ("--max-block-body-size", 65536, "maxBlockBodySize"),
+            EraName.MARY: ("--max-block-body-size", 65536, "maxBlockBodySize"),
+            EraName.ALONZO: ("--max-collateral-inputs", 4, "maxCollateralInputs"),
+            EraName.BABBAGE: ("--max-collateral-inputs", 4, "maxCollateralInputs"),
         }
 
         temp_template = common.get_test_id(cluster)

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
@@ -18,7 +18,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
@@ -23,7 +23,7 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
+++ b/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent.parent / "data"
 
 pytestmark = pytest.mark.skipif(
-    VERSIONS.transaction_era < VERSIONS.CONWAY,
+    VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST,
     reason="runs only with Tx era >= Conway",
 )
 

--- a/cardano_node_tests/tests/tests_plutus/spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/spend_build.py
@@ -118,7 +118,7 @@ def _build_fund_script(
             == token.amount
         ), f"Incorrect token balance for address `{dst_addr.address}`"
 
-    if VERSIONS.transaction_era >= VERSIONS.ALONZO:
+    if VERSIONS.transaction_era >= VERSIONS.ALONZO_FIRST:
         dbsync_utils.check_tx(cluster_obj=cluster_obj, tx_raw_output=tx_output)
 
     return script_utxos, collateral_utxos, tx_output
@@ -296,7 +296,10 @@ def _build_spend_locked_txin(  # noqa: C901
             cluster_obj.g_transaction.submit_tx_bare(tx_file=tx_signed)
         except clusterlib.CLIError as exc:
             str_exc = str(exc)
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY and "(DeserialiseFailure" in str_exc:
+            if (
+                VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
+                and "(DeserialiseFailure" in str_exc
+            ):
                 issues.ledger_4198.finish_test()
             # Check if resubmitting failed because an input UTxO was already spent
             inputs_spent = (

--- a/cardano_node_tests/tests/tests_plutus/spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/spend_raw.py
@@ -115,7 +115,7 @@ def _fund_script(
             == token.amount
         ), f"Incorrect token balance for address `{dst_addr.address}`"
 
-    if VERSIONS.transaction_era >= VERSIONS.ALONZO:
+    if VERSIONS.transaction_era >= VERSIONS.ALONZO_FIRST:
         dbsync_utils.check_tx(cluster_obj=cluster_obj, tx_raw_output=tx_raw_output)
 
     return script_utxos, collateral_utxos, tx_raw_output

--- a/cardano_node_tests/tests/tests_plutus/test_delegation.py
+++ b/cardano_node_tests/tests/tests_plutus/test_delegation.py
@@ -147,7 +147,7 @@ def register_delegate_stake_addr(
     # Register stake address and delegate it to pool
     execution_units = (218855869, 686154)
     raw_fee = 400_000
-    if VERSIONS.transaction_era >= VERSIONS.CONWAY:
+    if VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST:
         execution_units = (240000000, 790000)
         raw_fee = 500_000
 
@@ -798,14 +798,14 @@ class TestDelegateAddr:
             if (
                 build_method == clusterlib_utils.BuildMethods.BUILD
                 and "overspent budget" in str_exc
-                and VERSIONS.transaction_era >= VERSIONS.CONWAY
+                and VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
                 and VERSIONS.cli >= version.parse("10.2.0.0")
             ):
                 issues.cli_1023.finish_test()
             elif (
                 build_method == clusterlib_utils.BuildMethods.BUILD
                 and "overspent budget" in str_exc
-                and VERSIONS.transaction_era >= VERSIONS.CONWAY
+                and VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
             ):
                 issues.cli_650.finish_test()
             raise
@@ -880,7 +880,7 @@ class TestDelegateAddr:
                 )
             except AssertionError as exc:
                 if (
-                    VERSIONS.transaction_era >= VERSIONS.CONWAY
+                    VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
                     and len(tx_db_record.redeemers) == 2
                     and tx_db_record.redeemers[0].unit_steps == tx_db_record.redeemers[1].unit_steps
                     and "space:" in str(exc)

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -936,7 +936,7 @@ class TestBuildMinting:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.BABBAGE,
+        VERSIONS.transaction_era < VERSIONS.BABBAGE_FIRST,
         reason="runs only with Babbage+ TX",
     )
     @pytest.mark.parametrize(
@@ -1186,7 +1186,7 @@ class TestCollateralOutput:
 
         # Check return collateral amount, this is only available on Babbage+ TX
 
-        if VERSIONS.transaction_era >= VERSIONS.BABBAGE:
+        if VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST:
             tx_loaded = tx_view.load_tx_view(cluster_obj=cluster, tx_body_file=tx_body_step2)
 
             return_collateral = tx_loaded["return collateral"]["amount"]["lovelace"]

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -1035,7 +1035,7 @@ class TestMinting:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era < VERSIONS.BABBAGE,
+        VERSIONS.transaction_era < VERSIONS.BABBAGE_FIRST,
         reason="runs only with Babbage+ TX",
     )
     @pytest.mark.parametrize(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
@@ -96,7 +96,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.ALONZO,
+        VERSIONS.transaction_era >= VERSIONS.ALONZO_FIRST,
         reason="runs only with Tx era < Alonzo",
     )
     @pytest.mark.smoke

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -218,7 +218,7 @@ class TestNegativeDatum:
         """
         temp_template = common.get_test_id(cluster)
         amount = 2_000_000
-        in_conway_plus = VERSIONS.transaction_era >= VERSIONS.CONWAY
+        in_conway_plus = VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
 
         payment_addr = payment_addrs[0]
         dst_addr = payment_addrs[1]
@@ -415,7 +415,7 @@ class TestNegativeDatum:
         except clusterlib.CLIError as exc:
             err_str = str(exc)
         else:
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY:
+            if VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST:
                 return
             issues.cli_800.finish_test()
 

--- a/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
@@ -154,7 +154,7 @@ def _build_fund_script(
         assert reference_utxos, "No reference script UTxO"
         reference_utxo = reference_utxos[0]
 
-    if VERSIONS.transaction_era >= VERSIONS.BABBAGE:
+    if VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
         # Check if inline datum is returned by 'query utxo'

--- a/cardano_node_tests/tests/tests_plutus_v2/spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/spend_raw.py
@@ -139,7 +139,7 @@ def _fund_script(
         assert reference_utxos, "No reference script UTxO"
         reference_utxo = reference_utxos[0]
 
-    if VERSIONS.transaction_era >= VERSIONS.BABBAGE:
+    if VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
         # Check if inline datum is returned by 'query utxo'

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -204,7 +204,10 @@ class TestCollateralOutput:
             )
         except clusterlib.CLIError as exc:
             str_exc = str(exc)
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY and "(DeserialiseFailure" in str_exc:
+            if (
+                VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
+                and "(DeserialiseFailure" in str_exc
+            ):
                 issues.ledger_4198.finish_test()
             # Check if resubmitting failed because an input UTxO was already spent
             inputs_spent = (
@@ -352,7 +355,10 @@ class TestCollateralOutput:
             )
         except clusterlib.CLIError as exc:
             str_exc = str(exc)
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY and "(DeserialiseFailure" in str_exc:
+            if (
+                VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
+                and "(DeserialiseFailure" in str_exc
+            ):
                 issues.ledger_4198.finish_test()
             # Check if resubmitting failed because an input UTxO was already spent
             inputs_spent = (

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -165,7 +165,10 @@ class TestCollateralOutput:
             cluster.g_transaction.submit_tx_bare(tx_file=tx_signed_redeem)
         except clusterlib.CLIError as exc:
             str_exc = str(exc)
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY and "(DeserialiseFailure" in str_exc:
+            if (
+                VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
+                and "(DeserialiseFailure" in str_exc
+            ):
                 issues.ledger_4198.finish_test()
             # Check if resubmitting failed because an input UTxO was already spent
             inputs_spent = (
@@ -327,7 +330,10 @@ class TestCollateralOutput:
             cluster.g_transaction.submit_tx_bare(tx_file=tx_signed_redeem)
         except clusterlib.CLIError as exc:
             str_exc = str(exc)
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY and "(DeserialiseFailure" in str_exc:
+            if (
+                VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST
+                and "(DeserialiseFailure" in str_exc
+            ):
                 issues.ledger_4198.finish_test()
             # Check if resubmitting failed because an input UTxO was already spent
             inputs_spent = (

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
@@ -45,7 +45,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke
@@ -92,7 +92,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke
@@ -142,7 +142,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
@@ -44,7 +44,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke
@@ -102,7 +102,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke
@@ -161,7 +161,7 @@ class TestCompatibility:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
-        VERSIONS.transaction_era >= VERSIONS.BABBAGE,
+        VERSIONS.transaction_era >= VERSIONS.BABBAGE_FIRST,
         reason="runs only with Tx era < Babbage",
     )
     @pytest.mark.smoke

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -268,7 +268,7 @@ class TestReadonlyReferenceInputs:
                 txins=[t.txins[0] for t in tx_output_redeem.script_txins if t.txins],
             )
         except clusterlib.CLIError as exc:
-            if VERSIONS.transaction_era < VERSIONS.CONWAY:
+            if VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST:
                 raise
             if "BabbageNonDisjointRefInputs" not in str(exc):
                 raise
@@ -645,7 +645,7 @@ class TestNegativeReadonlyReferenceInputs:
                 change_address=payment_addrs[0].address,
             )
         except clusterlib.CLIError as exc:
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY:
+            if VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST:
                 raise
             if "ReferenceInputsNotSupported" not in str(exc):
                 raise

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
@@ -234,7 +234,7 @@ class TestReadonlyReferenceInputs:
                 script_txins=plutus_txins,
             )
         except clusterlib.CLIError as exc:
-            if VERSIONS.transaction_era < VERSIONS.CONWAY:
+            if VERSIONS.transaction_era < VERSIONS.CONWAY_FIRST:
                 raise
             if "BabbageNonDisjointRefInputs" not in str(exc):
                 raise
@@ -508,7 +508,7 @@ class TestNegativeReadonlyReferenceInputs:
                 script_txins=plutus_txins,
             )
         except clusterlib.CLIError as exc:
-            if VERSIONS.transaction_era >= VERSIONS.CONWAY:
+            if VERSIONS.transaction_era >= VERSIONS.CONWAY_FIRST:
                 raise
             if "ReferenceInputsNotSupported" not in str(exc):
                 raise

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -16,7 +16,12 @@ class Versions:
         ``PROTOCOL_VERSION`` env var, defaulting to ``DEFAULT_CLUSTER_ERA``),
         while ``cluster_era_name`` is the era name that corresponds to that
         protocol version. The era constants below (e.g. ``CONWAY``) are the
-        latest protocol version associated with each era.
+        latest protocol version associated with each era, and the ``*_FIRST``
+        constants (e.g. ``CONWAY_FIRST``) are the first protocol version of
+        each era. Use the ``*_FIRST`` constants for era membership checks
+        (e.g. ``transaction_era >= VERSIONS.CONWAY_FIRST`` for "in Conway era
+        or later"), so the checks keep working for all protocol versions of
+        an era. Both sets of constants must stay consistent with ``MAP``.
     """
 
     # Latest protocol version associated with each era
@@ -28,6 +33,16 @@ class Versions:
     BABBAGE: tp.Final[int] = 8
     CONWAY: tp.Final[int] = 11
     DIJKSTRA: tp.Final[int] = 12
+
+    # First protocol version associated with each era
+    BYRON_FIRST: tp.Final[int] = 0
+    SHELLEY_FIRST: tp.Final[int] = 2
+    ALLEGRA_FIRST: tp.Final[int] = 3
+    MARY_FIRST: tp.Final[int] = 4
+    ALONZO_FIRST: tp.Final[int] = 5
+    BABBAGE_FIRST: tp.Final[int] = 7
+    CONWAY_FIRST: tp.Final[int] = 9
+    DIJKSTRA_FIRST: tp.Final[int] = 12
 
     DEFAULT_CLUSTER_ERA: tp.Final[int] = CONWAY
     DEFAULT_TX_ERA: tp.Final[int] = DEFAULT_CLUSTER_ERA

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -1,11 +1,30 @@
 """Cardano node version, cluster era, transaction era, db-sync version."""
 
+import enum
 import typing as tp
 
 from packaging import version
 
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+
+
+class EraName(enum.StrEnum):
+    """Cardano era names.
+
+    Members compare equal to their lowercase era name strings (e.g.
+    ``EraName.CONWAY == "conway"``), so they can be used anywhere an era
+    name string is expected.
+    """
+
+    BYRON = "byron"
+    SHELLEY = "shelley"
+    ALLEGRA = "allegra"
+    MARY = "mary"
+    ALONZO = "alonzo"
+    BABBAGE = "babbage"
+    CONWAY = "conway"
+    DIJKSTRA = "dijkstra"
 
 
 class Versions:
@@ -48,20 +67,20 @@ class Versions:
     DEFAULT_TX_ERA: tp.Final[int] = DEFAULT_CLUSTER_ERA
 
     # Map protocol versions to era names
-    MAP: tp.ClassVar[dict[int, str]] = {
-        0: "byron",
-        1: "byron",
-        2: "shelley",
-        3: "allegra",
-        4: "mary",
-        5: "alonzo",
-        6: "alonzo",
-        7: "babbage",
-        8: "babbage",
-        9: "conway",
-        10: "conway",
-        11: "conway",
-        12: "dijkstra",
+    MAP: tp.ClassVar[dict[int, EraName]] = {
+        0: EraName.BYRON,
+        1: EraName.BYRON,
+        2: EraName.SHELLEY,
+        3: EraName.ALLEGRA,
+        4: EraName.MARY,
+        5: EraName.ALONZO,
+        6: EraName.ALONZO,
+        7: EraName.BABBAGE,
+        8: EraName.BABBAGE,
+        9: EraName.CONWAY,
+        10: EraName.CONWAY,
+        11: EraName.CONWAY,
+        12: EraName.DIJKSTRA,
     }
 
     def __init__(self) -> None:
@@ -80,7 +99,7 @@ class Versions:
 
         self.transaction_era = protocol_version
         if self.command_era_name and self.command_era_name in self.MAP.values():
-            self.transaction_era_name: str = self.command_era_name
+            self.transaction_era_name: EraName = EraName(self.command_era_name)
             if self.MAP[self.transaction_era] != self.transaction_era_name:
                 self.transaction_era = getattr(self, self.transaction_era_name.upper())
         else:


### PR DESCRIPTION
## Problem

Era constants in `versions.py` (e.g. `VERSIONS.CONWAY`) hold the latest
protocol version of an era. Era membership checks written as
`VERSIONS.transaction_era >= VERSIONS.CONWAY` therefore silently change
meaning whenever an era gains a new protocol version. The recent
PV10 -> PV11 default bump (#3555) made such checks exclude PV10, so a
`PROTOCOL_VERSION=10` run (the "conway 10" CI selection) silently
skipped the whole Conway test suite, PlutusV3 tests and other
era-gated tests. The same trap existed for every multi-PV era (e.g.
Babbage) and would resurface for Dijkstra with a future PV13.

Additionally, era names were compared as bare string literals
(`transaction_era_name == "alonzo"`), with no single source for the
valid names.

## Changes

### `*_FIRST` protocol version constants

- Add `BYRON_FIRST` .. `DIJKSTRA_FIRST` constants holding the first
  protocol version of each era, kept consistent with `Versions.MAP`.
- Migrate all era membership checks (`>=` / `<` against era constants,
  ~70 sites) to the `*_FIRST` variants, e.g.
  `transaction_era >= VERSIONS.CONWAY_FIRST` for "in Conway era or later".
- Checks using `<=` / `>` against the latest-PV constants ("era X or
  earlier" / "after era X") are already correct and left unchanged, as
  are the era ordinal comparisons in `tx_view.py` where both sides use
  the latest-PV convention.

### `EraName` enum

- Add `EraName(enum.StrEnum)` with era name constants. Members compare
  equal to the lowercase era name strings, so they work anywhere an era
  name string is expected (dict keys, f-strings, pytest parametrize IDs).
- Use it for `Versions.MAP` values, `cluster_era_name` /
  `transaction_era_name` (now typed as `EraName`), `COMPAT_ERAS` and
  era name comparisons that previously used string literals.
- Era names used as cardano-cli command groups, genesis directory names
  and db-sync config section keys are intentionally left as string
  literals - they are CLI/filesystem identifiers, not ledger era values.

## Net effect

Runs on any protocol version of an era exercise the full test selection
for that era again (e.g. "conway 10" no longer skips Conway tests), and
future protocol version bumps won't silently flip era membership checks.