### PR TITLE
refactor(cluster): read status from snapshot in scheduler

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -120,6 +120,18 @@ class ClusterGetter:
         self.strict_dead_fraction = 0.51
 
         self._cluster_instance_num = -1
+        self._snapshot: status_db.StatusSnapshot | None = None
+
+    @property
+    def snap(self) -> status_db.StatusSnapshot:
+        """Return the snapshot of status records.
+
+        The snapshot is valid only while the global cluster lock is held and must be
+        refreshed right after the lock is acquired.
+        """
+        if self._snapshot is None:
+            self._snapshot = status_db.StatusSnapshot()
+        return self._snapshot
 
     @property
     def cluster_instance_num(self) -> int:
@@ -347,11 +359,11 @@ class ClusterGetter:
     def _cluster_needs_respin(self, instance_num: int) -> bool:
         """Check if it is necessary to respin cluster."""
         # If cluster instance is not started yet
-        if not status_db.is_cluster_running(instance_num=instance_num):
+        if not self.snap.is_cluster_running(instance_num=instance_num):
             return True
 
         # If it was indicated that the cluster instance needs to be respun
-        if status_db.list_respin_needed(instance_num=instance_num):
+        if self.snap.list_respin_needed(instance_num=instance_num):
             return True
 
         # If a service failed on cluster instance.
@@ -415,11 +427,11 @@ class ClusterGetter:
         test was running for some time.
         """
         # No need to continue if there are no marked tests
-        if not status_db.list_curr_mark(instance_num=cget_status.instance_num):
+        if not self.snap.list_curr_mark(instance_num=cget_status.instance_num):
             return
 
         # Marked tests don't need to be running yet if the cluster is being respun
-        respin_in_progress = status_db.list_respin_progress(instance_num=cget_status.instance_num)
+        respin_in_progress = self.snap.list_respin_progress(instance_num=cget_status.instance_num)
         if respin_in_progress:
             return
 
@@ -429,7 +441,7 @@ class ClusterGetter:
         )
 
         # Update marked tests status
-        marks_in_progress = status_db.get_marks_in_progress(instance_num=cget_status.instance_num)
+        marks_in_progress = self.snap.get_marks_in_progress(instance_num=cget_status.instance_num)
 
         for m in marks_in_progress:
             marked_tests_status[m] = 0
@@ -447,14 +459,14 @@ class ClusterGetter:
 
     def _resolve_resources_availability(self, cget_status: _ClusterGetStatus) -> bool:
         """Resolve availability of required "use" and "lock" resources."""
-        resources_locked = status_db.get_resource_names(
+        resources_locked = self.snap.get_resource_names(
             mode=status_db.MODE_LOCK, instance_num=cget_status.instance_num
         )
 
         # This test wants to lock some resources, check if these are not in use
         res_lockable = []
         if cget_status.lock_resources:
-            resources_used = status_db.get_resource_names(
+            resources_used = self.snap.get_resource_names(
                 mode=status_db.MODE_USE, instance_num=cget_status.instance_num
             )
             unlockable_resources = {*resources_locked, *resources_used}
@@ -498,7 +510,7 @@ class ClusterGetter:
 
     def _is_already_running(self) -> bool:
         """Check if the test is already setup and running."""
-        tests_on_worker = status_db.list_test_running(worker_id=self.worker_id)
+        tests_on_worker = self.snap.list_test_running(worker_id=self.worker_id)
 
         # Test is already running, nothing to set up
         if tests_on_worker and self._cluster_instance_num != -1:
@@ -518,7 +530,7 @@ class ClusterGetter:
                 or cget_status.selected_instance != -1
                 or cget_status.marked_running_my_anywhere
             )
-            and status_db.list_prio_in_progress()
+            and self.snap.list_prio_in_progress()
         ):
             self.log("'prio' test setup in progress, cannot continue")
             return True
@@ -539,7 +551,7 @@ class ClusterGetter:
         if cget_status.respin_here:
             return False
 
-        respin_in_progress = status_db.list_respin_progress(instance_num=cget_status.instance_num)
+        respin_in_progress = self.snap.list_respin_progress(instance_num=cget_status.instance_num)
         return bool(respin_in_progress)
 
     def _marked_select_instance(self, cget_status: _ClusterGetStatus) -> bool:
@@ -579,7 +591,7 @@ class ClusterGetter:
         if total == 0:
             msg = "Number of cluster instances must be greater than 0."
             raise ValueError(msg)
-        dead_count = len(status_db.list_cluster_dead())
+        dead_count = len(self.snap.list_cluster_dead())
         dead_fraction = dead_count / total
 
         if dead_fraction >= max_dead_fraction:
@@ -897,6 +909,11 @@ class ClusterGetter:
 
             # Nothing time consuming can go under this lock as all other workers will need to wait
             with locking.FileLockIfXdist(self.cluster_lock):
+                # Load status records that were modified by other workers while the lock
+                # was not held. All status reads in this iteration are then answered from
+                # the snapshot - it refreshes itself after writes done by this process.
+                self.snap.refresh()
+
                 if self._is_already_running():
                     return self.cluster_instance_num
 
@@ -906,7 +923,7 @@ class ClusterGetter:
 
                 if mark:
                     # Check if tests with my mark are already locked to any cluster instance
-                    cget_status.marked_running_my_anywhere = status_db.list_curr_mark(mark=mark)
+                    cget_status.marked_running_my_anywhere = self.snap.list_curr_mark(mark=mark)
 
                 # A "prio" test has priority in obtaining cluster instance. Check if it is needed
                 # to wait until earlier "prio" test obtains a cluster instance.
@@ -932,7 +949,7 @@ class ClusterGetter:
                     cget_status.instance_dir.mkdir(exist_ok=True)
 
                     # Cleanup cluster instance where attempt to start cluster failed repeatedly
-                    if status_db.is_cluster_dead(instance_num=instance_num):
+                    if self.snap.is_cluster_dead(instance_num=instance_num):
                         self._cleanup_dead_clusters(cget_status)
                         continue
 
@@ -942,12 +959,12 @@ class ClusterGetter:
                         continue
 
                     # Are there tests already running on this cluster instance?
-                    cget_status.started_tests_rows = status_db.list_test_running(
+                    cget_status.started_tests_rows = self.snap.list_test_running(
                         instance_num=instance_num
                     )
 
                     # "marked tests" = group of tests marked with my mark
-                    cget_status.marked_ready_rows = status_db.list_curr_mark(
+                    cget_status.marked_ready_rows = self.snap.list_curr_mark(
                         instance_num=instance_num, mark=mark
                     )
 

--- a/cardano_node_tests/cluster_management/status_db.py
+++ b/cardano_node_tests/cluster_management/status_db.py
@@ -125,6 +125,10 @@ WHERE type != 'gc_last_run';
 _conn: sqlite3.Connection | None = None
 _conn_pid: int = -1
 
+# Incremented on every write done by this process. Used by `StatusSnapshot` to detect
+# that its data is stale.
+_write_generation: int = 0
+
 
 @dataclasses.dataclass(frozen=True)
 class StatusRow:
@@ -224,6 +228,19 @@ def _build_where(
     return where, params
 
 
+def _match_filters(
+    row: sqlite3.Row, instance_num: int | None, worker_id: str, mark: str | None
+) -> bool:
+    """Check if a record matches the common filter arguments (same semantics as SQL)."""
+    if instance_num is not None and row["instance_num"] != instance_num:
+        return False
+    if worker_id != "*" and row["worker_id"] != worker_id:
+        return False
+    if mark == "*":
+        return bool(row["mark"])
+    return mark is None or row["mark"] == mark
+
+
 def _row_to_status(row: sqlite3.Row) -> StatusRow:
     keys = row.keys()
     return StatusRow(
@@ -235,8 +252,15 @@ def _row_to_status(row: sqlite3.Row) -> StatusRow:
     )
 
 
+def _bump_write_generation() -> None:
+    """Record that this process modified the database."""
+    global _write_generation  # noqa: PLW0603
+    _write_generation += 1
+
+
 def _create_flag(ftype: str, instance_num: int, worker_id: str, mark: str = "") -> None:
     """Create (or refresh) a flag record."""
+    _bump_write_generation()
     _get_conn().execute(
         "INSERT OR REPLACE INTO flags (type, instance_num, worker_id, mark, pid, created_at) "
         "VALUES (?, ?, ?, ?, ?, ?)",
@@ -261,6 +285,7 @@ def _rm_flags(
     ftype: str, instance_num: int | None = None, worker_id: str = "*", mark: str | None = None
 ) -> list[StatusRow]:
     """Delete flag records matching the given filters and return the deleted records."""
+    _bump_write_generation()
     where, params = _build_where(instance_num=instance_num, worker_id=worker_id, mark=mark)
     where = f"{where} AND type = ?" if where else " WHERE type = ?"
     rows = _get_conn().execute(f"DELETE FROM flags{where} RETURNING *", [*params, ftype]).fetchall()
@@ -418,6 +443,7 @@ def rm_prio_in_progress(worker_id: str = "*") -> list[StatusRow]:
 
 def create_test_running(instance_num: int, worker_id: str, test_id: str, mark: str = "") -> None:
     """Indicate that a test is running on a pytest worker."""
+    _bump_write_generation()
     _get_conn().execute(
         "INSERT OR REPLACE INTO test_running "
         "(instance_num, worker_id, test_id, mark, pid, created_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -441,6 +467,7 @@ def rm_test_running(
     instance_num: int | None = None, worker_id: str = "*", mark: str | None = None
 ) -> list[StatusRow]:
     """Delete all "test running" records."""
+    _bump_write_generation()
     where, params = _build_where(instance_num=instance_num, worker_id=worker_id, mark=mark)
     rows = _get_conn().execute(f"DELETE FROM test_running{where} RETURNING *", params).fetchall()
     return [_row_to_status(r) for r in rows]
@@ -478,6 +505,7 @@ def create_resources(
         mode: Either `MODE_LOCK` or `MODE_USE`.
         mark: Test mark, empty string for no mark.
     """
+    _bump_write_generation()
     conn = _get_conn()
     pid = os.getpid()
     created_at = time.time()
@@ -508,6 +536,7 @@ def rm_resources(
     mode: str, instance_num: int | None = None, worker_id: str = "*", mark: str | None = None
 ) -> list[StatusRow]:
     """Delete all resource records for the given mode."""
+    _bump_write_generation()
     where, params = _build_where(instance_num=instance_num, worker_id=worker_id, mark=mark)
     where = f"{where} AND mode = ?" if where else " WHERE mode = ?"
     rows = (
@@ -631,6 +660,7 @@ def gc_stale_records(min_interval_sec: float = 0.0) -> list[str]:
 
     removed: list[str] = []
     placeholders = ",".join("?" * len(dead_pids))
+    _bump_write_generation()
     with _transaction(conn):
         removed.extend(
             f"'test running' of dead worker {r['worker_id']} (pid {r['pid']}) "
@@ -684,3 +714,155 @@ def gc_stale_records(min_interval_sec: float = 0.0) -> list[str]:
             )
 
     return removed
+
+
+# Snapshot
+
+
+class StatusSnapshot:
+    """In-memory view of all status records.
+
+    The snapshot is loaded with one query per table and its read accessors mirror the
+    module-level query functions, including the filter argument semantics. Reads from
+    the snapshot are plain list traversals, so e.g. the scheduler can evaluate all
+    cluster instances without doing repeated database queries.
+
+    The snapshot refreshes itself when this process modifies the database (tracked by
+    the module-level write generation counter). Writes done by other processes are NOT
+    visible until `refresh` is called explicitly. Users must therefore hold the global
+    cluster lock while using the snapshot and must call `refresh` right after acquiring
+    the lock.
+    """
+
+    def __init__(self) -> None:
+        self._generation = -1
+        self._flags: list[sqlite3.Row] = []
+        self._test_running: list[sqlite3.Row] = []
+        self._resources: list[sqlite3.Row] = []
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Reload all status records from the database."""
+        conn = _get_conn()
+        self._flags = conn.execute(
+            "SELECT * FROM flags ORDER BY instance_num, worker_id, mark"
+        ).fetchall()
+        self._test_running = conn.execute(
+            "SELECT * FROM test_running ORDER BY instance_num, worker_id"
+        ).fetchall()
+        self._resources = conn.execute(
+            "SELECT * FROM resources ORDER BY instance_num, name, worker_id"
+        ).fetchall()
+        self._generation = _write_generation
+
+    def _maybe_refresh(self) -> None:
+        """Refresh the snapshot if this process modified the database in the meantime."""
+        if self._generation != _write_generation:
+            self.refresh()
+
+    def _list_flags(
+        self,
+        ftype: str,
+        instance_num: int | None = None,
+        worker_id: str = "*",
+        mark: str | None = None,
+    ) -> list[StatusRow]:
+        self._maybe_refresh()
+        return [
+            _row_to_status(r)
+            for r in self._flags
+            if r["type"] == ftype
+            and _match_filters(r, instance_num=instance_num, worker_id=worker_id, mark=mark)
+        ]
+
+    # Cluster instance state
+
+    def is_cluster_running(self, instance_num: int) -> bool:
+        """Check if the cluster instance is running."""
+        return bool(self._list_flags(ftype=CLUSTER_RUNNING, instance_num=instance_num))
+
+    def is_cluster_stopped(self, instance_num: int) -> bool:
+        """Check if the cluster instance is stopped."""
+        return bool(self._list_flags(ftype=CLUSTER_STOPPED, instance_num=instance_num))
+
+    def is_cluster_dead(self, instance_num: int) -> bool:
+        """Check if the cluster instance is in broken state."""
+        return bool(self._list_flags(ftype=CLUSTER_DEAD, instance_num=instance_num))
+
+    def list_cluster_dead(self, instance_num: int | None = None) -> list[StatusRow]:
+        """List all "cluster dead" records."""
+        return self._list_flags(ftype=CLUSTER_DEAD, instance_num=instance_num)
+
+    # Respin flags
+
+    def list_respin_needed(
+        self, instance_num: int | None = None, worker_id: str = "*"
+    ) -> list[StatusRow]:
+        """List all "needs respin" records."""
+        return self._list_flags(ftype=RESPIN_NEEDED, instance_num=instance_num, worker_id=worker_id)
+
+    def list_respin_progress(
+        self, instance_num: int | None = None, worker_id: str = "*"
+    ) -> list[StatusRow]:
+        """List all "respin in progress" records."""
+        return self._list_flags(
+            ftype=RESPIN_IN_PROGRESS, instance_num=instance_num, worker_id=worker_id
+        )
+
+    # Marked tests
+
+    def list_curr_mark(
+        self, instance_num: int | None = None, worker_id: str = "*", mark: str = "*"
+    ) -> list[StatusRow]:
+        """List all "current mark" records."""
+        return self._list_flags(
+            ftype=CURR_MARK, instance_num=instance_num, worker_id=worker_id, mark=mark
+        )
+
+    # Priority tests
+
+    def list_prio_in_progress(self, worker_id: str = "*") -> list[StatusRow]:
+        """List all "priority test in progress" records."""
+        return self._list_flags(ftype=PRIO_IN_PROGRESS, worker_id=worker_id)
+
+    # Running tests
+
+    def list_test_running(
+        self, instance_num: int | None = None, worker_id: str = "*", mark: str | None = None
+    ) -> list[StatusRow]:
+        """List all "test running" records."""
+        self._maybe_refresh()
+        return [
+            _row_to_status(r)
+            for r in self._test_running
+            if _match_filters(r, instance_num=instance_num, worker_id=worker_id, mark=mark)
+        ]
+
+    def get_marks_in_progress(
+        self, instance_num: int | None = None, worker_id: str = "*"
+    ) -> list[str]:
+        """Return list of marks of currently running tests."""
+        return [
+            r.mark
+            for r in self.list_test_running(
+                instance_num=instance_num, worker_id=worker_id, mark="*"
+            )
+        ]
+
+    # Resources
+
+    def get_resource_names(
+        self,
+        mode: str,
+        instance_num: int | None = None,
+        worker_id: str = "*",
+        mark: str | None = None,
+    ) -> list[str]:
+        """Return names of resources that are locked or in use."""
+        self._maybe_refresh()
+        return [
+            r["name"]
+            for r in self._resources
+            if r["mode"] == mode
+            and _match_filters(r, instance_num=instance_num, worker_id=worker_id, mark=mark)
+        ]

--- a/framework_tests/test_status_db.py
+++ b/framework_tests/test_status_db.py
@@ -213,6 +213,88 @@ class TestTestRunning:
 
 
 @pytest.mark.usefixtures("db_dir")
+class TestSnapshot:
+    """Check that `StatusSnapshot` accessors match the module-level query functions."""
+
+    def _populate(self) -> None:
+        _populate_test_running()
+        status_db.create_resources(
+            instance_num=0, worker_id="gw0", names=["pool1"], mode=status_db.MODE_LOCK
+        )
+        status_db.create_resources(
+            instance_num=0, worker_id="gw1", names=["pool2"], mode=status_db.MODE_USE, mark="markA"
+        )
+        status_db.create_curr_mark(instance_num=0, worker_id="gw1", mark="markA")
+        status_db.create_respin_needed(instance_num=1, worker_id="gw2")
+        status_db.create_respin_progress(instance_num=1, worker_id="gw2")
+        status_db.create_prio_in_progress(worker_id="gw0")
+        status_db.set_cluster_running(instance_num=0)
+        status_db.set_cluster_dead(instance_num=1)
+
+    def test_parity(self):
+        """Check that snapshot reads return the same records as the module functions."""
+        self._populate()
+        snap = status_db.StatusSnapshot()
+
+        for mark in (None, "*", "", "markA"):
+            assert snap.list_test_running(mark=mark) == status_db.list_test_running(mark=mark)
+            for mode in (status_db.MODE_LOCK, status_db.MODE_USE):
+                assert snap.get_resource_names(mode=mode, mark=mark) == (
+                    status_db.get_resource_names(mode=mode, mark=mark)
+                )
+        for instance_num in (None, 0, 1, 5):
+            assert snap.list_test_running(instance_num=instance_num) == (
+                status_db.list_test_running(instance_num=instance_num)
+            )
+            assert snap.list_respin_needed(instance_num=instance_num) == (
+                status_db.list_respin_needed(instance_num=instance_num)
+            )
+            assert snap.list_respin_progress(instance_num=instance_num) == (
+                status_db.list_respin_progress(instance_num=instance_num)
+            )
+            assert snap.list_curr_mark(instance_num=instance_num) == (
+                status_db.list_curr_mark(instance_num=instance_num)
+            )
+            assert snap.list_cluster_dead(instance_num=instance_num) == (
+                status_db.list_cluster_dead(instance_num=instance_num)
+            )
+        assert snap.list_test_running(worker_id="gw0") == status_db.list_test_running(
+            worker_id="gw0"
+        )
+        assert snap.list_prio_in_progress() == status_db.list_prio_in_progress()
+        assert snap.get_marks_in_progress() == status_db.get_marks_in_progress()
+        assert snap.is_cluster_running(instance_num=0) == status_db.is_cluster_running(
+            instance_num=0
+        )
+        assert snap.is_cluster_dead(instance_num=1) == status_db.is_cluster_dead(instance_num=1)
+        assert snap.is_cluster_stopped(instance_num=0) == status_db.is_cluster_stopped(
+            instance_num=0
+        )
+
+    def test_auto_refresh_on_own_writes(self):
+        """Check that the snapshot sees writes done by this process."""
+        snap = status_db.StatusSnapshot()
+        assert snap.list_test_running() == []
+
+        status_db.create_test_running(instance_num=0, worker_id="gw0", test_id="test_a")
+        assert len(snap.list_test_running()) == 1
+
+        status_db.rm_test_running(instance_num=0)
+        assert snap.list_test_running() == []
+
+    def test_explicit_refresh(self):
+        """Check that writes not visible via the generation counter appear after refresh."""
+        snap = status_db.StatusSnapshot()
+        # Simulate a write by another process - direct SQL doesn't bump the generation counter
+        status_db._get_conn().execute(
+            "INSERT INTO test_running (instance_num, worker_id, test_id) VALUES (0, 'gw9', 't')"
+        )
+        assert snap.list_test_running() == []
+        snap.refresh()
+        assert len(snap.list_test_running()) == 1
+
+
+@pytest.mark.usefixtures("db_dir")
 def test_overview_view():
     """Check that the `overview` view combines all status records."""
     status_db.create_test_running(instance_num=0, worker_id="gw0", test_id="test_a")


### PR DESCRIPTION
The scheduling loop in `get_cluster_instance` queried the status database repeatedly - several queries per cluster instance in every iteration, all while holding the global cluster lock.

Add `StatusSnapshot` to `status_db` that loads all status records with one query per table. Its read accessors mirror the module-level query functions, including the filter argument semantics, so the scheduler call sites change only from `status_db.*` to `self.snap.*`. Reads from the snapshot are plain list traversals, which shortens the time the global lock is held and makes scheduling decisions testable against an in-memory state.

Writes keep going directly to the database. Every write done by this process bumps a module-level generation counter and the snapshot refreshes itself when its generation is stale, so mid-iteration writes (e.g. mark cleanup) stay visible to subsequent reads, same as with the direct queries. Writes done by other processes cannot happen while the lock is held - the scheduler refreshes the snapshot explicitly right after acquiring the lock.

The `_respin` method intentionally keeps the direct database queries, as it runs outside the global lock.