### PR TITLE
refactor(cluster): wall-clock mark staleness and xdist_group pairing

### DIFF
--- a/agent_docs/resource_management.md
+++ b/agent_docs/resource_management.md
@@ -62,6 +62,11 @@ def cluster_lock_pool_and_pots(
     return cluster_obj, locked_pools_names, used_pool_name
 ```
 
+## Sharing Expensive Setup
+
+To share one expensive setup across multiple test scenarios, use pytest-subtests, or the
+cluster manager `mark` when subtests are not applicable. See `subtests.md`.
+
 ## The `OneOf` Filter
 
 `resources_management.OneOf` selects one available resource from a set:

--- a/agent_docs/subtests.md
+++ b/agent_docs/subtests.md
@@ -1,6 +1,7 @@
 # Using pytest-subtests for Expensive Setup Reuse
 
-Use pytest-subtests to share expensive setup across multiple test scenarios.
+Use pytest-subtests to share expensive setup across multiple test scenarios. When
+subtests are not applicable, use marked tests instead (see the last section).
 
 ## Pattern 1: Method-Based Subtests
 
@@ -85,4 +86,37 @@ class TestGovernanceGuardrails:
         for scenario in get_test_scenarios():
             with subtests.test(scenario=getattr(scenario, "__name__", "")):
                 scenario(cluster_with_constitution)
+```
+
+## When Subtests Are Not Applicable: Marked Tests
+
+Subtests don't work with `hypothesis` property based tests. A group of such tests that
+needs the same expensive setup (e.g. a cluster started with custom scripts) can instead
+pass `mark="<name>"` to `cluster_manager.get()`. All tests with the same mark run on the
+same cluster instance and the setup is done only once.
+
+The mark is considered abandoned and cleaned up when no marked test is running for a while.
+Therefore always combine the cluster manager mark with `@pytest.mark.xdist_group` of the
+same name. The custom xdist scheduler (`pytest_plugins.xdist_scheduler`) schedules tests
+with the same `xdist_group` as one work unit on a single pytest worker, so the marked tests
+run back-to-back and the assigned "marked" cluster instance is reused instead of being
+cleaned up and prepared again.
+
+```python
+@pytest.fixture
+def cluster_mincost(
+    cluster_manager: cluster_management.ClusterManager, pool_cost_start_cluster: pl.Path
+) -> clusterlib.ClusterLib:
+    return cluster_manager.get(
+        mark="minPoolCost",
+        lock_resources=[cluster_management.Resources.CLUSTER],
+        prio=True,
+        cleanup=True,
+        scriptsdir=pool_cost_start_cluster,
+    )
+
+
+@pytest.mark.xdist_group("minPoolCost")
+class TestPoolCost:
+    ...
 ```

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -51,6 +51,21 @@ LOGGER = logging.getLogger(__name__)
 # status database, so the interval applies across all workers.
 GC_INTERVAL_SEC = 60
 
+# How long (seconds) no test with a given mark needs to be running before the mark
+# is considered abandoned and its status records are cleaned up.
+# To keep the gaps between marked tests short, the marked tests should also be marked
+# with `@pytest.mark.xdist_group("<same name>")`. The custom xdist scheduler
+# (`pytest_plugins.xdist_scheduler`) then schedules them as one work unit on a single
+# pytest worker, so they run back-to-back and the assigned "marked" cluster instance
+# is reused instead of being cleaned up and prepared again. Note that when the worker
+# dies mid-group, xdist re-queues the remaining tests and they can run on a different
+# worker with arbitrary tests in between.
+MARK_STALENESS_SEC = 60
+
+# Refresh the "current mark" records only when they are older than this (seconds),
+# so pollers don't write to the database on every scheduler iteration.
+MARK_REFRESH_SEC = 15
+
 if configuration.IS_XDIST:
     _xdist_sleep = time.sleep
 else:
@@ -404,30 +419,22 @@ class ClusterGetter:
         # Remove records of resources that are in-use by the marked tests
         status_db.rm_resources(mode=status_db.MODE_USE, instance_num=instance_num, mark=mark)
 
-    def _get_marked_tests_status(
-        self, marked_tests_cache: dict[int, dict[str, int]], instance_num: int
-    ) -> dict[str, int]:
-        """Return marked tests status for cluster instance."""
-        if instance_num not in marked_tests_cache:
-            marked_tests_cache[instance_num] = {}
-        marked_tests_status = marked_tests_cache[instance_num]
-        return marked_tests_status
-
-    def _update_marked_tests(
-        self,
-        marked_tests_cache: dict[int, dict[str, int]],
-        cget_status: _ClusterGetStatus,
-    ) -> None:
+    def _update_marked_tests(self, cget_status: _ClusterGetStatus) -> None:
         """Update status about running of marked test.
 
         When marked test is finished, we can't clear the mark right away. There might be a test
         with the same mark in the queue and it will be scheduled in a short while. We would need
-        to repeat all the expensive setup if we already cleared the mark. Therefore we need to
-        keep track of marked tests and clear the mark and cluster instance only when no marked
-        test was running for some time.
+        to repeat all the expensive setup if we already cleared the mark. Therefore the "current
+        mark" records are timestamped whenever a marked test is seen running or finishes
+        (see `ClusterManager.on_test_stop`), and the mark and cluster instance are cleared
+        only when no marked test was running for some time.
+
+        Must be called before the current state of the mark is read from the snapshot,
+        as the cleanup deletes the mark's status records.
         """
         # No need to continue if there are no marked tests
-        if not self.snap.list_curr_mark(instance_num=cget_status.instance_num):
+        curr_mark_rows = self.snap.list_curr_mark(instance_num=cget_status.instance_num)
+        if not curr_mark_rows:
             return
 
         # Marked tests don't need to be running yet if the cluster is being respun
@@ -435,27 +442,33 @@ class ClusterGetter:
         if respin_in_progress:
             return
 
-        # Get marked tests status
-        marked_tests_status = self._get_marked_tests_status(
-            marked_tests_cache=marked_tests_cache, instance_num=cget_status.instance_num
+        marks_in_progress = set(
+            self.snap.get_marks_in_progress(instance_num=cget_status.instance_num)
         )
 
-        # Update marked tests status
-        marks_in_progress = self.snap.get_marks_in_progress(instance_num=cget_status.instance_num)
+        # A mark can have one record per worker and the records age together - the newest
+        # one tells when a test with the mark was last seen running.
+        newest_by_mark: dict[str, float] = {}
+        for row in curr_mark_rows:
+            newest_by_mark[row.mark] = max(newest_by_mark.get(row.mark, 0.0), row.created_at)
 
-        for m in marks_in_progress:
-            marked_tests_status[m] = 0
+        now_ts = time.time()
+        for mark, newest in newest_by_mark.items():
+            # Record that a marked test is running now. Skip the write when the records
+            # are still fresh, so polling doesn't do a database write (and a snapshot
+            # reload) on every iteration.
+            if mark in marks_in_progress:
+                if now_ts - newest >= MARK_REFRESH_SEC:
+                    status_db.refresh_curr_mark(instance_num=cget_status.instance_num, mark=mark)
+                continue
 
-        for m in marked_tests_status:
-            marked_tests_status[m] += 1
-
-            # Clean the stale status records if we are waiting too long for the next marked test
-            if marked_tests_status[m] >= 20:
+            # Clean the stale status records if no marked test was running for too long
+            if now_ts - newest >= MARK_STALENESS_SEC:
                 self.log(
-                    f"c{cget_status.instance_num}: no marked tests running for a while, "
-                    "cleaning the mark status record"
+                    f"c{cget_status.instance_num}: no '{mark}' marked tests running "
+                    "for a while, cleaning the mark status record"
                 )
-                self._on_marked_test_stop(instance_num=cget_status.instance_num, mark=m)
+                self._on_marked_test_stop(instance_num=cget_status.instance_num, mark=mark)
 
     def _resolve_resources_availability(self, cget_status: _ClusterGetStatus) -> bool:
         """Resolve availability of required "use" and "lock" resources."""
@@ -806,7 +819,13 @@ class ClusterGetter:
         Args:
             mark: A string marking group of tests. Useful when group of tests need the same
                 expensive setup. The `mark` will make sure the marked tests run on the same
-                cluster instance.
+                cluster instance. Mark the tests also with
+                `@pytest.mark.xdist_group("<same name>")` so they are scheduled together
+                on a single pytest worker - the mark is considered abandoned and cleaned up
+                (see `MARK_STALENESS_SEC`) when no marked test is running for too long.
+                Where applicable, prefer subtests (`pytest_subtests`) over `mark` - a single
+                test with multiple subtests shares one setup with less magic. Subtests
+                however don't work with `hypothesis` property based tests.
             lock_resources: An iterable of resources (names of resources) that will be used
                 exclusively by the test (or marked group of tests). A locked resource cannot be used
                 by other tests.
@@ -870,7 +889,6 @@ class ClusterGetter:
             scriptsdir=scriptsdir,
             current_test=os.environ.get("PYTEST_CURRENT_TEST") or "",
         )
-        marked_tests_cache: dict[int, dict[str, int]] = {}
 
         self.log(f"want to run test '{cget_status.current_test}'")
 
@@ -958,6 +976,11 @@ class ClusterGetter:
                         cget_status.sleep_delay = 5
                         continue
 
+                    # If marked tests are already running, update their status.
+                    # Must be done before the mark state is read below, as stale marks
+                    # get cleaned up here.
+                    self._update_marked_tests(cget_status=cget_status)
+
                     # Are there tests already running on this cluster instance?
                     cget_status.started_tests_rows = self.snap.list_test_running(
                         instance_num=instance_num
@@ -966,11 +989,6 @@ class ClusterGetter:
                     # "marked tests" = group of tests marked with my mark
                     cget_status.marked_ready_rows = self.snap.list_curr_mark(
                         instance_num=instance_num, mark=mark
-                    )
-
-                    # If marked tests are already running, update their status
-                    self._update_marked_tests(
-                        marked_tests_cache=marked_tests_cache, cget_status=cget_status
                     )
 
                     # If there would be more tests running on this cluster instance than allowed,

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -284,10 +284,18 @@ class ClusterManager:
                 mark="",
             )
 
-            # Remove record that indicates that a test is running on the worker
-            status_db.rm_test_running(
+            # Remove record that indicates that a test is running on the worker.
+            # For a marked test, reset the staleness clock of its mark, so the mark
+            # doesn't expire while the next marked test is being scheduled - the clock
+            # is otherwise advanced only by workers that poll the cluster instance
+            # while a marked test is running.
+            for trow in status_db.rm_test_running(
                 instance_num=self.cluster_instance_num, worker_id=self.worker_id
-            )
+            ):
+                if trow.mark:
+                    status_db.refresh_curr_mark(
+                        instance_num=self.cluster_instance_num, mark=trow.mark
+                    )
 
             # Log names of tests that keep running on the cluster instance
             tnames = status_db.get_test_names(instance_num=self.cluster_instance_num)

--- a/cardano_node_tests/cluster_management/status_db.py
+++ b/cardano_node_tests/cluster_management/status_db.py
@@ -143,6 +143,7 @@ class StatusRow:
     mark: str
     test_id: str = ""
     name: str = ""
+    created_at: float = 0.0
 
 
 def get_db_file() -> "os.PathLike[str]":
@@ -249,6 +250,7 @@ def _row_to_status(row: sqlite3.Row) -> StatusRow:
         mark=row["mark"],
         test_id=row["test_id"] if "test_id" in keys else "",
         name=row["name"] if "name" in keys else "",
+        created_at=row["created_at"],
     )
 
 
@@ -418,6 +420,22 @@ def rm_curr_mark(
 ) -> list[StatusRow]:
     """Delete all "current mark" records."""
     return _rm_flags(ftype=CURR_MARK, instance_num=instance_num, worker_id=worker_id, mark=mark)
+
+
+def refresh_curr_mark(instance_num: int, mark: str) -> None:
+    """Update creation time of "current mark" records to the current time.
+
+    Called whenever a test with the given mark is seen running or finishes, so the age
+    of a "current mark" record tells for how long no marked test was running. All the
+    mark's records (one per worker) are refreshed together, as the mark is also cleaned
+    up as a whole.
+    """
+    cur = _get_conn().execute(
+        "UPDATE flags SET created_at = ? WHERE type = ? AND instance_num = ? AND mark = ?",
+        (time.time(), CURR_MARK, instance_num, mark),
+    )
+    if cur.rowcount > 0:
+        _bump_write_generation()
 
 
 # Priority tests

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1900,6 +1900,12 @@ class TestStakePool:
 # It takes long time to setup the cluster instance (when starting from Byron).
 # We mark the tests as "long" and set the highest priority, so the setup is done at the
 # beginning of the testrun, instead of needing to respin a cluster that is already running.
+# Note that the `order` and `long` markers apply only for testnet variants that start
+# from Byron; the cluster manager priority (`prio=True`) applies always.
+# The `xdist_group` matches the `mark` passed to `cluster_manager.get()` - the tests are
+# scheduled together on a single pytest worker, so they run back-to-back and reuse the
+# assigned "marked" cluster instance regardless of the testnet variant.
+@pytest.mark.xdist_group("minPoolCost")
 @common.ORDER5_BYRON
 @common.LONG_BYRON
 class TestPoolCost:

--- a/framework_tests/test_status_db.py
+++ b/framework_tests/test_status_db.py
@@ -144,6 +144,26 @@ class TestFlags:
         status_db.rm_prio_in_progress(worker_id="gw0")
         assert status_db.list_prio_in_progress() == []
 
+    def test_refresh_curr_mark(self):
+        """Check that refreshing "current mark" records updates their creation time.
+
+        All records of the given mark on the given instance are refreshed together,
+        records of other marks and other instances are left alone.
+        """
+        status_db.create_curr_mark(instance_num=0, worker_id="gw0", mark="markA")
+        status_db.create_curr_mark(instance_num=0, worker_id="gw1", mark="markA")
+        status_db.create_curr_mark(instance_num=0, worker_id="gw2", mark="markB")
+        status_db.create_curr_mark(instance_num=1, worker_id="gw3", mark="markA")
+        status_db._get_conn().execute("UPDATE flags SET created_at = 1.0")
+
+        status_db.refresh_curr_mark(instance_num=0, mark="markA")
+
+        refreshed = status_db.list_curr_mark(instance_num=0, mark="markA")
+        assert len(refreshed) == 2
+        assert all(r.created_at > 1.0 for r in refreshed)
+        assert status_db.list_curr_mark(instance_num=0, mark="markB")[0].created_at == 1.0
+        assert status_db.list_curr_mark(instance_num=1, mark="markA")[0].created_at == 1.0
+
     def test_respin_after_mark(self):
         """Check "respin after mark" records."""
         status_db.create_respin_after_mark(instance_num=0, worker_id="gw0", mark="markA")


### PR DESCRIPTION
## Motivation

Follow-up to #3563. An abandoned test mark (a group of marked tests
that stopped running) used to be detected by counting scheduler loop
iterations - a heuristic whose expiry time depended on a single
worker's sleep backoff (roughly 25 seconds to 2 minutes) and where
each newly arriving worker started counting from zero. It also
required a cache dict threaded through `get_cluster_instance`.

## What changed

### Wall-clock mark staleness

The "current mark" records are now timestamped and the mark is cleaned
up when no marked test was running for `MARK_STALENESS_SEC`
(60 seconds) - a deterministic wall-clock rule shared by all workers
that sits inside the old heuristic's expiry range.

The records are refreshed via the new `refresh_curr_mark` from two
places:

- by workers that observe a running marked test while polling the
  cluster instance, and
- in `on_test_stop` whenever a marked test finishes.

The refresh on test stop is essential: pollers are not guaranteed to
observe a long-running marked test (e.g. a hypothesis test running for
minutes while all other workers are busy), and without it the mark
could expire right between two back-to-back marked tests, causing a
respin of the exact setup the mark exists to protect.

A mark can have one record per worker; the records are refreshed
together and the newest one decides staleness for the whole mark, so
the cleanup fires once per mark. Pollers skip the refresh while the
records are younger than `MARK_REFRESH_SEC` (15 seconds), so the
polling hot path under the global cluster lock stays write-free.

The stale-mark cleanup now runs before the scheduler reads the mark
state for the current test. Previously the mark records were read
first and the cleanup could delete them right after, letting a test
act on dangling data - skip resource resolution as a "non-initial"
marked test and run with no resource records at all.

The iteration counters, the cache dict and its threading through the
scheduler are gone. `StatusRow` now exposes the `created_at` column.

### Documentation

How to share expensive setup across multiple tests: prefer
pytest-subtests; for cases where subtests don't work (hypothesis
property based tests) use the cluster manager `mark` paired with
`@pytest.mark.xdist_group` of the same name. The custom xdist
scheduler then schedules the marked tests as one work unit on a single
pytest worker, so they run back-to-back and the assigned "marked"
cluster instance is reused instead of expiring as stale between tests.
Documented in `agent_docs/subtests.md` (with `resource_management.md`
pointing to it) and in the `mark` argument docstring of
`get_cluster_instance`.

### Apply to TestPoolCost

`TestPoolCost` is the only current user of `mark=...`, but nothing
kept its tests scheduled together - the `ORDER5_BYRON` priority
applies only to testnet variants that start from Byron. The class now
carries `@pytest.mark.xdist_group("minPoolCost")`.

## Verification

- New `test_refresh_curr_mark` in `framework_tests/test_status_db.py`;
  all 37 framework tests pass.
- `make lint` clean, each commit tested individually.
- Recommend a full regression run including `TestPoolCost` (its
  scheduling changes with the new xdist group).