### PR TITLE
fix(cluster): remove marked resources together with marks

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -404,14 +404,12 @@ class ClusterGetter:
         """Perform actions after all marked tests are finished."""
         self.log(f"c{instance_num}: in `_on_marked_test_stop`")
 
-        # Set cluster instance to be respun if needed
-        respin_after_mark = status_db.rm_respin_after_mark(instance_num=instance_num, mark=mark)
+        respin_after_mark = self._rm_marks(instance_num=instance_num, mark=mark)
+
+        # Set cluster instance to be respun if it was requested by the marked tests
         if respin_after_mark:
             self.log(f"c{instance_num}: in `_on_marked_test_stop`, creating 'respin needed' record")
             status_db.create_respin_needed(instance_num=instance_num, worker_id=self.worker_id)
-
-        # Remove the rest of the mark's status records
-        self._rm_marks(instance_num=instance_num, mark=mark)
 
     def _update_marked_tests(self, cget_status: _ClusterGetStatus) -> None:
         """Update status about running of marked test.
@@ -636,7 +634,7 @@ class ClusterGetter:
 
         self._check_dead_fraction(max_dead_fraction)
 
-    def _rm_marks(self, instance_num: int, mark: str = "*") -> None:
+    def _rm_marks(self, instance_num: int, mark: str = "*") -> list[status_db.StatusRow]:
         """Remove status records of marks on the cluster instance.
 
         By default, records of all marks on the instance are removed. Pass `mark` to
@@ -648,21 +646,26 @@ class ClusterGetter:
         stay locked or in-use for the rest of the testrun.
 
         The "respin after mark" records are removed without converting them to "needs
-        respin". The `_on_marked_test_stop` caller does the conversion itself beforehand;
-        the other callers respin the cluster instance (or the instance is dead), so the
-        promised respin is either scheduled or moot. Note that when the respinning test
-        belongs to the marked group, the promise is re-created only when the test itself
-        requests cleanup - which holds as long as all tests of a group pass the same
-        arguments, as they are supposed to.
+        respin". The removed records are returned, so `_on_marked_test_stop` can do the
+        conversion itself; the other callers respin the cluster instance (or the
+        instance is dead), so the promised respin is either scheduled or moot. Note that
+        when the respinning test belongs to the marked group, the promise is re-created
+        only when the test itself requests cleanup - which holds as long as all tests of
+        a group pass the same arguments, as they are supposed to.
+
+        Returns:
+            The removed "respin after mark" records.
         """
         if not mark:
             msg = "`mark` must be '*' or a non-empty mark."
             raise ValueError(msg)
 
         status_db.rm_curr_mark(instance_num=instance_num, mark=mark)
-        status_db.rm_respin_after_mark(instance_num=instance_num, mark=mark)
+        respin_after_mark = status_db.rm_respin_after_mark(instance_num=instance_num, mark=mark)
         status_db.rm_resources(mode=status_db.MODE_LOCK, instance_num=instance_num, mark=mark)
         status_db.rm_resources(mode=status_db.MODE_USE, instance_num=instance_num, mark=mark)
+
+        return respin_after_mark
 
     def _cleanup_dead_clusters(self, cget_status: _ClusterGetStatus) -> None:
         """Cleanup if the selected cluster instance failed to start."""

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -410,14 +410,8 @@ class ClusterGetter:
             self.log(f"c{instance_num}: in `_on_marked_test_stop`, creating 'respin needed' record")
             status_db.create_respin_needed(instance_num=instance_num, worker_id=self.worker_id)
 
-        # Remove records that indicate that the mark is ready
-        status_db.rm_curr_mark(instance_num=instance_num, mark=mark)
-
-        # Remove records of resources that are locked by the marked tests
-        status_db.rm_resources(mode=status_db.MODE_LOCK, instance_num=instance_num, mark=mark)
-
-        # Remove records of resources that are in-use by the marked tests
-        status_db.rm_resources(mode=status_db.MODE_USE, instance_num=instance_num, mark=mark)
+        # Remove the rest of the mark's status records
+        self._rm_marks(instance_num=instance_num, mark=mark)
 
     def _update_marked_tests(self, cget_status: _ClusterGetStatus) -> None:
         """Update status about running of marked test.
@@ -577,14 +571,22 @@ class ClusterGetter:
             )
             return True
 
-        if cget_status.marked_running_my_anywhere:
+        if cget_status.marked_running_my_anywhere and not cget_status.respin_here:
             self.log(
                 f"c{cget_status.instance_num}: tests marked with my mark '{cget_status.mark}' "
                 "already running on other cluster instance, cannot start"
             )
             return False
 
-        # If here, this will be the first test with the mark
+        # If here, this will be the first test with the mark.
+        # A worker that is respinning this instance proceeds as the first test even when
+        # the mark is seen on another instance: its own mark records were removed when the
+        # respin was initiated, and another worker of the group (e.g. after the original
+        # worker died and xdist re-queued the remaining tests) could have claimed the mark
+        # elsewhere in the meantime. Waiting for the other instance would stall this worker
+        # forever - it is pinned to this instance by the respin. The mark then exists on
+        # two instances, which the framework already tolerates; it just means the expensive
+        # setup is done twice.
         return True
 
     def _gc_stale_records(self) -> None:
@@ -634,6 +636,34 @@ class ClusterGetter:
 
         self._check_dead_fraction(max_dead_fraction)
 
+    def _rm_marks(self, instance_num: int, mark: str = "*") -> None:
+        """Remove status records of marks on the cluster instance.
+
+        By default, records of all marks on the instance are removed. Pass `mark` to
+        remove records of a single mark.
+
+        The marked resource records must be removed together with the "current mark"
+        records: with the "current mark" records gone, the mark staleness handling
+        cannot see the marks anymore, so any marked resource records left behind would
+        stay locked or in-use for the rest of the testrun.
+
+        The "respin after mark" records are removed without converting them to "needs
+        respin". The `_on_marked_test_stop` caller does the conversion itself beforehand;
+        the other callers respin the cluster instance (or the instance is dead), so the
+        promised respin is either scheduled or moot. Note that when the respinning test
+        belongs to the marked group, the promise is re-created only when the test itself
+        requests cleanup - which holds as long as all tests of a group pass the same
+        arguments, as they are supposed to.
+        """
+        if not mark:
+            msg = "`mark` must be '*' or a non-empty mark."
+            raise ValueError(msg)
+
+        status_db.rm_curr_mark(instance_num=instance_num, mark=mark)
+        status_db.rm_respin_after_mark(instance_num=instance_num, mark=mark)
+        status_db.rm_resources(mode=status_db.MODE_LOCK, instance_num=instance_num, mark=mark)
+        status_db.rm_resources(mode=status_db.MODE_USE, instance_num=instance_num, mark=mark)
+
     def _cleanup_dead_clusters(self, cget_status: _ClusterGetStatus) -> None:
         """Cleanup if the selected cluster instance failed to start."""
         # Move on to other cluster instance
@@ -642,7 +672,7 @@ class ClusterGetter:
         cget_status.respin_ready = False
 
         # Remove status records that are checked by other workers
-        status_db.rm_curr_mark(instance_num=cget_status.instance_num)
+        self._rm_marks(instance_num=cget_status.instance_num)
 
     def _init_respin(self, cget_status: _ClusterGetStatus) -> bool:
         """Initialize respin of this cluster instance on this worker."""
@@ -671,8 +701,24 @@ class ClusterGetter:
             instance_num=cget_status.instance_num, worker_id=self.worker_id
         )
 
-        # Remove mark status records as these will not be valid after respin
-        status_db.rm_curr_mark(instance_num=cget_status.instance_num)
+        # Remove mark status records and marked resource records as these will not be
+        # valid after respin
+        self._rm_marks(instance_num=cget_status.instance_num)
+
+        if cget_status.marked_ready_rows:
+            # This test's own mark was just removed and the group's resource records went
+            # with it. Return back to the retry loop, so that this cluster instance is
+            # re-evaluated and this test resolves its resources again, as the initial
+            # test of the mark.
+            # Record that the instance needs the respin: the re-evaluation happens on a
+            # later iteration, after the global lock was released, and it can be delayed
+            # e.g. by a resource conflict. The durable record keeps the respin scheduled
+            # even when this worker doesn't get to it right away.
+            status_db.create_respin_needed(
+                instance_num=cget_status.instance_num, worker_id=self.worker_id
+            )
+            cget_status.marked_ready_rows = ()
+            return False
 
         return True
 

--- a/cardano_node_tests/cluster_management/status_db.py
+++ b/cardano_node_tests/cluster_management/status_db.py
@@ -659,7 +659,8 @@ def gc_stale_records(min_interval_sec: float = 0.0) -> list[str]:
     * "test running" records - the test is not running anymore.
     * Resource records without mark - the test that held them is gone. Marked resource
       records belong to the whole group of marked tests and are cleaned up by the mark
-      staleness handling.
+      staleness handling, or removed together with the marks when the cluster instance
+      is respun or failed to start.
     * "priority test in progress" flags - would otherwise block all other workers forever.
     * "respin in progress" flags - the cluster instance was left in an unknown state, so
       a "needs respin" flag is created in its place.

--- a/framework_tests/conftest.py
+++ b/framework_tests/conftest.py
@@ -1,7 +1,30 @@
 import os
 import pathlib as pl
+import typing as tp
 
+# The framework imports must come after this env setup - importing the framework modules
+# resolves `CARDANO_NODE_SOCKET_PATH` and looks up binaries on `PATH`
 if not os.environ.get("CARDANO_NODE_SOCKET_PATH"):
     os.environ["CARDANO_NODE_SOCKET_PATH"] = "/nonexistent/state-cluster/relay1.socket"
     mockdir = pl.Path(__file__).parent / "mocks"
     os.environ["PATH"] = f"{mockdir}:{os.environ['PATH']}"
+
+import pytest
+
+from cardano_node_tests.cluster_management import status_db
+from cardano_node_tests.utils import temptools
+
+
+@pytest.fixture
+def db_dir(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> tp.Generator[pl.Path]:
+    """Point the status database to a fresh temp dir and reset the cached connection."""
+    monkeypatch.setattr(temptools.PytestTempDirs, "pytest_root_tmp", tmp_path)
+    status_db._conn = None
+    status_db._conn_pid = -1
+    yield tmp_path
+    # Close the connection created during the test and clear the cached connection object,
+    # so a later `_get_conn()` call cannot reuse a closed connection.
+    if status_db._conn is not None:
+        status_db._conn.close()
+    status_db._conn = None
+    status_db._conn_pid = -1

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -1,0 +1,282 @@
+"""Tests for `cluster_management.cluster_getter`."""
+
+import pytest
+
+from cardano_node_tests.cluster_management import cluster_getter
+from cardano_node_tests.cluster_management import status_db
+
+
+def _get_cluster_getter() -> cluster_getter.ClusterGetter:
+    """Return a `ClusterGetter` instance suitable for unit testing.
+
+    Requires the `db_dir` fixture - the constructor reads the pytest root temp dir.
+    """
+    return cluster_getter.ClusterGetter(
+        worker_id="gw0",
+        pytest_config=None,  # type: ignore[arg-type]
+        num_of_instances=1,
+        log_func=lambda _msg: None,
+    )
+
+
+def _get_cget_status(instance_num: int, mark: str = "") -> cluster_getter._ClusterGetStatus:
+    """Return a `_ClusterGetStatus` instance suitable for unit testing."""
+    return cluster_getter._ClusterGetStatus(
+        mark=mark,
+        lock_resources=[],
+        use_resources=[],
+        prio=False,
+        cleanup=False,
+        scriptsdir="",
+        current_test="test_x",
+        instance_num=instance_num,
+    )
+
+
+def _populate_marked(instance_num: int = 0, mark: str = "markA") -> None:
+    """Create status records of a marked group of tests."""
+    status_db.create_curr_mark(instance_num=instance_num, worker_id="gw0", mark=mark)
+    status_db.create_respin_after_mark(instance_num=instance_num, worker_id="gw0", mark=mark)
+    status_db.create_resources(
+        instance_num=instance_num,
+        worker_id="gw0",
+        names=["pool1"],
+        mode=status_db.MODE_LOCK,
+        mark=mark,
+    )
+    status_db.create_resources(
+        instance_num=instance_num,
+        worker_id="gw0",
+        names=["pool2"],
+        mode=status_db.MODE_USE,
+        mark=mark,
+    )
+    # A marked record left by another worker of the same group
+    status_db.create_resources(
+        instance_num=instance_num,
+        worker_id="gw1",
+        names=["pool5"],
+        mode=status_db.MODE_LOCK,
+        mark=mark,
+    )
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_rm_marks_removes_marked_resources():
+    """Check that removing marks of an instance removes also the marked resource records.
+
+    With the "current mark" records gone, the mark staleness handling cannot see the
+    marks anymore, so marked resource records left behind would stay locked or in-use
+    for the rest of the testrun. Marked records of all workers are removed, unmarked
+    records and records of other instances are left alone.
+    """
+    getter = _get_cluster_getter()
+
+    _populate_marked(instance_num=0, mark="markA")
+    # Unmarked resource records and records of other instances are left alone
+    status_db.create_resources(
+        instance_num=0, worker_id="gw1", names=["pool3"], mode=status_db.MODE_LOCK
+    )
+    status_db.create_resources(
+        instance_num=1, worker_id="gw2", names=["pool4"], mode=status_db.MODE_LOCK, mark="markB"
+    )
+
+    getter._rm_marks(instance_num=0)
+
+    assert status_db.list_curr_mark(instance_num=0) == []
+    assert status_db.list_respin_after_mark(instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == ["pool3"]
+    assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=1) == ["pool4"]
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_rm_marks_single_mark():
+    """Check that removing a single mark leaves records of other marks alone."""
+    getter = _get_cluster_getter()
+
+    _populate_marked(instance_num=0, mark="markA")
+    status_db.create_curr_mark(instance_num=0, worker_id="gw2", mark="markB")
+    status_db.create_respin_after_mark(instance_num=0, worker_id="gw2", mark="markB")
+    status_db.create_resources(
+        instance_num=0, worker_id="gw2", names=["pool6"], mode=status_db.MODE_LOCK, mark="markB"
+    )
+
+    getter._rm_marks(instance_num=0, mark="markA")
+
+    assert status_db.list_curr_mark(instance_num=0, mark="markA") == []
+    assert len(status_db.list_curr_mark(instance_num=0, mark="markB")) == 1
+    assert len(status_db.list_respin_after_mark(instance_num=0, mark="markB")) == 1
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == ["pool6"]
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_rm_marks_rejects_empty_mark():
+    """Check that removing records of an empty mark is rejected.
+
+    An empty mark would match the unmarked resource records held by running tests.
+    """
+    getter = _get_cluster_getter()
+
+    with pytest.raises(ValueError, match="must be"):
+        getter._rm_marks(instance_num=0, mark="")
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_on_marked_test_stop():
+    """Check that finished marked group converts its "respin after mark" record.
+
+    The "respin after mark" record must be converted to "needs respin" before the
+    mark's status records are removed, so the promised post-group respin happens.
+    """
+    getter = _get_cluster_getter()
+    _populate_marked(instance_num=0, mark="markA")
+
+    getter._on_marked_test_stop(instance_num=0, mark="markA")
+
+    assert len(status_db.list_respin_needed(instance_num=0)) == 1
+    assert status_db.list_respin_after_mark(instance_num=0) == []
+    assert status_db.list_curr_mark(instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_on_marked_test_stop_no_respin_promise():
+    """Check that finished marked group without a "respin after mark" doesn't respin."""
+    getter = _get_cluster_getter()
+    _populate_marked(instance_num=0, mark="markA")
+    status_db.rm_respin_after_mark(instance_num=0, mark="markA")
+
+    getter._on_marked_test_stop(instance_num=0, mark="markA")
+
+    assert status_db.list_respin_needed(instance_num=0) == []
+    assert status_db.list_curr_mark(instance_num=0) == []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_cleanup_dead_clusters_removes_marks():
+    """Check that dead cluster instance cleanup removes marks and marked resources."""
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0)
+    cget_status.selected_instance = 0
+    cget_status.respin_here = True
+
+    _populate_marked(instance_num=0, mark="markA")
+
+    getter._cleanup_dead_clusters(cget_status)
+
+    assert cget_status.selected_instance == -1
+    assert cget_status.respin_here is False
+    assert cget_status.respin_ready is False
+    assert status_db.list_curr_mark(instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_init_respin_own_mark():
+    """Check that a marked test that triggers respin re-resolves its resources.
+
+    When a non-initial marked test initiates a respin, the mark status records -
+    including the group's resource records - are removed. The test must then be treated
+    as the initial test of the mark again, so its resources get resolved and created
+    anew. Otherwise the group would keep the cluster instance (the "current mark" record
+    gets re-created) while holding no resource records at all.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0, mark="markA")
+    cget_status.cluster_needs_respin = True
+
+    _populate_marked(instance_num=0, mark="markA")
+    cget_status.marked_ready_rows = status_db.list_curr_mark(instance_num=0, mark="markA")
+    assert cget_status.marked_ready_rows
+
+    # The test cannot continue in this iteration - it must re-evaluate the instance
+    # as the initial test of the mark
+    assert getter._init_respin(cget_status) is False
+
+    assert cget_status.marked_ready_rows == ()
+    assert cget_status.respin_here is True
+    assert cget_status.selected_instance == 0
+    assert len(status_db.list_respin_progress(instance_num=0)) == 1
+    # The respin stays scheduled even when the re-evaluation gets delayed
+    assert len(status_db.list_respin_needed(instance_num=0)) == 1
+    assert status_db.list_curr_mark(instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
+
+    # The re-evaluation re-creates the mark's records; the second `_init_respin` call
+    # must short-circuit on `respin_here` and not wipe them again
+    _populate_marked(instance_num=0, mark="markA")
+    assert getter._init_respin(cget_status) is True
+    assert len(status_db.list_curr_mark(instance_num=0)) == 1
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
+    assert len(status_db.list_respin_progress(instance_num=0)) == 1
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_marked_select_instance_respinner_not_blocked():
+    """Check that a respinning worker is not blocked by its mark on another instance.
+
+    The worker's own mark records were removed when it initiated the respin, so another
+    worker of the group could have claimed the mark on another instance in the meantime.
+    The respinning worker is pinned to its instance and must proceed as the first test
+    of the mark instead of waiting for the other instance forever.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0, mark="markA")
+    status_db.create_curr_mark(instance_num=1, worker_id="gw1", mark="markA")
+    cget_status.marked_running_my_anywhere = status_db.list_curr_mark(mark="markA")
+    assert cget_status.marked_running_my_anywhere
+
+    # Without the pending respin, the mark on the other instance blocks this worker
+    assert getter._marked_select_instance(cget_status) is False
+
+    # The respinning worker proceeds as the first test of the mark
+    cget_status.respin_here = True
+    cget_status.selected_instance = 0  # `respin_here` always comes with the pinned instance
+    assert getter._marked_select_instance(cget_status) is True
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_init_respin_tests_running():
+    """Check that respin is not initiated while tests are running on the instance.
+
+    Nothing can be wiped and no respin state set - the worker must wait for the
+    running tests to finish first.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0, mark="markA")
+    cget_status.cluster_needs_respin = True
+
+    _populate_marked(instance_num=0, mark="markA")
+    status_db.create_test_running(instance_num=0, worker_id="gw1", test_id="test_x")
+    cget_status.started_tests_rows = status_db.list_test_running(instance_num=0)
+
+    assert getter._init_respin(cget_status) is False
+
+    assert cget_status.respin_here is False
+    assert status_db.list_respin_progress(instance_num=0) == []
+    assert len(status_db.list_curr_mark(instance_num=0)) == 1
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_init_respin_foreign_marks():
+    """Check that respin init removes foreign marks and continues.
+
+    When the respinning test doesn't belong to any marked group present on the
+    instance, the marks are removed and the respin continues in the same iteration.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0)
+    cget_status.cluster_needs_respin = True
+
+    _populate_marked(instance_num=0, mark="markA")
+
+    assert getter._init_respin(cget_status) is True
+
+    assert cget_status.respin_here is True
+    assert status_db.list_curr_mark(instance_num=0) == []
+    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -126,8 +126,9 @@ def test_rm_marks_rejects_empty_mark():
 def test_on_marked_test_stop():
     """Check that finished marked group converts its "respin after mark" record.
 
-    The "respin after mark" record must be converted to "needs respin" before the
-    mark's status records are removed, so the promised post-group respin happens.
+    The "respin after mark" record is removed by `_rm_marks` and converted to
+    "needs respin" from its return value, so the promised post-group respin happens
+    even though the mark's status records are already gone.
     """
     getter = _get_cluster_getter()
     _populate_marked(instance_num=0, mark="markA")

--- a/framework_tests/test_status_db.py
+++ b/framework_tests/test_status_db.py
@@ -4,27 +4,11 @@ import multiprocessing
 import os
 import pathlib as pl
 import time
-import typing as tp
 
 import pytest
 
 from cardano_node_tests.cluster_management import status_db
 from cardano_node_tests.utils import temptools
-
-
-@pytest.fixture
-def db_dir(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> tp.Generator[pl.Path]:
-    """Point the status database to a fresh temp dir and reset the cached connection."""
-    monkeypatch.setattr(temptools.PytestTempDirs, "pytest_root_tmp", tmp_path)
-    status_db._conn = None
-    status_db._conn_pid = -1
-    yield tmp_path
-    # Close the connection created during the test and clear the cached connection object,
-    # so a later `_get_conn()` call cannot reuse a closed connection.
-    if status_db._conn is not None:
-        status_db._conn.close()
-    status_db._conn = None
-    status_db._conn_pid = -1
 
 
 def _populate_test_running() -> None:


### PR DESCRIPTION
## Problem

Follow-up to #3566, last finding from the independent review. The
scheduler removes "current mark" records when marks become invalid -
before a cluster respin (`_init_respin`) and when cleaning up a dead
cluster instance (`_cleanup_dead_clusters`). The mark's resource
records were left behind on those paths. With the "current mark"
records gone, the mark staleness handling could not see the marks
anymore, so the leftover resource records were unreachable by every
deletion path: pools locked by a marked group of tests stayed locked
for the rest of the testrun, and tests that wanted them waited out
the whole grace period and failed.

## Fix

New `_rm_marks` helper removes the marked resource records of the
cluster instance together with its "current mark" and "respin after
mark" records; used by both paths above and by `_on_marked_test_stop`
(which converts "respin after mark" to "needs respin" beforehand).
Unmarked resource records (owned by running tests, cleaned by
`on_test_stop`) and other instances are untouched. An empty mark is
rejected - it would match the unmarked records of running tests.

## Scheduler behavior changes

Two behavior changes fell out of the review-fix iterations and are
worth calling out:

- **A non-initial marked test that initiates a respin is re-evaluated
  as the initial test of its mark.** Its own mark records - including
  the group's resource records - are removed by the respin init, so
  the test must resolve its resources anew. Previously it would have
  kept the cluster instance for its group while holding no resource
  records at all, letting e.g. a singleton test lock the instance
  while the marked group is still mid-group. A "needs respin" record
  is created at that point, so the respin stays scheduled even when
  the re-evaluation is delayed by a resource conflict.

- **A worker respinning its instance is not blocked by its mark
  appearing on another instance.** The re-evaluation happens after
  the global lock was released, so another worker of the group (e.g.
  after the original worker died and xdist re-queued the remaining
  tests) can claim the mark elsewhere in that window. The pinned
  respinner now proceeds as the first test of the mark instead of
  waiting forever. The mark can then exist on two instances - a state
  the framework already tolerates; the cost is a duplicated expensive
  setup.

## Verification

- New `framework_tests/test_cluster_getter.py` - first unit tests that
  exercise `ClusterGetter` directly (10 tests): `_rm_marks` semantics
  (all-marks/single-mark scoping, other workers' records, unmarked and
  other-instance records preserved, empty-mark rejection), both
  `_init_respin` paths including the own-mark re-evaluation contract
  and the no-double-wipe short-circuit, the running-tests guard,
  `_on_marked_test_stop` conversion ordering, and the respinner
  bypass in `_marked_select_instance`. The shared `db_dir` fixture
  moved to `framework_tests/conftest.py`.
- All 50 framework tests pass, `make lint` clean.
- Reviewed in a 4-round review-fix loop (code review, test coverage,
  comment accuracy per round) until convergence; the re-evaluation
  path was verified by independent traces of the scheduling loop,
  including cross-worker interleavings.