### PR TITLE
fix(logfiles): track inode to apply seek offset to correct file

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -62,7 +62,10 @@ class TestLeadershipSchedule:
         pool_id = cluster.g_stake_pool.get_stake_pool_id(pool_rec["cold_key_pair"].vkey_file)
 
         pool_log = cluster_nodes.get_cluster_env().state_dir / f"{pool_short_name}.stdout"
-        seek_offset = helpers.get_eof_offset(pool_log)
+        # Single `stat` call, so the offset (file size) and the inode belong to the same file
+        pool_log_stat = pool_log.stat()
+        seek_offset = pool_log_stat.st_size
+        pool_log_inode = pool_log_stat.st_ino
         timestamp = time.time()
 
         if for_epoch == "current":
@@ -114,6 +117,7 @@ class TestLeadershipSchedule:
                 logfile=pool_log,
                 seek_offset=seek_offset,
                 timestamp=timestamp,
+                inode=pool_log_inode,
             )
 
             tip = cluster.g_query.get_tip()

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -4,7 +4,6 @@ import datetime
 import functools
 import hashlib
 import inspect
-import io
 import itertools
 import json
 import logging
@@ -293,14 +292,6 @@ def check_file_arg(file_path: str) -> pl.Path | None:
         msg = f"check_file_arg: file '{file_path}' doesn't exist"
         raise argparse.ArgumentTypeError(msg)
     return abs_path
-
-
-def get_eof_offset(infile: pl.Path) -> int:
-    """Return position of the current end of the file."""
-    with open(infile, "rb") as in_fp:
-        in_fp.seek(0, io.SEEK_END)
-        last_line_pos = in_fp.tell()
-    return last_line_pos
 
 
 def is_in_interval(num1: float, num2: float, *, frac: float = 0.1) -> bool:

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -14,7 +14,6 @@ from collections import deque
 
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import framework_log
-from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
 from cardano_node_tests.utils import temptools
 
@@ -134,12 +133,22 @@ def _retry_search[T](search_func: tp.Callable[[], T]) -> T:
 
 
 def _get_rotated_logs(
-    logfile: pl.Path, *, seek: int = 0, timestamp: float = 0.0
+    logfile: pl.Path, *, seek: int = 0, timestamp: float = 0.0, inode: int | None = None
 ) -> list[RotableLog]:
     """Return list of versions of the log file (list of `RotableLog`).
 
     When the seek offset was recorded for a log file and the log file was rotated,
     the seek offset now belongs to the rotated file and the "live" log file has seek offset 0.
+    Rotation is expected to rename the log file (as supervisord does), so the rotated file
+    keeps its inode.
+
+    When `inode` of the log file the `seek` offset was recorded for is known, the seek offset
+    is applied to the file with the matching inode. If no listed file matches the inode, the
+    seek offset is discarded, as it belongs to a file that was already fully searched (and so
+    it was filtered out by `timestamp`) or that no longer exists.
+
+    When the `inode` is not known, the seek offset is applied to the file with modification
+    time furthest in the past.
     """
     # Get logfile including rotated versions
     logfiles = list(logfile.parent.glob(f"{logfile.name}*"))
@@ -156,8 +165,14 @@ def _get_rotated_logs(
     if not logfile_records:
         return []
 
-    # The `seek` value belongs to the log file with modification time furthest in the past
-    logfile_records[0] = dataclasses.replace(logfile_records[0], seek=seek)
+    if inode is not None:
+        for i, rec in enumerate(logfile_records):
+            if rec.inode == inode:
+                logfile_records[i] = dataclasses.replace(rec, seek=seek)
+                break
+    else:
+        # The `seek` value belongs to the log file with modification time furthest in the past
+        logfile_records[0] = dataclasses.replace(logfile_records[0], seek=seek)
 
     return logfile_records
 
@@ -205,12 +220,68 @@ def _get_offset_file(logfile: pl.Path) -> pl.Path:
     return logfile.parent / f".{logfile.name}.offset"
 
 
-def _read_seek(offset_file: pl.Path) -> int:
+def _read_offset_file(offset_file: pl.Path) -> tuple[int, int | None]:
+    """Return the seek offset and the inode of the log file the offset was recorded for.
+
+    The inode is `None` when the offset file has no inode record or when the inode
+    record is not valid. The seek offset is 0 when the offset file is missing
+    or unreadable.
+    """
     try:
         with open(offset_file, encoding="utf-8") as infile:
-            return int(infile.readline().strip())
+            seek_str = infile.readline().strip()
+            inode_str = infile.readline().strip()
+    except FileNotFoundError:
+        LOGGER.debug("Offset file '%s' does not exist.", offset_file)
+        return 0, None
     except Exception:
-        return 0
+        LOGGER.warning("Cannot read offset file '%s'.", offset_file, exc_info=True)
+        return 0, None
+
+    try:
+        seek = int(seek_str)
+    except ValueError:
+        LOGGER.warning("Invalid seek offset in offset file '%s'.", offset_file)
+        return 0, None
+
+    try:
+        inode = int(inode_str) if inode_str else None
+    except ValueError:
+        # A valid seek offset with an unknown inode degrades to the oldest-file behavior
+        LOGGER.warning("Invalid inode in offset file '%s'.", offset_file)
+        inode = None
+
+    return seek, inode
+
+
+def _write_offset_file(offset_file: pl.Path, *, seek: int, inode: int) -> None:
+    """Store the seek offset and the inode of the log file the offset belongs to.
+
+    Write to a temp file first and rename, so that an interrupted write cannot leave
+    a valid seek offset without its inode record.
+    """
+    tmp_file = offset_file.parent / f"{offset_file.name}.tmp"
+    tmp_file.write_text(f"{seek}\n{inode}\n", encoding="utf-8")
+    tmp_file.replace(offset_file)
+
+
+def _load_search_state(logfile: pl.Path) -> tuple[int, float, int | None]:
+    """Return the seek offset, the timestamp of the last search and the inode.
+
+    The seek offset says where to start searching the log file. The timestamp of the last
+    search is the modification time of the offset file. The inode belongs to the log file
+    the seek offset was recorded for.
+
+    When there is no offset file, the log file was not searched yet and `(0, 0.0, None)`
+    is returned.
+    """
+    offset_file = _get_offset_file(logfile=logfile)
+    if offset_file.exists():
+        seek, inode = _read_offset_file(offset_file=offset_file)
+        timestamp = offset_file.stat().st_mtime
+    else:
+        seek, timestamp, inode = 0, 0.0, None
+    return seek, timestamp, inode
 
 
 def _get_ignore_regex(
@@ -362,6 +433,7 @@ def _search_log_lines(  # noqa: C901
 
     results: list[tuple[pl.Path, str]] = []
     last_offset_bytes = -1
+    last_inode = -1
 
     for rec in rotated_logs:
         path = rec.logfile
@@ -421,10 +493,11 @@ def _search_log_lines(  # noqa: C901
             if path == logfile:
                 cur = fb.tell()
                 last_offset_bytes = cur - len(leftover)
+                last_inode = rec.inode
 
     if last_offset_bytes >= 0:
         offset_file = _get_offset_file(logfile=logfile)
-        offset_file.write_text(str(last_offset_bytes), encoding="utf-8")
+        _write_offset_file(offset_file=offset_file, seek=last_offset_bytes, inode=last_inode)
 
     return results
 
@@ -463,6 +536,7 @@ def find_msgs_in_logs(
     logfile: pl.Path,
     seek_offset: int,
     timestamp: float,
+    inode: int | None = None,
     only_first: bool = False,
     encoding: str = "utf-8",
 ) -> list[str]:
@@ -476,6 +550,7 @@ def find_msgs_in_logs(
         logfile: Path to the primary log file.
         seek_offset: Byte offset to resume from (start of a line or 0).
         timestamp: Timestamp used by `_get_rotated_logs(...)`.
+        inode: Inode of the log file the `seek_offset` was recorded for (optional).
         only_first: If True, return immediately after the first match.
         encoding: Text encoding used to decode matched lines (default: "utf-8").
 
@@ -492,6 +567,7 @@ def find_msgs_in_logs(
             logfile=logfile,
             seek=seek_offset,
             timestamp=timestamp,
+            inode=inode,
         ):
             path = logfile_rec.logfile
             size = path.stat().st_size
@@ -525,7 +601,7 @@ def find_msgs_in_logs(
 
 def check_msgs_presence_in_logs(  # noqa: C901
     regex_pairs: list[tuple[str, str]],
-    seek_offsets: dict[str, int],
+    seek_offsets: tp.Mapping[str, tuple[int, int | None]],
     state_dir: pl.Path,
     timestamp: float,
 ) -> list[str]:
@@ -533,7 +609,7 @@ def check_msgs_presence_in_logs(  # noqa: C901
 
     Args:
         regex_pairs: (glob, regex) pairs.
-        seek_offsets: Mapping of absolute log path (str) -> byte offset.
+        seek_offsets: Mapping of absolute log path (str) -> (byte offset, inode or None).
         state_dir: Root directory for globs.
         timestamp: Passed to `_get_rotated_logs`.
 
@@ -541,11 +617,14 @@ def check_msgs_presence_in_logs(  # noqa: C901
         Error messages for missing entries and for globs that matched no log file.
     """
 
-    def _search(start_seek: int, logfile: str, regex_b: re.Pattern[bytes]) -> bool:
+    def _search(
+        start_seek: int, inode: int | None, logfile: str, regex_b: re.Pattern[bytes]
+    ) -> bool:
         for rec in _get_rotated_logs(
             logfile=pl.Path(logfile),
             seek=start_seek,
             timestamp=timestamp,
+            inode=inode,
         ):
             path = rec.logfile
             size = path.stat().st_size
@@ -589,9 +668,11 @@ def check_msgs_presence_in_logs(  # noqa: C901
             continue
 
         for logfile in matching_files:
-            start_seek = seek_offsets.get(logfile) or 0
+            start_seek, inode = seek_offsets.get(logfile) or (0, None)
             line_found = _retry_search(
-                functools.partial(_search, start_seek=start_seek, logfile=logfile, regex_b=regex_b)
+                functools.partial(
+                    _search, start_seek=start_seek, inode=inode, logfile=logfile, regex_b=regex_b
+                )
             )
             if not line_found:
                 errors.append(f"No line matching `{regex}` found in '{logfile}'.")
@@ -622,7 +703,9 @@ def expect_errors(regex_pairs: list[tuple[str, str]], *, worker_id: str) -> tp.I
     # Flatten the list
     expanded_paths = list(itertools.chain.from_iterable(_expanded_paths))
     # Record each end-of-file as a starting offset for searching the log file
-    seek_offsets = {str(p): helpers.get_eof_offset(p) for p in expanded_paths}
+    # Single `stat` call per file, so the offset (file size) and the inode belong to the
+    # same file even when the file is rotated in between.
+    seek_offsets = {str(p): ((st := p.stat()).st_size, st.st_ino) for p in expanded_paths}
 
     timestamp = time.time()
 
@@ -654,7 +737,9 @@ def expect_messages(regex_pairs: list[tuple[str, str]]) -> tp.Iterator[None]:
     # Flatten the list
     expanded_paths = list(itertools.chain.from_iterable(_expanded_paths))
     # Record each end-of-file as a starting offset for searching the log file
-    seek_offsets = {str(p): helpers.get_eof_offset(p) for p in expanded_paths}
+    # Single `stat` call per file, so the offset (file size) and the inode belong to the
+    # same file even when the file is rotated in between.
+    seek_offsets = {str(p): ((st := p.stat()).st_size, st.st_ino) for p in expanded_paths}
 
     timestamp = time.time()
 
@@ -674,11 +759,13 @@ def search_cluster_logs() -> list[tuple[pl.Path, str]]:
     lock_file = temptools.get_basetemp() / f"search_cluster_{cluster_env.instance_num}.lock"
 
     def _search(
-        logfile: pl.Path, seek: int, timestamp: float, errors_ignored: str
+        logfile: pl.Path, seek: int, timestamp: float, inode: int | None, errors_ignored: str
     ) -> list[tuple[pl.Path, str]]:
         return _search_log_lines(
             logfile=logfile,
-            rotated_logs=_get_rotated_logs(logfile=logfile, seek=seek, timestamp=timestamp),
+            rotated_logs=_get_rotated_logs(
+                logfile=logfile, seek=seek, timestamp=timestamp, inode=inode
+            ),
             errors_re=ERRORS_RE,
             errors_ignored_re=re.compile(errors_ignored),
             look_back_map=ERRORS_LOOK_BACK_MAP,
@@ -687,18 +774,13 @@ def search_cluster_logs() -> list[tuple[pl.Path, str]]:
     with locking.FileLockIfXdist(lock_file):
         errors = []
         for logfile in cluster_env.state_dir.glob("*.std*"):
-            # Skip if the log file is status file or rotated log
-            if logfile.name.endswith(".offset") or ROTATED_RE.match(logfile.name):
+            # Skip if the log file is offset file (or its temp file) or rotated log
+            if logfile.name.endswith((".offset", ".offset.tmp")) or ROTATED_RE.match(logfile.name):
                 continue
 
-            # Get seek offset (from where to start searching) and timestamp of last search
-            offset_file = _get_offset_file(logfile=logfile)
-            if offset_file.exists():
-                seek = _read_seek(offset_file=offset_file)
-                timestamp = offset_file.stat().st_mtime
-            else:
-                seek = 0
-                timestamp = 0.0
+            # Get seek offset (from where to start searching), timestamp of last search
+            # and inode of the log file the seek offset was recorded for
+            seek, timestamp, inode = _load_search_state(logfile=logfile)
 
             # Get ignore rules for the log file
             ignore_rules = _get_ignore_rules(
@@ -716,6 +798,7 @@ def search_cluster_logs() -> list[tuple[pl.Path, str]]:
                         logfile=logfile,
                         seek=seek,
                         timestamp=timestamp,
+                        inode=inode,
                         errors_ignored=errors_ignored,
                     )
                 )
@@ -730,19 +813,16 @@ def search_framework_log() -> list[tuple[pl.Path, str]]:
     # Each worker is checking only its own log file.
     logfile = framework_log.get_framework_log_path()
 
-    # Get seek offset (from where to start searching) and timestamp of last search
-    offset_file = _get_offset_file(logfile=logfile)
-    if offset_file.exists():
-        seek = _read_seek(offset_file=offset_file)
-        timestamp = offset_file.stat().st_mtime
-    else:
-        seek = 0
-        timestamp = 0.0
+    # Get seek offset (from where to start searching), timestamp of last search
+    # and inode of the log file the seek offset was recorded for
+    seek, timestamp, inode = _load_search_state(logfile=logfile)
 
     def _search() -> list[tuple[pl.Path, str]]:
         return _search_log_lines(
             logfile=logfile,
-            rotated_logs=_get_rotated_logs(logfile=logfile, seek=seek, timestamp=timestamp),
+            rotated_logs=_get_rotated_logs(
+                logfile=logfile, seek=seek, timestamp=timestamp, inode=inode
+            ),
             errors_re=ERRORS_RE,
         )
 
@@ -760,19 +840,16 @@ def search_supervisord_logs() -> list[tuple[pl.Path, str]]:
     with locking.FileLockIfXdist(lock_file):
         logfile = cluster_env.state_dir / "supervisord.log"
 
-        # Get seek offset (from where to start searching) and timestamp of last search
-        offset_file = _get_offset_file(logfile=logfile)
-        if offset_file.exists():
-            seek = _read_seek(offset_file=offset_file)
-            timestamp = offset_file.stat().st_mtime
-        else:
-            seek = 0
-            timestamp = 0.0
+        # Get seek offset (from where to start searching), timestamp of last search
+        # and inode of the log file the seek offset was recorded for
+        seek, timestamp, inode = _load_search_state(logfile=logfile)
 
         def _search() -> list[tuple[pl.Path, str]]:
             return _search_log_lines(
                 logfile=logfile,
-                rotated_logs=_get_rotated_logs(logfile=logfile, seek=seek, timestamp=timestamp),
+                rotated_logs=_get_rotated_logs(
+                    logfile=logfile, seek=seek, timestamp=timestamp, inode=inode
+                ),
                 errors_re=SUPERVISORD_ERRORS_RE,
             )
 

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -176,7 +176,7 @@ def test_check_msgs_present(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -189,7 +189,7 @@ def test_check_msgs_missing(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -203,7 +203,7 @@ def test_check_msgs_no_files_matched(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stderr", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -223,7 +223,7 @@ def test_check_msgs_dotted_dir_in_path(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=state_dir,
         timestamp=0.0,
     )
@@ -243,7 +243,10 @@ def test_check_msgs_rotated_file_skipped(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout*", "expected msg")],
-        seek_offsets={str(logfile): 0, str(rotated): 0},
+        seek_offsets={
+            str(logfile): (0, logfile.stat().st_ino),
+            str(rotated): (0, rotated.stat().st_ino),
+        },
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -260,7 +263,7 @@ def test_check_msgs_only_rotated_matched(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout*", "expected msg")],
-        seek_offsets={str(rotated): 0},
+        seek_offsets={str(rotated): (0, rotated.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -278,7 +281,7 @@ def test_check_msgs_dotted_file_name(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -299,7 +302,7 @@ def test_check_msgs_found_in_rotated(tmp_path: pl.Path):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): 0},
+        seek_offsets={str(logfile): (0, logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -318,7 +321,7 @@ def test_check_msgs_seek_offset(tmp_path: pl.Path, msg_before_offset: bool):
 
     errors = logfiles.check_msgs_presence_in_logs(
         regex_pairs=[("*.stdout", "expected msg")],
-        seek_offsets={str(logfile): len(first_line)},
+        seek_offsets={str(logfile): (len(first_line), logfile.stat().st_ino)},
         state_dir=tmp_path,
         timestamp=0.0,
     )
@@ -327,3 +330,192 @@ def test_check_msgs_seek_offset(tmp_path: pl.Path, msg_before_offset: bool):
         assert "No line matching" in errors[0]
     else:
         assert errors == []
+
+
+def test_offset_file_roundtrip(tmp_path: pl.Path):
+    """Check that the seek offset and inode survive the offset file round trip."""
+    offset_file = tmp_path / ".node1.stdout.offset"
+    logfiles._write_offset_file(offset_file=offset_file, seek=1234, inode=56)
+
+    assert logfiles._read_offset_file(offset_file=offset_file) == (1234, 56)
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    (
+        pytest.param("1234\n", (1234, None), id="missing_inode"),
+        pytest.param("garbage\n", (0, None), id="garbage"),
+        pytest.param("123\nabc\n", (123, None), id="corrupt_inode"),
+        pytest.param(None, (0, None), id="missing_file"),
+    ),
+)
+def test_read_offset_file_fallback(
+    tmp_path: pl.Path, content: str | None, expected: tuple[int, int | None]
+):
+    """Check reading of an incomplete or invalid or missing offset file."""
+    offset_file = tmp_path / ".node1.stdout.offset"
+    if content is not None:
+        offset_file.write_text(content, encoding="utf-8")
+
+    assert logfiles._read_offset_file(offset_file=offset_file) == expected
+
+
+def test_rotated_logs_seek_by_inode(tmp_path: pl.Path):
+    """Check that the seek offset is applied to the file with the matching inode."""
+    rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
+    live_mtime = logfile.stat().st_mtime
+    os.utime(rotated, (live_mtime - 10, live_mtime - 10))
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=5, timestamp=0.0, inode=rotated.stat().st_ino
+    )
+    assert [(r.logfile, r.seek) for r in records] == [(rotated, 5), (logfile, 0)]
+
+
+def test_rotated_logs_seek_dropped(tmp_path: pl.Path):
+    """Check that the seek offset is dropped when its file was already fully searched.
+
+    When the file the seek offset was recorded for was not modified since the last search,
+    it is filtered out by the timestamp check. The seek offset must not be applied to
+    another file, as that would skip unsearched content.
+    """
+    rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
+    live_mtime = logfile.stat().st_mtime
+    os.utime(rotated, (live_mtime - 10, live_mtime - 10))
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=5, timestamp=live_mtime - 5, inode=rotated.stat().st_ino
+    )
+    assert [(r.logfile, r.seek) for r in records] == [(logfile, 0)]
+
+
+def test_rotated_logs_seek_without_inode(tmp_path: pl.Path):
+    """Check that without a known inode the seek offset is applied to the oldest file."""
+    rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
+    live_mtime = logfile.stat().st_mtime
+    os.utime(rotated, (live_mtime - 10, live_mtime - 10))
+
+    records = logfiles._get_rotated_logs(logfile=logfile, seek=5, timestamp=0.0, inode=None)
+    assert [(r.logfile, r.seek) for r in records] == [(rotated, 5), (logfile, 0)]
+
+
+def _search_cluster_like(logfile: pl.Path) -> list[tuple[pl.Path, str]]:
+    """Search the log file for errors the same way `search_cluster_logs` does."""
+    seek, timestamp, inode = logfiles._load_search_state(logfile=logfile)
+    return logfiles._search_log_lines(
+        logfile=logfile,
+        rotated_logs=logfiles._get_rotated_logs(
+            logfile=logfile, seek=seek, timestamp=timestamp, inode=inode
+        ),
+        errors_re=logfiles.ERRORS_RE,
+    )
+
+
+def test_search_log_lines_offset_persistence(tmp_path: pl.Path):
+    """Check that repeated searches report each error only once."""
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\nerror one\n")
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error one"]
+
+    # Second search must start where the first search ended
+    errors = _search_cluster_like(logfile=logfile)
+    assert errors == []
+
+    with open(logfile, "a", encoding="utf-8") as outfile:
+        outfile.write("error two\n")
+    # Make sure the log file modification time is newer than the recorded search time
+    # even on filesystems with coarse timestamps.
+    offset_mtime = logfiles._get_offset_file(logfile=logfile).stat().st_mtime
+    os.utime(logfile, (offset_mtime + 10, offset_mtime + 10))
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error two"]
+
+
+def test_search_log_lines_after_rotation(tmp_path: pl.Path):
+    """Check that errors at the beginning of a fresh log file are found after rotation.
+
+    After the log file was searched and then rotated without further writes, the recorded
+    seek offset belongs to the rotated file. The offset must not be applied to the fresh
+    live log file, so errors at its beginning are reported.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\nerror one\n")
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error one"]
+
+    # Rotate: rename the searched file and let its mtime predate the last search
+    rotated = tmp_path / "node1.stdout.1"
+    logfile.rename(rotated)
+    offset_mtime = logfiles._get_offset_file(logfile=logfile).stat().st_mtime
+    os.utime(rotated, (offset_mtime - 10, offset_mtime - 10))
+
+    # The fresh live log file has an error at its beginning and is larger than the
+    # recorded seek offset, so a misapplied offset would skip the error.
+    _write_log(state_dir=tmp_path, name="node1.stdout", content="error two\n" + "padding\n" * 5)
+    # Make sure the log file modification time is newer than the recorded search time
+    # even on filesystems with coarse timestamps.
+    os.utime(logfile, (offset_mtime + 10, offset_mtime + 10))
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error two"]
+
+
+def test_rotated_logs_seek_on_live(tmp_path: pl.Path):
+    """Check that the seek offset is applied to the live file when its inode matches.
+
+    The live log file is not the oldest file in the list, so this checks that the inode
+    matching is not limited to the oldest file.
+    """
+    rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
+    live_mtime = logfile.stat().st_mtime
+    os.utime(rotated, (live_mtime - 10, live_mtime - 10))
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=5, timestamp=0.0, inode=logfile.stat().st_ino
+    )
+    assert [(r.logfile, r.seek) for r in records] == [(rotated, 0), (logfile, 5)]
+
+
+def test_search_log_lines_rotation_with_new_content(tmp_path: pl.Path):
+    """Check the search through a rotated file with unsearched content and a fresh live file.
+
+    Content that was appended to the log file after the last search and then rotated away
+    is searched (starting at the recorded seek offset), together with the whole fresh live
+    log file. Already searched content is not reported again. The new search state is
+    recorded for the live log file.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\nerror one\n")
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error one"]
+
+    # Append new content and rotate. The renamed file keeps its inode and modification time.
+    with open(logfile, "a", encoding="utf-8") as outfile:
+        outfile.write("error two\n")
+    rotated = tmp_path / "node1.stdout.1"
+    logfile.rename(rotated)
+    live_content = "error three\n"
+    _write_log(state_dir=tmp_path, name="node1.stdout", content=live_content)
+
+    # Make sure the log file modification times are newer than the recorded search time
+    # even on filesystems with coarse timestamps, and that the rotated file is older
+    # than the live file.
+    offset_mtime = logfiles._get_offset_file(logfile=logfile).stat().st_mtime
+    os.utime(rotated, (offset_mtime + 5, offset_mtime + 5))
+    os.utime(logfile, (offset_mtime + 10, offset_mtime + 10))
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error two", "error three"]
+
+    # The new search state belongs to the live log file
+    offset_file = logfiles._get_offset_file(logfile=logfile)
+    assert logfiles._read_offset_file(offset_file=offset_file) == (
+        len(live_content),
+        logfile.stat().st_ino,
+    )


### PR DESCRIPTION
## Problem

The log search records a seek offset so that each search continues where the
previous one ended. The offset was applied to the oldest known version of the
log file (by modification time). When the file the offset was recorded for was
rotated and not modified since the last search, the timestamp filter dropped it
from the list and the offset was applied to a different file - typically the
fresh live log file. The beginning of that file was then silently skipped, so
errors in it were never reported.

## Fix

Track the inode of the log file the seek offset belongs to:

* The offset file stores the inode on a second line and is written atomically
  (temp file + rename). An offset file without a valid inode record degrades to
  the old oldest-file behavior.
* `_get_rotated_logs` applies the seek offset to the file with the matching
  inode. When no listed file matches, the offset is discarded (the file was
  already fully searched or no longer exists) instead of being applied to the
  wrong file.
* `expect_errors` / `expect_messages` and `find_msgs_in_logs` pass the inode
  captured together with the end-of-file offset. Both come from a single `stat`
  call, so the pair is consistent even when rotation happens in between.
* Rotation is expected to rename the log file (as supervisord does), so the
  rotated file keeps its inode.

## Tests

New unit tests in `framework_tests/test_logfiles.py` (13 new, 37 total):

* Offset file round trip, missing/garbage/partially valid content fallbacks.
* Inode-based seek assignment: match on rotated file, match on live file,
  discard when the matching file was filtered out, oldest-file fallback
  without inode.
* End-to-end searches: repeated searches report each error once, errors at
  the beginning of a fresh log file are found after rotation, rotated file
  with unsearched content is searched from the recorded offset while the
  fresh live file is searched from the beginning.

The regression tests fail when the inode logic is reverted (mutation checked).

`get_eof_offset` in `helpers.py` lost its last consumer and is removed in a
follow-up commit.