### PR TITLE
fix(logfiles): don't lose log lines appended during search

### DIFF
--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -145,22 +145,33 @@ def _get_rotated_logs(
 
     When `inode` of the log file the `seek` offset was recorded for is known, the seek offset
     is applied to the file with the matching inode. If no listed file matches the inode, the
-    seek offset is discarded, as it belongs to a file that was already fully searched (and so
-    it was filtered out by `timestamp`) or that no longer exists.
+    seek offset is discarded, as it belongs to a file that no longer exists.
 
     When the `inode` is not known, the seek offset is applied to the file with modification
     time furthest in the past.
+
+    The live log file and the file the seek offset was recorded for are always included,
+    even when their modification time is not newer than `timestamp`. Their already searched
+    content is excluded by the seek offset, so this cannot report anything twice, and it
+    protects against filesystems with coarse timestamps, where a line appended shortly
+    after the search start can get a modification time that is not newer than the recorded
+    search start time.
     """
     # Get logfile including rotated versions
     logfiles = list(logfile.parent.glob(f"{logfile.name}*"))
 
     # Get list of logfiles modified after `timestamp`, sorted by their last modification time
-    # from oldest to newest.
+    # from oldest to newest. The live log file and the file matching `inode` are always
+    # included (see the docstring).
     _logfile_records = [
         RotableLog(logfile=f, seek=0, timestamp=(st := f.stat()).st_mtime, inode=st.st_ino)
         for f in logfiles
     ]
-    _logfile_records = [r for r in _logfile_records if r.timestamp > timestamp]
+    _logfile_records = [
+        r
+        for r in _logfile_records
+        if r.timestamp > timestamp or r.logfile == logfile or r.inode == inode
+    ]
     logfile_records = sorted(_logfile_records, key=lambda r: r.timestamp)
 
     if not logfile_records:

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -5,6 +5,7 @@ import functools
 import io
 import itertools
 import logging
+import math
 import os
 import pathlib as pl
 import re
@@ -206,8 +207,9 @@ def _get_ignore_rules(
                     # Split on the first two separators only, so the regex itself may contain ";;"
                     files_glob, skip_after_str, regex = line.split(";;", maxsplit=2)
                     skip_after = float(skip_after_str)
-                    # Skip the rule if it is expired. The `timestamp` is the time of the last log
-                    # search, so the expire time is compared to the time of the last log check.
+                    # Skip the rule if it is expired. The `timestamp` is the start time of the
+                    # last log search, so the expire time is compared to the time when the log
+                    # file was last checked.
                     if 0 < skip_after < timestamp:
                         continue
                     rules.append((files_glob, regex.rstrip("\n")))
@@ -220,29 +222,33 @@ def _get_offset_file(logfile: pl.Path) -> pl.Path:
     return logfile.parent / f".{logfile.name}.offset"
 
 
-def _read_offset_file(offset_file: pl.Path) -> tuple[int, int | None]:
-    """Return the seek offset and the inode of the log file the offset was recorded for.
+def _read_offset_file(offset_file: pl.Path) -> tuple[int, int | None, float | None]:
+    """Return the seek offset, the inode and the timestamp of the last search.
 
-    The inode is `None` when the offset file has no inode record or when the inode
-    record is not valid. The seek offset is 0 when the offset file is missing
+    The inode belongs to the log file the seek offset was recorded for. The timestamp
+    is the time when the last search started reading the log files.
+
+    The inode (or the timestamp) is `None` when the offset file has no such record or
+    when the record is not valid. The seek offset is 0 when the offset file is missing
     or unreadable.
     """
     try:
         with open(offset_file, encoding="utf-8") as infile:
             seek_str = infile.readline().strip()
             inode_str = infile.readline().strip()
+            timestamp_str = infile.readline().strip()
     except FileNotFoundError:
         LOGGER.debug("Offset file '%s' does not exist.", offset_file)
-        return 0, None
+        return 0, None, None
     except Exception:
         LOGGER.warning("Cannot read offset file '%s'.", offset_file, exc_info=True)
-        return 0, None
+        return 0, None, None
 
     try:
         seek = int(seek_str)
     except ValueError:
         LOGGER.warning("Invalid seek offset in offset file '%s'.", offset_file)
-        return 0, None
+        return 0, None, None
 
     try:
         inode = int(inode_str) if inode_str else None
@@ -251,17 +257,32 @@ def _read_offset_file(offset_file: pl.Path) -> tuple[int, int | None]:
         LOGGER.warning("Invalid inode in offset file '%s'.", offset_file)
         inode = None
 
-    return seek, inode
+    try:
+        timestamp = float(timestamp_str) if timestamp_str else None
+        # Reject nan/inf - such timestamp would permanently exclude all files from searches
+        if timestamp is not None and not (math.isfinite(timestamp) and timestamp >= 0):
+            raise ValueError
+    except ValueError:
+        # An invalid timestamp degrades to the offset file modification time
+        LOGGER.warning("Invalid timestamp in offset file '%s'.", offset_file)
+        timestamp = None
+
+    return seek, inode, timestamp
 
 
-def _write_offset_file(offset_file: pl.Path, *, seek: int, inode: int) -> None:
-    """Store the seek offset and the inode of the log file the offset belongs to.
+def _write_offset_file(offset_file: pl.Path, *, seek: int, inode: int, timestamp: float) -> None:
+    """Store the seek offset, the inode of the log file the offset belongs to and the timestamp.
+
+    The timestamp is the time when the search started reading the log files, **not** the time
+    the search finished. Lines can be appended to a log file while it is being searched. When
+    the time of the search start is compared with the log file modification time, such log
+    file is included in the next search.
 
     Write to a temp file first and rename, so that an interrupted write cannot leave
-    a valid seek offset without its inode record.
+    a partial record.
     """
     tmp_file = offset_file.parent / f"{offset_file.name}.tmp"
-    tmp_file.write_text(f"{seek}\n{inode}\n", encoding="utf-8")
+    tmp_file.write_text(f"{seek}\n{inode}\n{timestamp}\n", encoding="utf-8")
     tmp_file.replace(offset_file)
 
 
@@ -269,16 +290,17 @@ def _load_search_state(logfile: pl.Path) -> tuple[int, float, int | None]:
     """Return the seek offset, the timestamp of the last search and the inode.
 
     The seek offset says where to start searching the log file. The timestamp of the last
-    search is the modification time of the offset file. The inode belongs to the log file
-    the seek offset was recorded for.
+    search is read from the offset file, with fallback to the offset file modification time.
+    The inode belongs to the log file the seek offset was recorded for.
 
     When there is no offset file, the log file was not searched yet and `(0, 0.0, None)`
     is returned.
     """
     offset_file = _get_offset_file(logfile=logfile)
     if offset_file.exists():
-        seek, inode = _read_offset_file(offset_file=offset_file)
-        timestamp = offset_file.stat().st_mtime
+        seek, inode, timestamp = _read_offset_file(offset_file=offset_file)
+        if timestamp is None:
+            timestamp = offset_file.stat().st_mtime
     else:
         seek, timestamp, inode = 0, 0.0, None
     return seek, timestamp, inode
@@ -421,7 +443,8 @@ def _search_log_lines(  # noqa: C901
 
     - Uses binary I/O + byte offsets for correctness and speed.
     - Decodes only matched lines for output.
-    - Persists a byte offset at a line boundary for the live logfile.
+    - Persists the search state for the live logfile: a byte offset at a line boundary,
+      the file inode and the search start time.
     """
     errs_b = _compile_bytes_from_pattern(pat=errors_re, encoding=encoding)
     if not errs_b:
@@ -434,6 +457,9 @@ def _search_log_lines(  # noqa: C901
     results: list[tuple[pl.Path, str]] = []
     last_offset_bytes = -1
     last_inode = -1
+    # Time when this search starts reading the log files. Recorded in the offset file, so
+    # the next search doesn't skip lines that were appended while this search was running.
+    search_start = time.time()
 
     for rec in rotated_logs:
         path = rec.logfile
@@ -497,7 +523,13 @@ def _search_log_lines(  # noqa: C901
 
     if last_offset_bytes >= 0:
         offset_file = _get_offset_file(logfile=logfile)
-        _write_offset_file(offset_file=offset_file, seek=last_offset_bytes, inode=last_inode)
+        _write_offset_file(
+            offset_file=offset_file,
+            seek=last_offset_bytes,
+            inode=last_inode,
+            # Clamp to the current time in case the clock stepped backward during the search
+            timestamp=min(search_start, time.time()),
+        )
 
     return results
 

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -378,12 +378,13 @@ def test_rotated_logs_seek_by_inode(tmp_path: pl.Path):
     assert [(r.logfile, r.seek) for r in records] == [(rotated, 5), (logfile, 0)]
 
 
-def test_rotated_logs_seek_dropped(tmp_path: pl.Path):
-    """Check that the seek offset is dropped when its file was already fully searched.
+def test_rotated_logs_unmodified_seek_file_included(tmp_path: pl.Path):
+    """Check that the file the seek offset was recorded for is always included.
 
-    When the file the seek offset was recorded for was not modified since the last search,
-    it is filtered out by the timestamp check. The seek offset must not be applied to
-    another file, as that would skip unsearched content.
+    The file is included with the seek offset applied even when it was not modified since
+    the last search. Content before the seek offset was already searched, so this cannot
+    report anything twice, and content appended with a coarse modification time equal to
+    the last search time is not lost.
     """
     rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
     logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
@@ -393,7 +394,51 @@ def test_rotated_logs_seek_dropped(tmp_path: pl.Path):
     records = logfiles._get_rotated_logs(
         logfile=logfile, seek=5, timestamp=live_mtime - 5, inode=rotated.stat().st_ino
     )
+    assert [(r.logfile, r.seek) for r in records] == [(rotated, 5), (logfile, 0)]
+
+
+def test_rotated_logs_seek_dropped_for_missing_file(tmp_path: pl.Path):
+    """Check that the seek offset is dropped when its file no longer exists.
+
+    When no listed file matches the recorded inode, the seek offset must not be applied
+    to another file, as that would skip unsearched content.
+    """
+    rotated = _write_log(state_dir=tmp_path, name="node1.stdout.1", content="old content\n")
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="new content\n")
+    live_mtime = logfile.stat().st_mtime
+    os.utime(rotated, (live_mtime - 10, live_mtime - 10))
+    missing_inode = rotated.stat().st_ino + logfile.stat().st_ino + 1
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=5, timestamp=0.0, inode=missing_inode
+    )
+    assert [(r.logfile, r.seek) for r in records] == [(rotated, 0), (logfile, 0)]
+
+
+def test_rotated_logs_live_file_always_included(tmp_path: pl.Path):
+    """Check that the live log file is included even when unmodified since the last search.
+
+    The live log file inode differs from the recorded inode (the file is fresh after
+    rotation), so the file is included purely because it is the live log file.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="content\n")
+    live_mtime = logfile.stat().st_mtime
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=3, timestamp=live_mtime + 10, inode=logfile.stat().st_ino + 1
+    )
     assert [(r.logfile, r.seek) for r in records] == [(logfile, 0)]
+
+
+def test_rotated_logs_live_file_included_without_inode(tmp_path: pl.Path):
+    """Check that the unmodified live log file is included also when the inode is unknown."""
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="content\n")
+    live_mtime = logfile.stat().st_mtime
+
+    records = logfiles._get_rotated_logs(
+        logfile=logfile, seek=3, timestamp=live_mtime + 10, inode=None
+    )
+    assert [(r.logfile, r.seek) for r in records] == [(logfile, 3)]
 
 
 def test_rotated_logs_seek_without_inode(tmp_path: pl.Path):
@@ -576,6 +621,32 @@ def test_search_log_lines_appended_during_search(tmp_path: pl.Path):
         offset_file=offset_file, seek=seek, inode=inode, timestamp=offset_mtime - 10
     )
     os.utime(logfile, (offset_mtime - 5, offset_mtime - 5))
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error two"]
+
+
+def test_search_log_lines_coarse_mtime(tmp_path: pl.Path):
+    """Check that a line appended in the same coarse time tick as the search is not lost.
+
+    On filesystems with coarse timestamps, a line appended shortly after the search start
+    can get a modification time equal to the recorded search start time. The live log file
+    is searched from the seek offset regardless of its modification time, so the line is
+    found by the next search.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\nerror one\n")
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error one"]
+
+    with open(logfile, "a", encoding="utf-8") as outfile:
+        outfile.write("error two\n")
+    # Simulate a coarse filesystem timestamp: the log file modification time is exactly
+    # the recorded search start time, so the `mtime > timestamp` check filters it out.
+    offset_file = logfiles._get_offset_file(logfile=logfile)
+    _seek, _inode, stored_timestamp = logfiles._read_offset_file(offset_file=offset_file)
+    assert stored_timestamp is not None
+    os.utime(logfile, (stored_timestamp, stored_timestamp))
 
     errors = _search_cluster_like(logfile=logfile)
     assert [e[1] for e in errors] == ["error two"]

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -333,24 +333,29 @@ def test_check_msgs_seek_offset(tmp_path: pl.Path, msg_before_offset: bool):
 
 
 def test_offset_file_roundtrip(tmp_path: pl.Path):
-    """Check that the seek offset and inode survive the offset file round trip."""
+    """Check that the seek offset, inode and timestamp survive the offset file round trip."""
     offset_file = tmp_path / ".node1.stdout.offset"
-    logfiles._write_offset_file(offset_file=offset_file, seek=1234, inode=56)
+    logfiles._write_offset_file(offset_file=offset_file, seek=1234, inode=56, timestamp=789.5)
 
-    assert logfiles._read_offset_file(offset_file=offset_file) == (1234, 56)
+    assert logfiles._read_offset_file(offset_file=offset_file) == (1234, 56, 789.5)
 
 
 @pytest.mark.parametrize(
     ("content", "expected"),
     (
-        pytest.param("1234\n", (1234, None), id="missing_inode"),
-        pytest.param("garbage\n", (0, None), id="garbage"),
-        pytest.param("123\nabc\n", (123, None), id="corrupt_inode"),
-        pytest.param(None, (0, None), id="missing_file"),
+        pytest.param("1234\n", (1234, None, None), id="missing_inode"),
+        pytest.param("garbage\n", (0, None, None), id="garbage"),
+        pytest.param("123\nabc\n", (123, None, None), id="corrupt_inode"),
+        pytest.param("123\n45\n", (123, 45, None), id="missing_timestamp"),
+        pytest.param("123\n45\nbad\n", (123, 45, None), id="corrupt_timestamp"),
+        pytest.param("123\n45\ninf\n", (123, 45, None), id="inf_timestamp"),
+        pytest.param("123\n45\nnan\n", (123, 45, None), id="nan_timestamp"),
+        pytest.param("123\n45\n-1.0\n", (123, 45, None), id="negative_timestamp"),
+        pytest.param(None, (0, None, None), id="missing_file"),
     ),
 )
 def test_read_offset_file_fallback(
-    tmp_path: pl.Path, content: str | None, expected: tuple[int, int | None]
+    tmp_path: pl.Path, content: str | None, expected: tuple[int, int | None, float | None]
 ):
     """Check reading of an incomplete or invalid or missing offset file."""
     offset_file = tmp_path / ".node1.stdout.offset"
@@ -515,7 +520,62 @@ def test_search_log_lines_rotation_with_new_content(tmp_path: pl.Path):
 
     # The new search state belongs to the live log file
     offset_file = logfiles._get_offset_file(logfile=logfile)
-    assert logfiles._read_offset_file(offset_file=offset_file) == (
-        len(live_content),
-        logfile.stat().st_ino,
+    seek, inode, timestamp = logfiles._read_offset_file(offset_file=offset_file)
+    assert (seek, inode) == (len(live_content), logfile.stat().st_ino)
+    assert timestamp is not None
+
+
+def test_load_search_state_stored_timestamp(tmp_path: pl.Path):
+    """Check that the timestamp of the last search is read from the offset file."""
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\n")
+    offset_file = logfiles._get_offset_file(logfile=logfile)
+    logfiles._write_offset_file(offset_file=offset_file, seek=3, inode=7, timestamp=123.5)
+
+    assert logfiles._load_search_state(logfile=logfile) == (3, 123.5, 7)
+
+
+def test_load_search_state_mtime_fallback(tmp_path: pl.Path):
+    """Check the fallback to the offset file modification time.
+
+    When the offset file has no timestamp record, the modification time of the offset
+    file is used as the timestamp of the last search.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\n")
+    offset_file = logfiles._get_offset_file(logfile=logfile)
+    offset_file.write_text("3\n7\n", encoding="utf-8")
+
+    assert logfiles._load_search_state(logfile=logfile) == (
+        3,
+        offset_file.stat().st_mtime,
+        7,
     )
+
+
+def test_search_log_lines_appended_during_search(tmp_path: pl.Path):
+    """Check that lines appended to the log file during a search are not lost.
+
+    A line can be appended to the log file after the search read the file but before
+    the search state was recorded. The log file modification time then predates the
+    offset file, but is newer than the recorded search start time, so the file is
+    included in the next search.
+    """
+    logfile = _write_log(state_dir=tmp_path, name="node1.stdout", content="ok\nerror one\n")
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error one"]
+
+    # Simulate the line appended while the previous search was running: the log file
+    # modification time predates the offset file, but is after the recorded search start.
+    with open(logfile, "a", encoding="utf-8") as outfile:
+        outfile.write("error two\n")
+    offset_file = logfiles._get_offset_file(logfile=logfile)
+    offset_mtime = offset_file.stat().st_mtime
+    seek, inode, _ = logfiles._read_offset_file(offset_file=offset_file)
+    assert inode is not None
+    logfiles._write_offset_file(
+        offset_file=offset_file, seek=seek, inode=inode, timestamp=offset_mtime - 10
+    )
+    os.utime(logfile, (offset_mtime - 5, offset_mtime - 5))
+
+    errors = _search_cluster_like(logfile=logfile)
+    assert [e[1] for e in errors] == ["error two"]


### PR DESCRIPTION
The timestamp of the last log search was the modification time of the offset file, which is written after the search finishes reading the log files. A line appended to a log file while the search was running got a modification time older than the offset file. When the log file was never modified again (e.g. node shut down), the next search filtered the file out and the line was never searched.

Record the time when the search starts reading the log files in the offset file (third record) and use it as the timestamp of the last search. An offset file without a valid timestamp record degrades to the old modification time behavior. Non-finite and negative timestamps are rejected, as e.g. an "inf" timestamp would permanently exclude all files from searches. The recorded timestamp is clamped to the current time in case the clock stepped backward during the search.

This also improves the ignore rules expiry: the expire time is now compared with the search start, so a rule cannot expire while messages created before its expire time are still unsearched.

Add unit tests covering the timestamp round trip and fallbacks, and a regression test for the appended-during-search scenario.