### PR TITLE
docs(agents): split E2E vs unit test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,18 @@ You are a test engineer writing end-to-end tests for the Cardano blockchain usin
 
 ---
 
+## Test Types
+
+This repository contains two distinct kinds of tests. Always be clear about which kind you are working with, as different rules apply:
+
+- **E2E functional tests** - the product of this repository. Located under `cardano_node_tests/tests/`. They test the Cardano node by running against a local testnet cluster. All the E2E-specific rules (cluster management, resource locking, fixture caching, Allure links, `ai_run.sh` wrapper) apply only to these tests.
+- **Unit tests** - tests of the testing framework itself. Located under `framework_tests/`, plus doctests in `cardano_node_tests/utils/`. They are plain pytest tests that need no cluster and no `ai_run.sh` wrapper, and the E2E-specific rules do not apply to them.
+
+---
+
 ## Code Organization
 
-Tests are organized under:
+E2E tests are organized under:
 
 - `cardano_node_tests/tests/` - Main test directory
 - `cardano_node_tests/tests/tests_plutus/` - Plutus-specific tests for all Plutus versions
@@ -20,6 +29,10 @@ Framework components are organized under:
 - `cardano_node_tests/cluster_management/` - Cluster management utilities
 - `cardano_node_tests/utils/` - Utility functions
 - `cardano_node_tests/pytest_plugins/` - Pytest plugins (custom pytest-xdist scheduler)
+
+Unit tests for the framework components are organized under:
+
+- `framework_tests/` - Unit tests for cluster management, log file checking, etc.
 
 ---
 
@@ -44,9 +57,9 @@ Before running tests, you must first open `agent_docs/running_tests.md` and foll
 
 ---
 
-## Writing New Tests
+## Writing New E2E Tests
 
-Before writing new test from scratch, you must first open `agent_docs/new_tests.md` and follow the instructions.
+Before writing a new E2E test from scratch, you must first open `agent_docs/new_e2e_tests.md` and follow the instructions.
 
 ---
 

--- a/agent_docs/new_e2e_tests.md
+++ b/agent_docs/new_e2e_tests.md
@@ -1,4 +1,6 @@
-# Writing New Tests
+# Writing New E2E Tests
+
+This document applies only to E2E functional tests under `cardano_node_tests/tests/`. Unit tests for the framework itself live under `framework_tests/` and are plain pytest tests.
 
 Organize tests in classes that group related functionality.
 
@@ -10,13 +12,13 @@ When tests modify or use shared resources (stake pools, treasury, reserves, DRep
 
 Cache expensive fixture resources (addresses, keys, scripts) to avoid recreation on every test. Open `agent_docs/fixtures_caching.md` and follow the instructions.
 
-## Tests with Expensive Setup
+## E2E Tests with Expensive Setup
 
 Reuse expensive setups (governance actions, etc.) across multiple scenarios using pytest-subtests. Open `agent_docs/subtests.md` and follow the instructions.
 
 ## Summary Checklist
 
-When writing a new test, ensure:
+When writing a new E2E test, ensure:
 
 - [ ] Test is in a class grouping related functionality
 - [ ] `@allure.link(helpers.get_vcs_link())` decorator is present

--- a/agent_docs/running_tests.md
+++ b/agent_docs/running_tests.md
@@ -1,6 +1,16 @@
 # Running Tests
 
-The tests are using pytest. Always use the `ai_run.sh` wrapper script to run the `pytest` command.
+## Unit Tests
+
+Unit tests cover the testing framework itself (`framework_tests/` plus doctests in `cardano_node_tests/utils/`). They need no running cluster and no `ai_run.sh` wrapper. Run them directly:
+
+```sh
+./.venv/bin/pytest --doctest-modules framework_tests cardano_node_tests/utils/
+```
+
+## E2E Functional Tests
+
+E2E functional tests (everything under `cardano_node_tests/tests/`) run against a local testnet cluster. The tests are using pytest. Always use the `ai_run.sh` wrapper script to run the `pytest` command.
 For example, to run the `test_minting_one_token` test:
 
 ```sh


### PR DESCRIPTION
Differentiate E2E functional tests (the product, under cardano_node_tests/tests/) from unit tests of the framework itself (framework_tests/ plus doctests) so AI agents know which rules apply to which tests:

- add Test Types section to AGENTS.md
- rename new_tests.md to new_e2e_tests.md and scope it to E2E tests
- document how to run unit tests (no cluster, no ai_run.sh wrapper) in running_tests.md