### PR TITLE
fix(logfiles): harden ignore rules parsing and validation

### DIFF
--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -24,11 +24,11 @@ LOGGER = logging.getLogger(__name__)
 
 @functools.lru_cache(maxsize=1000)
 def _warn_once(message: str) -> None:
-    """Log the warning only once per process.
+    """Log the warning at most once per process (while it stays in the LRU cache).
 
     The ignore rules files are parsed again in every log search, so a warning about
     a malformed record would be logged again in every log search. The LRU cache keeps
-    the deduplication memory bounded.
+    the deduplication memory bounded - after eviction, the warning can be logged again.
     """
     LOGGER.warning("%s", message)
 

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -21,19 +21,15 @@ from cardano_node_tests.utils import temptools
 
 LOGGER = logging.getLogger(__name__)
 
-# Warnings that were already logged in this process
-_logged_warnings: set[str] = set()
 
-
+@functools.lru_cache(maxsize=1000)
 def _warn_once(message: str) -> None:
     """Log the warning only once per process.
 
     The ignore rules files are parsed again in every log search, so a warning about
-    a malformed record would be logged again in every log search.
+    a malformed record would be logged again in every log search. The LRU cache keeps
+    the deduplication memory bounded.
     """
-    if message in _logged_warnings:
-        return
-    _logged_warnings.add(message)
     LOGGER.warning("%s", message)
 
 
@@ -246,6 +242,10 @@ def _get_ignore_rules(
                     files_glob, skip_after_str, regex = parts
                     try:
                         skip_after = float(skip_after_str)
+                        # Reject nan/inf/negative - they would silently turn the expire
+                        # time into "never expire"
+                        if not (math.isfinite(skip_after) and skip_after >= 0):
+                            raise ValueError
                     except ValueError:
                         _warn_once(f"Skipping malformed ignore rule in '{rules_file}': {line!r}")
                         continue
@@ -379,8 +379,8 @@ def _get_ignore_regex(
                 f"all errors: {regex!r}"
             )
             continue
-        candidate_regexes = [*valid_regexes, regex]
-        combined = "x|" + "|".join(candidate_regexes)
+        valid_regexes.append(regex)
+        combined = "x|" + "|".join(valid_regexes)
         try:
             # Compile the actual combination, so that also conflicts between the rules
             # (e.g. a redefined group name) and global inline flags that are not valid
@@ -391,9 +391,9 @@ def _get_ignore_regex(
             re.compile(combined)
             re.compile(combined.encode("utf-8"))
         except re.error as err:
+            valid_regexes.pop()
             _warn_once(f"Skipping ignore regex that cannot be combined: {regex!r}: {err}")
             continue
-        valid_regexes = candidate_regexes
 
     return "|".join(valid_regexes) or "nothing_to_ignore"
 

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -21,6 +21,22 @@ from cardano_node_tests.utils import temptools
 
 LOGGER = logging.getLogger(__name__)
 
+# Warnings that were already logged in this process
+_logged_warnings: set[str] = set()
+
+
+def _warn_once(message: str) -> None:
+    """Log the warning only once per process.
+
+    The ignore rules files are parsed again in every log search, so a warning about
+    a malformed record would be logged again in every log search.
+    """
+    if message in _logged_warnings:
+        return
+    _logged_warnings.add(message)
+    LOGGER.warning("%s", message)
+
+
 BUFFER_SIZE = 512 * 1024  # 512 KB buffer
 ROTATED_RE = re.compile(r".+\.[0-9]+$")  # Detect rotated log file
 # NOTE: The regex needs to be unanchored.
@@ -206,7 +222,11 @@ def _get_ignore_rules_lock_file(instance_num: int) -> pl.Path:
 def _get_ignore_rules(
     cluster_env: cluster_nodes.ClusterEnv, timestamp: float
 ) -> list[tuple[str, str]]:
-    """Get rules (file glob and regex) for ignored errors."""
+    """Get rules (file glob and regex) for ignored errors.
+
+    Malformed rule records are skipped with a warning. Skipping a rule can only lead to
+    reporting previously ignored errors, while a crash would abort the whole log check.
+    """
     rules: list[tuple[str, str]] = []
     lock_file = _get_ignore_rules_lock_file(instance_num=cluster_env.instance_num)
 
@@ -214,11 +234,21 @@ def _get_ignore_rules(
         for rules_file in cluster_env.state_dir.glob(f"{ERRORS_IGNORE_FILE_NAME}_*"):
             with open(rules_file, encoding="utf-8") as infile:
                 for line in infile:
-                    if ";;" not in line:
+                    if not line.strip():
                         continue
                     # Split on the first two separators only, so the regex itself may contain ";;"
-                    files_glob, skip_after_str, regex = line.split(";;", maxsplit=2)
-                    skip_after = float(skip_after_str)
+                    parts = line.split(";;", maxsplit=2)
+                    if len(parts) != 3:
+                        # A malformed line must not crash the whole log check. Skipping the
+                        # rule can only lead to reporting the previously ignored errors.
+                        _warn_once(f"Skipping malformed ignore rule in '{rules_file}': {line!r}")
+                        continue
+                    files_glob, skip_after_str, regex = parts
+                    try:
+                        skip_after = float(skip_after_str)
+                    except ValueError:
+                        _warn_once(f"Skipping malformed ignore rule in '{rules_file}': {line!r}")
+                        continue
                     # Skip the rule if it is expired. The `timestamp` is the start time of the
                     # last log search, so the expire time is compared to the time when the log
                     # file was last checked.
@@ -321,13 +351,51 @@ def _load_search_state(logfile: pl.Path) -> tuple[int, float, int | None]:
 def _get_ignore_regex(
     ignore_rules: list[tuple[str, str]], regexes: list[str], logfile: pl.Path
 ) -> str:
-    """Combine together regex for the given log file using file specific and global ignore rules."""
+    """Combine together regex for the given log file using file specific and global ignore rules.
+
+    Regexes that match an empty string or that cannot be combined into the alternation
+    (they don't compile, they use global inline flags that are not valid mid-pattern, or
+    they conflict with other rules, e.g. on a redefined group name) are skipped with
+    a warning. Skipping a regex can only lead to reporting previously ignored errors,
+    while a bad regex in the alternation would crash every log check on compile.
+    """
     regex_set = set(regexes)
     for record in ignore_rules:
         files_glob, regex = record
         if fnmatch.filter([logfile.name], files_glob):
             regex_set.add(regex)
-    return "|".join(regex_set) or "nothing_to_ignore"
+
+    valid_regexes: list[str] = []
+    # Sorted iteration makes the outcome deterministic when regexes conflict
+    for regex in sorted(regex_set):
+        try:
+            compiled = re.compile(regex)
+        except re.error as err:
+            _warn_once(f"Skipping ignore regex that is not valid: {regex!r}: {err}")
+            continue
+        if compiled.search(""):
+            _warn_once(
+                f"Skipping ignore regex that matches an empty string, as it would suppress "
+                f"all errors: {regex!r}"
+            )
+            continue
+        candidate_regexes = [*valid_regexes, regex]
+        combined = "x|" + "|".join(candidate_regexes)
+        try:
+            # Compile the actual combination, so that also conflicts between the rules
+            # (e.g. a redefined group name) and global inline flags that are not valid
+            # mid-pattern are caught. The "x|" prefix makes sure no regex relies on being
+            # the first branch of the alternation. Compile also as bytes - the log search
+            # compiles the combined regex as bytes, and e.g. the "\\N{...}" escape is
+            # valid only in str regexes.
+            re.compile(combined)
+            re.compile(combined.encode("utf-8"))
+        except re.error as err:
+            _warn_once(f"Skipping ignore regex that cannot be combined: {regex!r}: {err}")
+            continue
+        valid_regexes = candidate_regexes
+
+    return "|".join(valid_regexes) or "nothing_to_ignore"
 
 
 def _resume_at_line_boundary(fb: tp.BinaryIO, pos: int, size: int) -> None:
@@ -557,7 +625,7 @@ def _search_log_lines(  # noqa: C901
 def add_ignore_rule(
     *, files_glob: str, regex: str, ignore_file_id: str, skip_after: float = 0.0
 ) -> None:
-    """Add ignore rule for expected errors.
+    r"""Add ignore rule for expected errors.
 
     Args:
         files_glob: A glob matching files that the `regex` should apply to.
@@ -573,7 +641,48 @@ def add_ignore_rule(
 
             NOTE: The rule will expire **only** when there are no yet to be searched log messages
             that were created before the `skip_after` time.
+
+    Raises:
+        ValueError: When the rule cannot be stored in the rules file format (";;" in the
+            file glob, a line break in the file glob or in the regex), when the regex is
+            not valid or cannot be combined with other rules, when the regex matches an
+            empty string (it would suppress all errors for the matching files), or when
+            the `skip_after` value is not a non-negative finite number.
+
+    NOTE: Conflicts between rules that fail compilation of the combined ignore regex
+    (e.g. two rules redefining the same group name) cannot be detected here. Such rules
+    are skipped with a warning when the combined ignore regex is built. Avoid numeric
+    backreferences (e.g. "\1") - group numbers shift in the combined regex, so the
+    backreference can silently bind to a group of a different rule.
     """
+    if ";;" in files_glob:
+        msg = f"The files glob must not contain ';;': {files_glob!r}"
+        raise ValueError(msg)
+    if any(char in files_glob or char in regex for char in "\r\n"):
+        msg = (
+            f"The files glob and the regex must not contain line breaks: {files_glob!r}, {regex!r}"
+        )
+        raise ValueError(msg)
+    try:
+        compiled = re.compile(regex)
+        # Compile also in an alternation context, as the rule is combined with other rules.
+        # This rejects global inline flags that are not valid mid-pattern. Compile also as
+        # bytes - the log search compiles the combined regex as bytes, and e.g. the
+        # "\\N{...}" escape is valid only in str regexes.
+        re.compile(f"x|{regex}")
+        re.compile(f"x|{regex}".encode())
+    except re.error as err:
+        msg = f"The regex is not valid or cannot be combined with other rules: {regex!r}: {err}"
+        raise ValueError(msg) from err
+    if compiled.search(""):
+        msg = (
+            f"The regex must not match an empty string, as it would suppress all errors: {regex!r}"
+        )
+        raise ValueError(msg)
+    if not (math.isfinite(skip_after) and skip_after >= 0):
+        msg = f"The `skip_after` value must be a non-negative finite number: {skip_after!r}"
+        raise ValueError(msg)
+
     cluster_env = cluster_nodes.get_cluster_env()
     rules_file = cluster_env.state_dir / f"{ERRORS_IGNORE_FILE_NAME}_{ignore_file_id}"
     lock_file = _get_ignore_rules_lock_file(instance_num=cluster_env.instance_num)

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -1,5 +1,6 @@
 """Tests for `utils.logfiles` ignore rules handling and expected messages checks."""
 
+import logging
 import os
 import pathlib as pl
 import re
@@ -9,6 +10,12 @@ import pytest
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils import temptools
+
+
+@pytest.fixture(autouse=True)
+def _reset_logged_warnings(monkeypatch: pytest.MonkeyPatch):
+    """Reset the warn-once dedup set, so tests don't depend on the execution order."""
+    monkeypatch.setattr(logfiles, "_logged_warnings", set())
 
 
 @pytest.fixture
@@ -73,13 +80,77 @@ def test_ignore_rules_expiry(
     assert rules == ([("*", "foo")] if expected_kept else [])
 
 
-def test_ignore_rules_skip_lines_without_separator(cluster_env: cluster_nodes.ClusterEnv):
-    """Check that lines without the ";;" separator are skipped without an error."""
-    rules_file = cluster_env.state_dir / f"{logfiles.ERRORS_IGNORE_FILE_NAME}_test_id"
-    rules_file.write_text("\nnot a rule\n*.stdout;;0.0;;valid\n", encoding="utf-8")
+@pytest.mark.parametrize(
+    "malformed_line",
+    (
+        pytest.param("not a rule", id="no_separator"),
+        pytest.param("*.stdout;;no regex part", id="one_separator"),
+        pytest.param("*.stdout;;not_a_float;;regex", id="invalid_expire_time"),
+    ),
+)
+def test_ignore_rules_skip_malformed_lines(
+    cluster_env: cluster_nodes.ClusterEnv,
+    caplog: pytest.LogCaptureFixture,
+    malformed_line: str,
+):
+    """Check that a malformed line is skipped with a warning and doesn't crash the parsing.
 
-    rules = logfiles._get_ignore_rules(cluster_env=cluster_env, timestamp=1000.0)
+    A crash while parsing ignore rules would abort the whole log check and poison every
+    subsequent log check on the cluster instance. Valid rules on other lines are still
+    parsed. Blank lines are skipped silently.
+    """
+    rules_file = cluster_env.state_dir / f"{logfiles.ERRORS_IGNORE_FILE_NAME}_test_id"
+    rules_file.write_text(f"\n{malformed_line}\n*.stdout;;0.0;;valid\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        rules = logfiles._get_ignore_rules(cluster_env=cluster_env, timestamp=1000.0)
+
     assert rules == [("*.stdout", "valid")]
+    malformed_warnings = [r for r in caplog.records if "malformed ignore rule" in r.message]
+    assert len(malformed_warnings) == 1
+
+
+@pytest.mark.parametrize(
+    ("files_glob", "regex", "match"),
+    (
+        pytest.param("*.std;;out", "regex", "must not", id="separator_in_glob"),
+        pytest.param("*.std\nout", "regex", "must not", id="newline_in_glob"),
+        pytest.param("*.stdout", "re\ngex", "must not", id="newline_in_regex"),
+        pytest.param("*.stdout", "re\rgex", "must not", id="carriage_return_in_regex"),
+        pytest.param("*.stdout", "", "empty string", id="empty_regex"),
+        pytest.param("*.stdout", "a*|foo", "empty string", id="matches_empty_string"),
+        pytest.param("*.stdout", "foo(", "not valid", id="regex_not_valid"),
+        pytest.param("*.stdout", "(?i)foo", "not valid", id="global_flag_mid_pattern"),
+        pytest.param("*.stdout", r"\N{BULLET}err", "not valid", id="str_only_escape"),
+    ),
+)
+def test_add_ignore_rule_validation(
+    cluster_env: cluster_nodes.ClusterEnv, files_glob: str, regex: str, match: str
+):
+    """Check that a hazardous ignore rule is rejected and nothing is written.
+
+    A files glob with ";;" or a newline in the glob or the regex would corrupt the
+    line-based rules file format. A regex matching an empty string would suppress all
+    errors for the matching files. A regex that doesn't compile, or that cannot be
+    combined into an alternation with other rules, would crash every log check.
+    """
+    with pytest.raises(ValueError, match=match):
+        logfiles.add_ignore_rule(files_glob=files_glob, regex=regex, ignore_file_id="test_id")
+
+    assert not list(cluster_env.state_dir.glob(f"{logfiles.ERRORS_IGNORE_FILE_NAME}_*"))
+
+
+@pytest.mark.parametrize("skip_after", (float("nan"), float("inf"), -1.0))
+@pytest.mark.usefixtures("cluster_env")
+def test_add_ignore_rule_invalid_skip_after(skip_after: float):
+    """Check that a non-finite or negative rule expire time is rejected.
+
+    Such expire time would silently turn "expire after X" into "never expire".
+    """
+    with pytest.raises(ValueError, match="skip_after"):
+        logfiles.add_ignore_rule(
+            files_glob="*.stdout", regex="foo", ignore_file_id="test_id", skip_after=skip_after
+        )
 
 
 def test_ignore_rules_multiple_files(cluster_env: cluster_nodes.ClusterEnv):
@@ -144,23 +215,35 @@ def test_get_ignore_regex_multiple():
     assert sorted(regex.split("|")) == ["bar", "foo"]
 
 
-def test_empty_regex_matches_everything(cluster_env: cluster_nodes.ClusterEnv):
-    """Pin the hazard of an empty regex in an ignore rule.
+def test_get_ignore_regex_skips_hazardous(caplog: pytest.LogCaptureFixture):
+    """Check that hazardous regexes from ignore rules are skipped with a warning.
 
-    An empty regex round-trips through the rules file and becomes an empty branch in
-    the combined alternation, which matches every line - i.e. it suppresses all errors
-    for the matching files. This documents the current behavior; `add_ignore_rule`
-    does not reject empty regexes.
+    An empty regex (or a regex matching an empty string) would suppress all errors for
+    the matching files. A regex that doesn't compile, that uses global inline flags that
+    are not valid mid-pattern, or that conflicts with another rule (a redefined group
+    name - the first rule in sorted order wins) would crash every log check on compile.
+    Such regexes can appear in hand-edited rules files. Valid regexes are kept.
     """
-    logfiles.add_ignore_rule(files_glob="*", regex="", ignore_file_id="id1")
+    with caplog.at_level(logging.WARNING):
+        regex = logfiles._get_ignore_regex(
+            ignore_rules=[
+                ("*.stdout", ""),
+                ("*.stdout", "b*|bar"),
+                ("*.stdout", "unbalanced("),
+                ("*.stdout", "(?s)dotall"),
+                ("*.stdout", "(?P<g>aaa)"),
+                ("*.stdout", "(?P<g>bbb)"),
+                ("*.stdout", r"\N{BULLET}err"),
+                ("*.stdout", "kept1"),
+            ],
+            regexes=["kept2"],
+            logfile=pl.Path("/tmp/node1.stdout"),
+        )
 
-    rules = logfiles._get_ignore_rules(cluster_env=cluster_env, timestamp=1000.0)
-    assert rules == [("*", "")]
-
-    regex = logfiles._get_ignore_regex(
-        ignore_rules=rules, regexes=["foo"], logfile=pl.Path("/tmp/node1.stdout")
-    )
-    assert re.search(regex, "arbitrary line")
+    assert sorted(regex.split("|")) == ["(?P<g>aaa)", "kept1", "kept2"]
+    assert re.compile(f"x|{regex}")
+    skip_warnings = [r for r in caplog.records if "Skipping ignore regex" in r.message]
+    assert len(skip_warnings) == 6
 
 
 def _write_log(state_dir: pl.Path, name: str, content: str) -> pl.Path:

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -13,9 +13,9 @@ from cardano_node_tests.utils import temptools
 
 
 @pytest.fixture(autouse=True)
-def _reset_logged_warnings(monkeypatch: pytest.MonkeyPatch):
-    """Reset the warn-once dedup set, so tests don't depend on the execution order."""
-    monkeypatch.setattr(logfiles, "_logged_warnings", set())
+def _reset_logged_warnings():
+    """Reset the warn-once dedup cache, so tests don't depend on the execution order."""
+    logfiles._warn_once.cache_clear()
 
 
 @pytest.fixture
@@ -86,6 +86,9 @@ def test_ignore_rules_expiry(
         pytest.param("not a rule", id="no_separator"),
         pytest.param("*.stdout;;no regex part", id="one_separator"),
         pytest.param("*.stdout;;not_a_float;;regex", id="invalid_expire_time"),
+        pytest.param("*.stdout;;nan;;regex", id="nan_expire_time"),
+        pytest.param("*.stdout;;inf;;regex", id="inf_expire_time"),
+        pytest.param("*.stdout;;-1.0;;regex", id="negative_expire_time"),
     ),
 )
 def test_ignore_rules_skip_malformed_lines(

--- a/framework_tests/test_logfiles.py
+++ b/framework_tests/test_logfiles.py
@@ -112,6 +112,12 @@ def test_ignore_rules_skip_malformed_lines(
     malformed_warnings = [r for r in caplog.records if "malformed ignore rule" in r.message]
     assert len(malformed_warnings) == 1
 
+    # Repeated parsing must not log the same warning again
+    with caplog.at_level(logging.WARNING):
+        logfiles._get_ignore_rules(cluster_env=cluster_env, timestamp=1000.0)
+    malformed_warnings = [r for r in caplog.records if "malformed ignore rule" in r.message]
+    assert len(malformed_warnings) == 1
+
 
 @pytest.mark.parametrize(
     ("files_glob", "regex", "match"),


### PR DESCRIPTION
A malformed line in an ignore rules file crashed the whole log check with a ValueError. The crash happened in the cluster manager fixture teardown, so the cleanup was skipped and every subsequent log check on the cluster instance kept crashing until the rules file was manually removed. Skip malformed lines with a warning instead - skipping a rule can only lead to reporting previously ignored errors.

Validate rules when they are added, so that a hazardous rule fails the offending test loudly at the source:

* Reject ";;" in the files glob and line breaks in the glob or the regex - they would corrupt the line-based rules file format.
* Reject a regex that matches an empty string - as an empty branch of the combined alternation it would suppress all errors.
* Reject a regex that doesn't compile (as str and as bytes - the log search compiles the combined regex as bytes) or that cannot be combined with other rules (e.g. global inline flags) - it would crash every log check on compile.
* Reject a non-finite or negative expire time - it would silently turn "expire after X" into "never expire".

Apply the same checks with warning and skip when the combined ignore regex is built, so that hand-edited rules files and conflicts between rules (e.g. a redefined group name) cannot crash the log checks either. The rules are combined in sorted order, so the outcome is deterministic when rules conflict. Warnings are logged once per process, as the rules files are parsed again in every log search.