### PR TITLE
Harden artifacts collection and make its failures observable

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -250,11 +250,18 @@ class ClusterGetter:
 
             # Save artifacts only when produced during this test run
             if cluster_running or i > 0:
-                artifacts.save_start_script_coverage(
-                    log_file=state_dir / common.START_CLUSTER_LOG,
-                    pytest_config=self.pytest_config,
-                )
-                artifacts.save_cluster_artifacts(save_dir=self.pytest_tmp_dir, state_dir=state_dir)
+                # Artifact collection is best-effort diagnostics, it must not abort
+                # the cluster restart.
+                try:
+                    artifacts.save_start_script_coverage(
+                        log_file=state_dir / common.START_CLUSTER_LOG,
+                        pytest_config=self.pytest_config,
+                    )
+                    artifacts.save_cluster_artifacts(
+                        save_dir=self.pytest_tmp_dir, state_dir=state_dir
+                    )
+                except Exception as err:
+                    self.log(f"c{self.cluster_instance_num}: failed to save artifacts:\n{err}")
 
             shutil.rmtree(state_dir, ignore_errors=True)
 

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -248,20 +248,29 @@ class ClusterGetter:
                 instance_num=self.cluster_instance_num, log_func=_netstat_log_func
             )
 
-            # Save artifacts only when produced during this test run
+            # Save artifacts only when produced during this test run.
+            # Artifact collection is best-effort diagnostics, its failure must not abort
+            # the cluster restart. The two saves are independent, so a failure in one
+            # must not prevent the other.
             if cluster_running or i > 0:
-                # Artifact collection is best-effort diagnostics, it must not abort
-                # the cluster restart.
                 try:
                     artifacts.save_start_script_coverage(
                         log_file=state_dir / common.START_CLUSTER_LOG,
                         pytest_config=self.pytest_config,
                     )
+                except Exception as err:
+                    self.log(
+                        f"c{self.cluster_instance_num}: failed to save start script coverage:"
+                        f"\n{err}"
+                    )
+                    LOGGER.exception("Failed to save start script coverage.")
+                try:
                     artifacts.save_cluster_artifacts(
                         save_dir=self.pytest_tmp_dir, state_dir=state_dir
                     )
                 except Exception as err:
                     self.log(f"c{self.cluster_instance_num}: failed to save artifacts:\n{err}")
+                    LOGGER.exception("Failed to save cluster artifacts.")
 
             shutil.rmtree(state_dir, ignore_errors=True)
 

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -263,14 +263,18 @@ class ClusterGetter:
                         f"c{self.cluster_instance_num}: failed to save start script coverage:"
                         f"\n{err}"
                     )
-                    LOGGER.exception("Failed to save start script coverage.")
+                    LOGGER.exception(
+                        f"Failed to save start script coverage for 'c{self.cluster_instance_num}'."
+                    )
                 try:
                     artifacts.save_cluster_artifacts(
                         save_dir=self.pytest_tmp_dir, state_dir=state_dir
                     )
                 except Exception as err:
                     self.log(f"c{self.cluster_instance_num}: failed to save artifacts:\n{err}")
-                    LOGGER.exception("Failed to save cluster artifacts.")
+                    LOGGER.exception(
+                        f"Failed to save cluster artifacts for 'c{self.cluster_instance_num}'."
+                    )
 
             shutil.rmtree(state_dir, ignore_errors=True)
 

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -168,11 +168,19 @@ class ClusterManager:
             if not self._is_valid_cluster_instance(work_dir=work_dir, instance_num=instance_num):
                 continue
 
-            artifacts.save_start_script_coverage(
-                log_file=state_dir / common.START_CLUSTER_LOG,
-                pytest_config=self.pytest_config,
-            )
-            artifacts.save_cluster_artifacts(save_dir=self.pytest_tmp_dir, state_dir=state_dir)
+            # Artifact collection is best-effort diagnostics, a failure on one cluster
+            # instance must not prevent saving artifacts of the remaining instances.
+            try:
+                artifacts.save_start_script_coverage(
+                    log_file=state_dir / common.START_CLUSTER_LOG,
+                    pytest_config=self.pytest_config,
+                )
+            except Exception:
+                LOGGER.exception(f"Failed to save start script coverage for 'c{instance_num}'.")
+            try:
+                artifacts.save_cluster_artifacts(save_dir=self.pytest_tmp_dir, state_dir=state_dir)
+            except Exception:
+                LOGGER.exception(f"Failed to save cluster artifacts for 'c{instance_num}'.")
 
     def stop_all_clusters(self) -> None:
         """Stop all cluster instances."""

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -103,32 +103,38 @@ def _copy_state_dir_content(*, state_dir: pl.Path, destdir: pl.Path) -> int:
 
 def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
     """Save cluster artifacts (logs, certs, etc.)."""
-    dir_rand_str = ""
-    cluster_instance_id_log = state_dir / CLUSTER_INSTANCE_ID_FILENAME
-    if cluster_instance_id_log.exists():
-        with open(cluster_instance_id_log, encoding="utf-8") as fp_in:
-            dir_rand_str = fp_in.read().strip()
-    dir_rand_str = dir_rand_str or helpers.get_rand_str(8)
+    try:
+        dir_rand_str = ""
+        cluster_instance_id_log = state_dir / CLUSTER_INSTANCE_ID_FILENAME
+        if cluster_instance_id_log.exists():
+            with open(cluster_instance_id_log, encoding="utf-8") as fp_in:
+                dir_rand_str = fp_in.read().strip()
+        dir_rand_str = dir_rand_str or helpers.get_rand_str(8)
 
-    destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
-    if destdir.exists():
-        # Artifacts for this cluster instance were already saved. Append a random
-        # suffix so the new save doesn't clash with the existing directory.
-        destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
-        LOGGER.warning(f"Cluster artifacts dir already exists, saving to '{destdir}' instead.")
-    destdir.mkdir(parents=True)
+        destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
+        if destdir.exists():
+            # Artifacts for this cluster instance were already saved. Append a random
+            # suffix so the new save doesn't clash with the existing directory.
+            destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
+            LOGGER.warning(f"Cluster artifacts dir already exists, saving to '{destdir}' instead.")
+        destdir.mkdir(parents=True)
 
-    copy_failures = _copy_state_dir_content(state_dir=state_dir, destdir=destdir)
+        copy_failures = _copy_state_dir_content(state_dir=state_dir, destdir=destdir)
 
-    if not any(destdir.iterdir()):
-        if copy_failures:
-            LOGGER.error(f"Failed to save any cluster artifacts from '{state_dir}'.")
-        else:
-            LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")
-        destdir.rmdir()
-        return
+        if not any(destdir.iterdir()):
+            if copy_failures:
+                LOGGER.error(f"Failed to save any cluster artifacts from '{state_dir}'.")
+            else:
+                LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")
+            destdir.rmdir()
+            return
 
-    LOGGER.info(f"Cluster artifacts saved to '{destdir}'.")
+        LOGGER.info(f"Cluster artifacts saved to '{destdir}'.")
+    except OSError:
+        # The function runs in teardown paths, some of which don't guard it. It must
+        # stay best-effort even when the setup I/O (reading the cluster instance id,
+        # creating the destination dir) fails, not just the per-file copies.
+        LOGGER.exception(f"Failed to save cluster artifacts from '{state_dir}'.")
 
 
 def copy_artifacts(*, pytest_tmp_dir: pl.Path, pytest_config: Config) -> None:

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -30,7 +30,7 @@ def save_cli_coverage(
     )
     with open(json_file, "w", encoding="utf-8") as out_json:
         json.dump(cluster_obj.cli_coverage, out_json, indent=4)  # pyright: ignore [reportAttributeAccessIssue]
-    LOGGER.info(f"Coverage file saved to '{cli_coverage_dir}'.")
+    LOGGER.info(f"Coverage file saved to '{json_file}'.")
     return json_file
 
 

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -35,7 +35,12 @@ def save_cli_coverage(
 
 
 def save_start_script_coverage(*, log_file: pl.Path, pytest_config: Config) -> pl.Path | None:
-    """Save info about CLI commands executed by cluster start script."""
+    """Save info about CLI commands executed by cluster start script.
+
+    Returns:
+        Path to the saved coverage log file, or `None` when coverage collection is
+        disabled, the log file doesn't exist, or the copy failed.
+    """
     cli_coverage_dir = pytest_config.getoption(CLI_COVERAGE_ARG)
     if not (cli_coverage_dir and log_file.exists()):
         return None
@@ -46,8 +51,9 @@ def save_start_script_coverage(*, log_file: pl.Path, pytest_config: Config) -> p
     try:
         shutil.copy(log_file, dest_file)
     except OSError as err:
-        # The log file may disappear between the check above and the copy.
-        LOGGER.warning(f"Failed to copy '{log_file}': {err}")
+        # The log file may disappear between the check above and the copy, or the
+        # destination may not be writable.
+        LOGGER.warning(f"Failed to copy '{log_file}' to '{dest_file}': {err}")
         return None
     LOGGER.info(f"Start script coverage log file saved to '{dest_file}'.")
     return dest_file

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -58,6 +58,10 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
     dir_rand_str = dir_rand_str or helpers.get_rand_str(8)
 
     destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
+    if destdir.exists():
+        # Artifacts for this cluster instance were already saved once. Append a random
+        # suffix so the new save doesn't clash with the existing directory.
+        destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
     destdir.mkdir(parents=True)
 
     files_list = [

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -59,9 +59,10 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
 
     destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
     if destdir.exists():
-        # Artifacts for this cluster instance were already saved once. Append a random
+        # Artifacts for this cluster instance were already saved. Append a random
         # suffix so the new save doesn't clash with the existing directory.
         destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
+        LOGGER.warning(f"Cluster artifacts dir already exists, saving to '{destdir}' instead.")
     destdir.mkdir(parents=True)
 
     files_list = [

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -48,23 +48,8 @@ def save_start_script_coverage(*, log_file: pl.Path, pytest_config: Config) -> p
     return dest_file
 
 
-def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
-    """Save cluster artifacts (logs, certs, etc.)."""
-    dir_rand_str = ""
-    cluster_instance_id_log = state_dir / CLUSTER_INSTANCE_ID_FILENAME
-    if cluster_instance_id_log.exists():
-        with open(cluster_instance_id_log, encoding="utf-8") as fp_in:
-            dir_rand_str = fp_in.read().strip()
-    dir_rand_str = dir_rand_str or helpers.get_rand_str(8)
-
-    destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
-    if destdir.exists():
-        # Artifacts for this cluster instance were already saved. Append a random
-        # suffix so the new save doesn't clash with the existing directory.
-        destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
-        LOGGER.warning(f"Cluster artifacts dir already exists, saving to '{destdir}' instead.")
-    destdir.mkdir(parents=True)
-
+def _copy_state_dir_content(*, state_dir: pl.Path, destdir: pl.Path) -> int:
+    """Copy artifact files and dirs from the state dir and return the number of failures."""
     files_list = [
         *state_dir.glob("*.stdout"),
         *state_dir.glob("*.stderr"),
@@ -101,6 +86,28 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
             # modifying the directory content.
             LOGGER.warning(f"Failed to copy '{src_dir}': {err}")
             copy_failures += 1
+
+    return copy_failures
+
+
+def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
+    """Save cluster artifacts (logs, certs, etc.)."""
+    dir_rand_str = ""
+    cluster_instance_id_log = state_dir / CLUSTER_INSTANCE_ID_FILENAME
+    if cluster_instance_id_log.exists():
+        with open(cluster_instance_id_log, encoding="utf-8") as fp_in:
+            dir_rand_str = fp_in.read().strip()
+    dir_rand_str = dir_rand_str or helpers.get_rand_str(8)
+
+    destdir = save_dir / "cluster_artifacts" / f"{state_dir.name}_{dir_rand_str}"
+    if destdir.exists():
+        # Artifacts for this cluster instance were already saved. Append a random
+        # suffix so the new save doesn't clash with the existing directory.
+        destdir = destdir.with_name(f"{destdir.name}_{helpers.get_rand_str(8)}")
+        LOGGER.warning(f"Cluster artifacts dir already exists, saving to '{destdir}' instead.")
+    destdir.mkdir(parents=True)
+
+    copy_failures = _copy_state_dir_content(state_dir=state_dir, destdir=destdir)
 
     if not any(destdir.iterdir()):
         if copy_failures:

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -79,7 +79,7 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
 
     for fpath in files_list:
         # Skip dangling symlinks, directories and special files that `shutil.copy`
-        # would fail or block on.
+        # would fail or hang on.
         if not fpath.is_file():
             LOGGER.warning(f"Skipping non-regular file '{fpath}'.")
             continue
@@ -126,5 +126,5 @@ def copy_artifacts(*, pytest_tmp_dir: pl.Path, pytest_config: Config) -> None:
         return
 
     destdir = artifacts_dir / f"{pytest_tmp_dir.name}-{helpers.get_rand_str(8)}"
-    shutil.copytree(pytest_tmp_dir, destdir, symlinks=True, ignore_dangling_symlinks=True)
+    shutil.copytree(pytest_tmp_dir, destdir, symlinks=True)
     LOGGER.info(f"Collected artifacts copied to '{destdir}'.")

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -75,6 +75,8 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
     ]
     dirs_to_copy = ("nodes", "shelley")
 
+    copy_failures = 0
+
     for fpath in files_list:
         # Skip dangling symlinks, directories and special files that `shutil.copy`
         # would fail or block on.
@@ -87,6 +89,7 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
             # The cluster may still be running and rotate or delete the file between
             # the check above and the copy. Don't let one file abort the whole save.
             LOGGER.warning(f"Failed to copy '{fpath}': {err}")
+            copy_failures += 1
     for dname in dirs_to_copy:
         src_dir = state_dir / dname
         if not src_dir.exists():
@@ -97,9 +100,13 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
             # Same race as with the files above - the cluster may still be running and
             # modifying the directory content.
             LOGGER.warning(f"Failed to copy '{src_dir}': {err}")
+            copy_failures += 1
 
     if not any(destdir.iterdir()):
-        LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")
+        if copy_failures:
+            LOGGER.error(f"Failed to save any cluster artifacts from '{state_dir}'.")
+        else:
+            LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")
         destdir.rmdir()
         return
 

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -91,7 +91,12 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
         src_dir = state_dir / dname
         if not src_dir.exists():
             continue
-        shutil.copytree(src_dir, destdir / dname, symlinks=True, ignore_dangling_symlinks=True)
+        try:
+            shutil.copytree(src_dir, destdir / dname, symlinks=True)
+        except OSError as err:
+            # Same race as with the files above - the cluster may still be running and
+            # modifying the directory content.
+            LOGGER.warning(f"Failed to copy '{src_dir}': {err}")
 
     if not any(destdir.iterdir()):
         LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -75,10 +75,17 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
     dirs_to_copy = ("nodes", "shelley")
 
     for fpath in files_list:
-        # Skip dangling symlinks and other non-regular files
+        # Skip dangling symlinks, directories and special files that `shutil.copy`
+        # would fail or block on.
         if not fpath.is_file():
+            LOGGER.warning(f"Skipping non-regular file '{fpath}'.")
             continue
-        shutil.copy(fpath, destdir)
+        try:
+            shutil.copy(fpath, destdir)
+        except OSError as err:
+            # The cluster may still be running and rotate or delete the file between
+            # the check above and the copy. Don't let one file abort the whole save.
+            LOGGER.warning(f"Failed to copy '{fpath}': {err}")
     for dname in dirs_to_copy:
         src_dir = state_dir / dname
         if not src_dir.exists():

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -78,7 +78,7 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
             continue
         shutil.copytree(src_dir, destdir / dname, symlinks=True, ignore_dangling_symlinks=True)
 
-    if not destdir.iterdir():
+    if not any(destdir.iterdir()):
         destdir.rmdir()
         return
 

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -75,6 +75,9 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
     dirs_to_copy = ("nodes", "shelley")
 
     for fpath in files_list:
+        # Skip dangling symlinks and other non-regular files
+        if not fpath.is_file():
+            continue
         shutil.copy(fpath, destdir)
     for dname in dirs_to_copy:
         src_dir = state_dir / dname

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -105,8 +105,5 @@ def copy_artifacts(*, pytest_tmp_dir: pl.Path, pytest_config: Config) -> None:
         return
 
     destdir = artifacts_dir / f"{pytest_tmp_dir.name}-{helpers.get_rand_str(8)}"
-    if destdir.resolve().is_dir():
-        shutil.rmtree(destdir)
-
     shutil.copytree(pytest_tmp_dir, destdir, symlinks=True, ignore_dangling_symlinks=True)
     LOGGER.info(f"Collected artifacts copied to '{artifacts_dir}'.")

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -43,7 +43,12 @@ def save_start_script_coverage(*, log_file: pl.Path, pytest_config: Config) -> p
     dest_file = (
         pl.Path(cli_coverage_dir) / f"cli_coverage_script_{helpers.get_timestamped_rand_str()}.log"
     )
-    shutil.copy(log_file, dest_file)
+    try:
+        shutil.copy(log_file, dest_file)
+    except OSError as err:
+        # The log file may disappear between the check above and the copy.
+        LOGGER.warning(f"Failed to copy '{log_file}': {err}")
+        return None
     LOGGER.info(f"Start script coverage log file saved to '{dest_file}'.")
     return dest_file
 

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -115,4 +115,4 @@ def copy_artifacts(*, pytest_tmp_dir: pl.Path, pytest_config: Config) -> None:
 
     destdir = artifacts_dir / f"{pytest_tmp_dir.name}-{helpers.get_rand_str(8)}"
     shutil.copytree(pytest_tmp_dir, destdir, symlinks=True, ignore_dangling_symlinks=True)
-    LOGGER.info(f"Collected artifacts copied to '{artifacts_dir}'.")
+    LOGGER.info(f"Collected artifacts copied to '{destdir}'.")

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -94,6 +94,7 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
         shutil.copytree(src_dir, destdir / dname, symlinks=True, ignore_dangling_symlinks=True)
 
     if not any(destdir.iterdir()):
+        LOGGER.warning(f"No cluster artifacts found in '{state_dir}', nothing saved.")
         destdir.rmdir()
         return
 

--- a/framework_tests/test_artifacts.py
+++ b/framework_tests/test_artifacts.py
@@ -236,6 +236,19 @@ class TestSaveClusterArtifacts:
         assert not _get_saved_dirs(save_dir)
         assert "Failed to save any cluster artifacts" in caplog.text
 
+    def test_setup_failure_tolerated(
+        self, save_dir: pl.Path, state_dir: pl.Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Log the failure instead of raising when the setup I/O fails."""
+        # A directory in place of the instance id file makes `open()` raise
+        # `IsADirectoryError` before any file copy starts.
+        (state_dir / artifacts.CLUSTER_INSTANCE_ID_FILENAME).mkdir()
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        assert not _get_saved_dirs(save_dir)
+        assert "Failed to save cluster artifacts" in caplog.text
+
     def test_empty_state_dir(
         self, save_dir: pl.Path, tmp_path: pl.Path, caplog: pytest.LogCaptureFixture
     ):

--- a/framework_tests/test_artifacts.py
+++ b/framework_tests/test_artifacts.py
@@ -1,0 +1,123 @@
+"""Unit tests for `cardano_node_tests.utils.artifacts`."""
+
+import logging
+import pathlib as pl
+
+import pytest
+
+from cardano_node_tests.utils import artifacts
+
+
+@pytest.fixture
+def state_dir(tmp_path: pl.Path) -> pl.Path:
+    """Create a state dir populated with typical cluster artifacts."""
+    sdir = tmp_path / "state-cluster0"
+    sdir.mkdir()
+    (sdir / "bft1.stdout").write_text("stdout")
+    (sdir / "bft1.stderr").write_text("stderr")
+    (sdir / "config.json").write_text("{}")
+    nodes_dir = sdir / "nodes"
+    nodes_dir.mkdir()
+    (nodes_dir / "node.skey").write_text("key")
+    return sdir
+
+
+@pytest.fixture
+def save_dir(tmp_path: pl.Path) -> pl.Path:
+    """Create a directory for saving the artifacts."""
+    sdir = tmp_path / "save"
+    sdir.mkdir()
+    return sdir
+
+
+def _get_saved_dirs(save_dir: pl.Path) -> list[pl.Path]:
+    """Return directories created under the `cluster_artifacts` dir."""
+    return sorted((save_dir / "cluster_artifacts").glob("*"))
+
+
+class TestSaveClusterArtifacts:
+    """Tests for `save_cluster_artifacts`."""
+
+    def test_save_files_and_dirs(self, save_dir: pl.Path, state_dir: pl.Path):
+        """Copy matching files and known subdirectories to the destination dir."""
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        destdir = saved_dirs[0]
+        assert (destdir / "bft1.stdout").read_text() == "stdout"
+        assert (destdir / "bft1.stderr").read_text() == "stderr"
+        assert (destdir / "config.json").read_text() == "{}"
+        assert (destdir / "nodes" / "node.skey").read_text() == "key"
+
+    def test_instance_id_in_dir_name(self, save_dir: pl.Path, state_dir: pl.Path):
+        """Use the cluster instance id from the state dir in the destination dir name."""
+        instance_id_file = state_dir / artifacts.CLUSTER_INSTANCE_ID_FILENAME
+        instance_id_file.write_text("abcdefgh")
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        assert saved_dirs[0].name == f"{state_dir.name}_abcdefgh"
+
+    def test_dangling_symlink_skipped(
+        self, save_dir: pl.Path, state_dir: pl.Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Skip a dangling symlink and still save the remaining artifacts."""
+        (state_dir / "broken.log").symlink_to(state_dir / "missing.log")
+
+        with caplog.at_level(logging.WARNING):
+            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        destdir = saved_dirs[0]
+        assert not (destdir / "broken.log").exists()
+        assert (destdir / "bft1.stdout").exists()
+        assert "broken.log" in caplog.text
+
+    def test_dir_matching_glob_skipped(
+        self, save_dir: pl.Path, state_dir: pl.Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Skip a directory whose name matches the file glob patterns."""
+        (state_dir / "subdir.log").mkdir()
+
+        with caplog.at_level(logging.WARNING):
+            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        assert not (saved_dirs[0] / "subdir.log").exists()
+        assert "subdir.log" in caplog.text
+
+    def test_empty_state_dir(
+        self, save_dir: pl.Path, tmp_path: pl.Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Remove the empty destination dir when there was nothing to save."""
+        empty_state_dir = tmp_path / "state-cluster-empty"
+        empty_state_dir.mkdir()
+
+        with caplog.at_level(logging.WARNING):
+            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=empty_state_dir)
+
+        assert not _get_saved_dirs(save_dir)
+        assert "No cluster artifacts found" in caplog.text
+
+    def test_existing_destdir_gets_suffix(
+        self, save_dir: pl.Path, state_dir: pl.Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Save to a new dir with a random suffix when the destination dir already exists."""
+        instance_id_file = state_dir / artifacts.CLUSTER_INSTANCE_ID_FILENAME
+        instance_id_file.write_text("abcdefgh")
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+        with caplog.at_level(logging.WARNING):
+            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 2
+        base_name = f"{state_dir.name}_abcdefgh"
+        assert saved_dirs[0].name == base_name
+        assert saved_dirs[1].name.startswith(f"{base_name}_")
+        assert "already exists" in caplog.text

--- a/framework_tests/test_artifacts.py
+++ b/framework_tests/test_artifacts.py
@@ -1,7 +1,7 @@
 """Unit tests for `cardano_node_tests.utils.artifacts`."""
 
-import logging
 import pathlib as pl
+import shutil
 
 import pytest
 
@@ -19,6 +19,9 @@ def state_dir(tmp_path: pl.Path) -> pl.Path:
     nodes_dir = sdir / "nodes"
     nodes_dir.mkdir()
     (nodes_dir / "node.skey").write_text("key")
+    shelley_dir = sdir / "shelley"
+    shelley_dir.mkdir()
+    (shelley_dir / "genesis.json").write_text("{}")
     return sdir
 
 
@@ -31,7 +34,7 @@ def save_dir(tmp_path: pl.Path) -> pl.Path:
 
 
 def _get_saved_dirs(save_dir: pl.Path) -> list[pl.Path]:
-    """Return directories created under the `cluster_artifacts` dir."""
+    """Return entries created under the `cluster_artifacts` dir."""
     return sorted((save_dir / "cluster_artifacts").glob("*"))
 
 
@@ -49,6 +52,7 @@ class TestSaveClusterArtifacts:
         assert (destdir / "bft1.stderr").read_text() == "stderr"
         assert (destdir / "config.json").read_text() == "{}"
         assert (destdir / "nodes" / "node.skey").read_text() == "key"
+        assert (destdir / "shelley" / "genesis.json").read_text() == "{}"
 
     def test_instance_id_in_dir_name(self, save_dir: pl.Path, state_dir: pl.Path):
         """Use the cluster instance id from the state dir in the destination dir name."""
@@ -67,8 +71,7 @@ class TestSaveClusterArtifacts:
         """Skip a dangling symlink and still save the remaining artifacts."""
         (state_dir / "broken.log").symlink_to(state_dir / "missing.log")
 
-        with caplog.at_level(logging.WARNING):
-            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
 
         saved_dirs = _get_saved_dirs(save_dir)
         assert len(saved_dirs) == 1
@@ -83,13 +86,84 @@ class TestSaveClusterArtifacts:
         """Skip a directory whose name matches the file glob patterns."""
         (state_dir / "subdir.log").mkdir()
 
-        with caplog.at_level(logging.WARNING):
-            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
 
         saved_dirs = _get_saved_dirs(save_dir)
         assert len(saved_dirs) == 1
         assert not (saved_dirs[0] / "subdir.log").exists()
         assert "subdir.log" in caplog.text
+
+    def test_copy_failure_tolerated(
+        self,
+        save_dir: pl.Path,
+        state_dir: pl.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Keep saving the remaining artifacts when copying one file fails."""
+        real_copy = shutil.copy
+
+        def _failing_copy(src: str, dst: str) -> str:
+            if pl.Path(src).name == "bft1.stderr":
+                err = "Simulated copy failure"
+                raise OSError(err)
+            return str(real_copy(src, dst))
+
+        monkeypatch.setattr(artifacts.shutil, "copy", _failing_copy)
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        destdir = saved_dirs[0]
+        assert (destdir / "bft1.stdout").exists()
+        assert not (destdir / "bft1.stderr").exists()
+        assert "Failed to copy" in caplog.text
+
+    def test_dir_copy_failure_tolerated(
+        self,
+        save_dir: pl.Path,
+        state_dir: pl.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Keep the file artifacts when copying a subdirectory fails."""
+
+        def _failing_copytree(*_args: object, **_kwargs: object) -> str:
+            err = "Simulated copytree failure"
+            raise OSError(err)
+
+        monkeypatch.setattr(artifacts.shutil, "copytree", _failing_copytree)
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        saved_dirs = _get_saved_dirs(save_dir)
+        assert len(saved_dirs) == 1
+        destdir = saved_dirs[0]
+        assert (destdir / "bft1.stdout").exists()
+        assert not (destdir / "nodes").exists()
+        assert "Failed to copy" in caplog.text
+
+    def test_all_copies_failed(
+        self,
+        save_dir: pl.Path,
+        state_dir: pl.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Log an error and remove the empty destination dir when every copy fails."""
+
+        def _failing_copy(*_args: object, **_kwargs: object) -> str:
+            err = "Simulated copy failure"
+            raise OSError(err)
+
+        monkeypatch.setattr(artifacts.shutil, "copy", _failing_copy)
+        monkeypatch.setattr(artifacts.shutil, "copytree", _failing_copy)
+
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+
+        assert not _get_saved_dirs(save_dir)
+        assert "Failed to save any cluster artifacts" in caplog.text
 
     def test_empty_state_dir(
         self, save_dir: pl.Path, tmp_path: pl.Path, caplog: pytest.LogCaptureFixture
@@ -98,8 +172,7 @@ class TestSaveClusterArtifacts:
         empty_state_dir = tmp_path / "state-cluster-empty"
         empty_state_dir.mkdir()
 
-        with caplog.at_level(logging.WARNING):
-            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=empty_state_dir)
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=empty_state_dir)
 
         assert not _get_saved_dirs(save_dir)
         assert "No cluster artifacts found" in caplog.text
@@ -112,8 +185,7 @@ class TestSaveClusterArtifacts:
         instance_id_file.write_text("abcdefgh")
 
         artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
-        with caplog.at_level(logging.WARNING):
-            artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
+        artifacts.save_cluster_artifacts(save_dir=save_dir, state_dir=state_dir)
 
         saved_dirs = _get_saved_dirs(save_dir)
         assert len(saved_dirs) == 2

--- a/framework_tests/test_artifacts.py
+++ b/framework_tests/test_artifacts.py
@@ -2,10 +2,24 @@
 
 import pathlib as pl
 import shutil
+import typing as tp
 
 import pytest
+from _pytest.config import Config
 
 from cardano_node_tests.utils import artifacts
+
+
+class _PytestConfigStub:
+    """Minimal stub of pytest `Config` that provides only `getoption`."""
+
+    def __init__(self, cli_coverage_dir: str) -> None:
+        self._cli_coverage_dir = cli_coverage_dir
+
+    def getoption(self, name: str) -> str:
+        """Return the configured CLI coverage dir."""
+        assert name == artifacts.CLI_COVERAGE_ARG
+        return self._cli_coverage_dir
 
 
 @pytest.fixture
@@ -36,6 +50,63 @@ def save_dir(tmp_path: pl.Path) -> pl.Path:
 def _get_saved_dirs(save_dir: pl.Path) -> list[pl.Path]:
     """Return entries created under the `cluster_artifacts` dir."""
     return sorted((save_dir / "cluster_artifacts").glob("*"))
+
+
+class TestSaveStartScriptCoverage:
+    """Tests for `save_start_script_coverage`."""
+
+    def test_copies_log_file(self, tmp_path: pl.Path):
+        """Copy the start script log file to the coverage dir."""
+        log_file = tmp_path / "start_cluster.log"
+        log_file.write_text("cli commands")
+        coverage_dir = tmp_path / "coverage"
+        coverage_dir.mkdir()
+        pytest_config = tp.cast(Config, _PytestConfigStub(str(coverage_dir)))
+
+        dest_file = artifacts.save_start_script_coverage(
+            log_file=log_file, pytest_config=pytest_config
+        )
+
+        assert dest_file is not None
+        assert dest_file.parent == coverage_dir
+        assert dest_file.read_text() == "cli commands"
+
+    def test_disabled_coverage(self, tmp_path: pl.Path):
+        """Return `None` when CLI coverage collection is not enabled."""
+        log_file = tmp_path / "start_cluster.log"
+        log_file.write_text("cli commands")
+        pytest_config = tp.cast(Config, _PytestConfigStub(""))
+
+        assert (
+            artifacts.save_start_script_coverage(log_file=log_file, pytest_config=pytest_config)
+            is None
+        )
+
+    def test_copy_failure_returns_none(
+        self,
+        tmp_path: pl.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Log a warning and return `None` when the copy fails."""
+        log_file = tmp_path / "start_cluster.log"
+        log_file.write_text("cli commands")
+        coverage_dir = tmp_path / "coverage"
+        coverage_dir.mkdir()
+        pytest_config = tp.cast(Config, _PytestConfigStub(str(coverage_dir)))
+
+        def _failing_copy(*_args: object, **_kwargs: object) -> str:
+            err = "Simulated copy failure"
+            raise OSError(err)
+
+        monkeypatch.setattr(artifacts.shutil, "copy", _failing_copy)
+
+        dest_file = artifacts.save_start_script_coverage(
+            log_file=log_file, pytest_config=pytest_config
+        )
+
+        assert dest_file is None
+        assert "Failed to copy" in caplog.text
 
 
 class TestSaveClusterArtifacts:


### PR DESCRIPTION
## Summary

Fixes several bugs and silent failure modes in test artifacts collection
(`cardano_node_tests/utils/artifacts.py`) and its callers, and adds unit
tests for the module.

Artifact collection runs in teardown paths, often while the cluster is
still running. Previously a single problematic file could abort the whole
save, and several failure modes either crashed teardown or passed without
any trace in the logs.

### Bug fixes

- `save_cluster_artifacts` treated every destination dir as non-empty:
  `if not destdir.iterdir()` is always false for a generator, so empty
  dirs were kept and a success message was logged even when nothing was
  copied.
- Repeated save of the same cluster instance (e.g. on respin and again at
  session end) crashed with `FileExistsError`. Now a random suffix is
  appended and a warning is logged.
- A dangling symlink, a directory matching the file globs, or a file
  rotated/deleted mid-save aborted the whole artifacts save. Per-file and
  per-directory copies are now tolerant: each failure logs a warning and
  the save continues.
- An artifact save failure inside the cluster restart loop
  (`cluster_getter.py`) aborted the restart attempt, and in session
  teardown (`manager.py`) it skipped saving of the remaining cluster
  instances, stopping of the clusters and the final copy to the artifacts
  base dir. Artifact collection is now best-effort in both places, with
  failures logged with traceback via the standard logger (visible even
  when `SCHEDULING_LOG` is not set).
- `save_start_script_coverage` had the same check-then-copy race and now
  logs a warning and returns `None` instead of raising.

### Observability

- Total copy failure (disk full, permissions) is now logged as an error,
  distinct from the "state dir had no artifacts" warning.
- Log messages report the actual saved file/dir instead of its parent.

### Cleanups

- Removed a dead (and unsafe on collision) `rmtree` branch in
  `copy_artifacts` and a no-op `ignore_dangling_symlinks` argument.
- Extracted `_copy_state_dir_content` helper.

### Tests

New `framework_tests/test_artifacts.py` with 12 unit tests covering
`save_cluster_artifacts` (copy, naming, skips, failure paths, collisions)
and `save_start_script_coverage`. No cluster needed.