### PR TITLE
Improve GitHub issue blockers: fail loud on bad issue refs, harden state handling

### DIFF
--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -38,8 +38,13 @@ class GH:
         self.issue = issue
         self.repo = repo
         self.fixed_in = fixed_in
-        # Parse eagerly so an invalid version is reported already when the issue is defined
-        self._fixed_in_version = version.parse(fixed_in) if fixed_in else None
+        # Validate eagerly so an invalid version is reported already when the issue is defined
+        if fixed_in:
+            try:
+                version.parse(fixed_in)
+            except version.InvalidVersion as excp:
+                msg = f"Invalid `fixed_in` version for issue '{repo}#{issue}': '{fixed_in}'"
+                raise ValueError(msg) from excp
         self.message = message
         self.gh_issue = gh_issue.GHIssue(number=self.issue, repo=self.repo)
 
@@ -51,8 +56,27 @@ class GH:
         else:
             self.is_blocked = self._issue_is_blocked
 
+    @property
+    def _fixed_in_version(self) -> version.Version | None:
+        """Parsed `fixed_in` version, or `None` when no `fixed_in` was set.
+
+        Parsed on access, so the check stays correct even when the `fixed_in`
+        attribute was changed after init.
+        """
+        return version.parse(self.fixed_in) if self.fixed_in else None
+
     def _issue_blocked_in_version(self, product_version: version.Version) -> bool:
-        """Check if an issue is blocked in given product version."""
+        """Check if an issue is blocked in given product version.
+
+        Args:
+            product_version: A version of the product to check the issue against.
+
+        Returns:
+            Whether the issue is considered blocked.
+
+        Raises:
+            ValueError: If the GitHub issue doesn't exist or is not accessible.
+        """
         # Assume that the issue is blocked if no GitHub token was provided and so the check
         # cannot be performed.
         if not self.gh_issue.TOKEN:
@@ -64,11 +88,20 @@ class GH:
 
         state = self.gh_issue.get_state()
 
-        # Fail early when the issue doesn't exist, e.g. because of a typo in the issue number.
-        # Otherwise the test would be silently xfailed forever.
-        if state == "unknown":
-            msg = f"Issue '{self.repo}#{self.issue}' doesn't exist"
+        # Fail early when the issue cannot be found, e.g. because of a typo in the issue
+        # number or repo name. Otherwise the test would be silently xfailed forever.
+        if state == gh_issue.STATE_UNKNOWN:
+            msg = f"Issue '{self.repo}#{self.issue}' doesn't exist or is not accessible"
             raise ValueError(msg)
+
+        # Assume that the issue is blocked when its state could not be determined,
+        # e.g. due to an API failure or rate limiting.
+        if state is None or state == gh_issue.STATE_FAILURE:
+            LOGGER.warning(
+                "Could not determine state of issue '%s', assuming it is blocked",
+                f"{self.repo}#{self.issue}",
+            )
+            return True
 
         # The issue is blocked if it was not closed yet
         if state != "closed":
@@ -93,7 +126,14 @@ class GH:
         return self._issue_blocked_in_version(VERSIONS.node)
 
     def finish_test(self, force_blocked: bool = False) -> None:
-        """Fail or Xfail test with GitHub issue reference."""
+        """Fail or Xfail test with GitHub issue reference.
+
+        Args:
+            force_blocked: Treat the issue as blocked without checking its state.
+
+        Raises:
+            ValueError: If the GitHub issue doesn't exist or is not accessible.
+        """
         reason = f"{self.gh_issue}: {self.message}"
         log_message = f"{self.gh_issue.url} => {self.message}"
 
@@ -118,7 +158,15 @@ class GH:
 
 
 def finish_test(issues: tp.Iterable[GH]) -> None:
-    """Fail or Xfail test with references to multiple GitHub issues."""
+    """Fail or Xfail test with references to multiple GitHub issues.
+
+    Args:
+        issues: GitHub issues to report. Must not be empty.
+
+    Raises:
+        ValueError: If no issues were provided, or if a referenced GitHub issue doesn't
+            exist or is not accessible.
+    """
 
     def _get_outcome(issue: GH) -> tuple[bool, str, str]:
         blocked = issue.is_blocked()

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -127,6 +127,9 @@ def finish_test(issues: tp.Iterable[GH]) -> None:
         return blocked, reason, log_message
 
     outcomes = [_get_outcome(i) for i in issues]
+    if not outcomes:
+        msg = "No issues were provided"
+        raise ValueError(msg)
 
     should_fail = False
     for blocked, __, log_message in outcomes:

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -38,6 +38,8 @@ class GH:
         self.issue = issue
         self.repo = repo
         self.fixed_in = fixed_in
+        # Parse eagerly so an invalid version is reported already when the issue is defined
+        self._fixed_in_version = version.parse(fixed_in) if fixed_in else None
         self.message = message
         self.gh_issue = gh_issue.GHIssue(number=self.issue, repo=self.repo)
 
@@ -74,10 +76,9 @@ class GH:
 
         # The issue is blocked if it was fixed or integrated into a product version that is greater
         # than the product version we are currently running.
-        if self.fixed_in and version.parse(self.fixed_in) > product_version:  # noqa:SIM103
-            return True
-
-        return False
+        if self._fixed_in_version is None:
+            return False
+        return self._fixed_in_version > product_version
 
     def _cli_issue_is_blocked(self) -> bool:
         """Check if cardano-cli issue is blocked."""

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -35,9 +35,6 @@ class GH:
         fixed_in: str = "",
         message: str = "",
     ) -> None:
-        self.issue = issue
-        self.repo = repo
-        self.fixed_in = fixed_in
         # Validate eagerly so an invalid version is reported already when the issue is defined
         if fixed_in:
             try:
@@ -45,6 +42,10 @@ class GH:
             except version.InvalidVersion as excp:
                 msg = f"Invalid `fixed_in` version for issue '{repo}#{issue}': '{fixed_in}'"
                 raise ValueError(msg) from excp
+
+        self.issue = issue
+        self.repo = repo
+        self.fixed_in = fixed_in
         self.message = message
         self.gh_issue = gh_issue.GHIssue(number=self.issue, repo=self.repo)
 
@@ -55,15 +56,6 @@ class GH:
             self.is_blocked = self._dbsync_issue_is_blocked
         else:
             self.is_blocked = self._issue_is_blocked
-
-    @property
-    def _fixed_in_version(self) -> version.Version | None:
-        """Parsed `fixed_in` version, or `None` when no `fixed_in` was set.
-
-        Parsed on access, so the check stays correct even when the `fixed_in`
-        attribute was changed after init.
-        """
-        return version.parse(self.fixed_in) if self.fixed_in else None
 
     def _issue_blocked_in_version(self, product_version: version.Version) -> bool:
         """Check if an issue is blocked in given product version.
@@ -77,12 +69,13 @@ class GH:
         Raises:
             ValueError: If the GitHub issue doesn't exist or is not accessible.
         """
+        issue_id = f"{self.repo}#{self.issue}"
+
         # Assume that the issue is blocked if no GitHub token was provided and so the check
         # cannot be performed.
         if not self.gh_issue.TOKEN:
             LOGGER.warning(
-                "No GitHub token provided, cannot check if issue '%s' is blocked",
-                f"{self.repo}#{self.issue}",
+                "No GitHub token provided, cannot check if issue '%s' is blocked", issue_id
             )
             return True
 
@@ -91,27 +84,26 @@ class GH:
         # Fail early when the issue cannot be found, e.g. because of a typo in the issue
         # number or repo name. Otherwise the test would be silently xfailed forever.
         if state == gh_issue.STATE_UNKNOWN:
-            msg = f"Issue '{self.repo}#{self.issue}' doesn't exist or is not accessible"
+            msg = f"Issue '{issue_id}' doesn't exist or is not accessible"
             raise ValueError(msg)
 
         # Assume that the issue is blocked when its state could not be determined,
         # e.g. due to an API failure or rate limiting.
-        if state is None or state == gh_issue.STATE_FAILURE:
+        if state == gh_issue.STATE_FAILURE:
             LOGGER.warning(
-                "Could not determine state of issue '%s', assuming it is blocked",
-                f"{self.repo}#{self.issue}",
+                "Could not determine state of issue '%s', assuming it is blocked", issue_id
             )
             return True
 
         # The issue is blocked if it was not closed yet
-        if state != "closed":
+        if state != gh_issue.STATE_CLOSED:
             return True
 
         # The issue is blocked if it was fixed or integrated into a product version that is greater
         # than the product version we are currently running.
-        if self._fixed_in_version is None:
+        if not self.fixed_in:
             return False
-        return self._fixed_in_version > product_version
+        return version.parse(self.fixed_in) > product_version
 
     def _cli_issue_is_blocked(self) -> bool:
         """Check if cardano-cli issue is blocked."""
@@ -128,11 +120,14 @@ class GH:
     def finish_test(self, force_blocked: bool = False) -> None:
         """Fail or Xfail test with GitHub issue reference.
 
+        Never returns - the test outcome is always set via `pytest.xfail` or `pytest.fail`.
+
         Args:
             force_blocked: Treat the issue as blocked without checking its state.
 
         Raises:
             ValueError: If the GitHub issue doesn't exist or is not accessible.
+                Cannot happen with `force_blocked`, as the issue state is not checked.
         """
         reason = f"{self.gh_issue}: {self.message}"
         log_message = f"{self.gh_issue.url} => {self.message}"
@@ -157,8 +152,10 @@ class GH:
         return f"<GH: issue='{self.repo}#{self.issue}', fixed_in='{self.fixed_in}'>"
 
 
-def finish_test(issues: tp.Iterable[GH]) -> None:
+def finish_test(issues: tp.Collection[GH]) -> None:
     """Fail or Xfail test with references to multiple GitHub issues.
+
+    Never returns - the test outcome is always set via `pytest.xfail` or `pytest.fail`.
 
     Args:
         issues: GitHub issues to report. Must not be empty.
@@ -167,6 +164,9 @@ def finish_test(issues: tp.Iterable[GH]) -> None:
         ValueError: If no issues were provided, or if a referenced GitHub issue doesn't
             exist or is not accessible.
     """
+    if not issues:
+        msg = "No issues were provided"
+        raise ValueError(msg)
 
     def _get_outcome(issue: GH) -> tuple[bool, str, str]:
         blocked = issue.is_blocked()
@@ -176,9 +176,6 @@ def finish_test(issues: tp.Iterable[GH]) -> None:
         return blocked, reason, log_message
 
     outcomes = [_get_outcome(i) for i in issues]
-    if not outcomes:
-        msg = "No issues were provided"
-        raise ValueError(msg)
 
     should_fail = False
     for blocked, __, log_message in outcomes:

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -22,7 +22,9 @@ class GH:
     Attributes:
         issue: A GitHub issue number.
         repo: A repository where the issue belongs to. Default: `IntersectMBO/cardano-node`.
-        fixed_in: A version of the project where the issue is fixed. Ignored on unknown projects.
+        fixed_in: A version of the project where the issue is fixed. On projects other than
+            cardano-node, cardano-cli and cardano-db-sync, it is the cardano-node version
+            into which the fix was integrated.
         message: A message to be added to blocking outcome.
     """
 

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -70,7 +70,7 @@ class GH:
             msg = f"Issue '{self.repo}#{self.issue}' doesn't exist"
             raise ValueError(msg)
 
-        # The issue is blocked if it is was not closed yet
+        # The issue is blocked if it was not closed yet
         if state != "closed":
             return True
 

--- a/cardano_node_tests/utils/blockers.py
+++ b/cardano_node_tests/utils/blockers.py
@@ -60,8 +60,16 @@ class GH:
             )
             return True
 
+        state = self.gh_issue.get_state()
+
+        # Fail early when the issue doesn't exist, e.g. because of a typo in the issue number.
+        # Otherwise the test would be silently xfailed forever.
+        if state == "unknown":
+            msg = f"Issue '{self.repo}#{self.issue}' doesn't exist"
+            raise ValueError(msg)
+
         # The issue is blocked if it is was not closed yet
-        if not self.gh_issue.is_closed():
+        if state != "closed":
             return True
 
         # The issue is blocked if it was fixed or integrated into a product version that is greater

--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -7,11 +7,11 @@ import github
 
 LOGGER = logging.getLogger(__name__)
 
-#: State of a closed issue.
+# State of a closed issue.
 STATE_CLOSED: tp.Final[str] = "closed"
-#: State reported when the issue cannot be found, e.g. wrong issue number or repo name.
+# State reported when the issue cannot be found, e.g. wrong issue number or repo name.
 STATE_UNKNOWN: tp.Final[str] = "unknown"
-#: State reported when the issue state could not be retrieved, e.g. due to an API failure.
+# State reported when the issue state could not be retrieved, e.g. due to an API failure.
 STATE_FAILURE: tp.Final[str] = "get_state_failure"
 
 
@@ -62,8 +62,9 @@ class GHIssue:
         """Get issue state.
 
         Returns:
-            The issue state (e.g. "open", `STATE_CLOSED`), `STATE_UNKNOWN` when the issue
-            cannot be found, or `STATE_FAILURE` when the state could not be retrieved.
+            The state as reported by GitHub, e.g. "open" or `STATE_CLOSED`; `STATE_UNKNOWN`
+            when the issue cannot be found, or `STATE_FAILURE` when the state could not
+            be retrieved.
         """
         if not self.github:
             LOGGER.error("Failed to get GitHub instance")

--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -7,6 +7,8 @@ import github
 
 LOGGER = logging.getLogger(__name__)
 
+#: State of a closed issue.
+STATE_CLOSED: tp.Final[str] = "closed"
 #: State reported when the issue cannot be found, e.g. wrong issue number or repo name.
 STATE_UNKNOWN: tp.Final[str] = "unknown"
 #: State reported when the issue state could not be retrieved, e.g. due to an API failure.
@@ -56,17 +58,16 @@ class GHIssue:
     def url(self) -> str:
         return f"https://github.com/{self.repo}/issues/{self.number}"
 
-    def get_state(self) -> str | None:
+    def get_state(self) -> str:
         """Get issue state.
 
         Returns:
-            The issue state (e.g. "open", "closed"), `STATE_UNKNOWN` when the issue cannot
-            be found, `STATE_FAILURE` when the state could not be retrieved, or `None` when
-            the GitHub instance is not available.
+            The issue state (e.g. "open", `STATE_CLOSED`), `STATE_UNKNOWN` when the issue
+            cannot be found, or `STATE_FAILURE` when the state could not be retrieved.
         """
         if not self.github:
             LOGGER.error("Failed to get GitHub instance")
-            return None
+            return STATE_FAILURE
 
         identifier = f"{self.repo}#{self.number}"
         cached_state = self.issue_cache.get(identifier)

--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -7,6 +7,11 @@ import github
 
 LOGGER = logging.getLogger(__name__)
 
+#: State reported when the issue cannot be found, e.g. wrong issue number or repo name.
+STATE_UNKNOWN: tp.Final[str] = "unknown"
+#: State reported when the issue state could not be retrieved, e.g. due to an API failure.
+STATE_FAILURE: tp.Final[str] = "get_state_failure"
+
 
 class GHIssue:
     """GitHub issue."""
@@ -52,7 +57,13 @@ class GHIssue:
         return f"https://github.com/{self.repo}/issues/{self.number}"
 
     def get_state(self) -> str | None:
-        """Get issue state."""
+        """Get issue state.
+
+        Returns:
+            The issue state (e.g. "open", "closed"), `STATE_UNKNOWN` when the issue cannot
+            be found, `STATE_FAILURE` when the state could not be retrieved, or `None` when
+            the GitHub instance is not available.
+        """
         if not self.github:
             LOGGER.error("Failed to get GitHub instance")
             return None
@@ -65,17 +76,14 @@ class GHIssue:
                 cached_state = self.github.get_repo(self.repo).get_issue(self.number).state.lower()
             except github.UnknownObjectException:
                 LOGGER.exception("Unknown issue '%s'", identifier)
-                cached_state = "unknown"
+                cached_state = STATE_UNKNOWN
             except Exception:
                 LOGGER.exception("Failed to get issue '%s'", identifier)
-                cached_state = "get_state_failure"
+                # Don't cache the failure, the retrieval may succeed on the next call
+                return STATE_FAILURE
             self.issue_cache[identifier] = cached_state
 
         return cached_state
-
-    def is_closed(self) -> bool:
-        """Check if issue is closed."""
-        return self.get_state() == "closed"
 
     def __repr__(self) -> str:
         return f"<GHIssue: {self.repo}#{self.number}>"

--- a/framework_tests/test_blockers.py
+++ b/framework_tests/test_blockers.py
@@ -1,0 +1,163 @@
+"""Unit tests for `cardano_node_tests.utils.blockers`.
+
+The tests must not touch the GitHub API. The issue state is controlled by monkeypatching
+`GHIssue.get_state` and the token by monkeypatching `GHIssue.TOKEN`.
+"""
+
+import logging
+
+import pytest
+from packaging import version
+
+from cardano_node_tests.utils import blockers
+from cardano_node_tests.utils import gh_issue
+
+PRODUCT_VERSION = version.parse("2.0.0")
+
+
+@pytest.fixture
+def gh_token(monkeypatch: pytest.MonkeyPatch):
+    """Set a dummy GitHub token so the blocked check is not skipped."""
+    monkeypatch.setattr(gh_issue.GHIssue, "TOKEN", "dummy_token")
+
+
+def _set_state(monkeypatch: pytest.MonkeyPatch, state: str | None) -> None:
+    """Make `GHIssue.get_state` return the given state without any API call."""
+    monkeypatch.setattr(gh_issue.GHIssue, "get_state", lambda self: state)
+
+
+class TestFixedIn:
+    """Tests for the `fixed_in` handling."""
+
+    def test_invalid_fixed_in(self):
+        """Report an invalid `fixed_in` version already when the issue is defined."""
+        with pytest.raises(ValueError, match="Invalid `fixed_in` version for issue 'r/r#1'"):
+            blockers.GH(issue=1, repo="r/r", fixed_in="not-a-version")
+
+    @pytest.mark.usefixtures("gh_token")
+    def test_fixed_in_changed_after_copy(self, monkeypatch: pytest.MonkeyPatch):
+        """Respect a `fixed_in` value that was changed after init."""
+        _set_state(monkeypatch, "closed")
+        issue = blockers.GH(issue=1, fixed_in="1.0.0")
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
+
+        issue_copy = issue.copy()
+        issue_copy.fixed_in = "3.0.0"
+        assert issue_copy._issue_blocked_in_version(PRODUCT_VERSION) is True
+
+
+@pytest.mark.usefixtures("gh_token")
+class TestIsBlocked:
+    """Tests for the issue blocked check."""
+
+    def test_open_issue_is_blocked(self, monkeypatch: pytest.MonkeyPatch):
+        """Treat an open issue as blocked."""
+        _set_state(monkeypatch, "open")
+        issue = blockers.GH(issue=1)
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+
+    def test_closed_issue_is_not_blocked(self, monkeypatch: pytest.MonkeyPatch):
+        """Treat a closed issue without `fixed_in` as not blocked."""
+        _set_state(monkeypatch, "closed")
+        issue = blockers.GH(issue=1)
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
+
+    def test_closed_fixed_in_future_version(self, monkeypatch: pytest.MonkeyPatch):
+        """Treat a closed issue as blocked when the fix is in a newer product version."""
+        _set_state(monkeypatch, "closed")
+        issue = blockers.GH(issue=1, fixed_in="3.0.0")
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+
+    def test_closed_fixed_in_current_version(self, monkeypatch: pytest.MonkeyPatch):
+        """Treat a closed issue as not blocked when the fix is in the current version."""
+        _set_state(monkeypatch, "closed")
+        issue = blockers.GH(issue=1, fixed_in="2.0.0")
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
+
+    def test_nonexistent_issue(self, monkeypatch: pytest.MonkeyPatch):
+        """Raise an error when the issue cannot be found, instead of xfailing forever."""
+        _set_state(monkeypatch, gh_issue.STATE_UNKNOWN)
+        issue = blockers.GH(issue=1, repo="r/r")
+        with pytest.raises(ValueError, match="Issue 'r/r#1' doesn't exist"):
+            issue._issue_blocked_in_version(PRODUCT_VERSION)
+
+    @pytest.mark.parametrize("state", [gh_issue.STATE_FAILURE, None])
+    def test_undetermined_state_is_blocked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        state: str | None,
+    ):
+        """Assume blocked and warn when the issue state could not be determined."""
+        _set_state(monkeypatch, state)
+        issue = blockers.GH(issue=1)
+        with caplog.at_level(logging.WARNING):
+            assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+        assert "Could not determine state" in caplog.text
+
+    def test_no_token_is_blocked(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """Assume blocked and warn when no GitHub token is available."""
+        monkeypatch.setattr(gh_issue.GHIssue, "TOKEN", None)
+        monkeypatch.setattr(
+            gh_issue.GHIssue,
+            "get_state",
+            lambda self: pytest.fail("get_state must not be called"),
+        )
+        issue = blockers.GH(issue=1)
+        with caplog.at_level(logging.WARNING):
+            assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+        assert "No GitHub token provided" in caplog.text
+
+
+@pytest.mark.usefixtures("gh_token")
+class TestFinishTest:
+    """Tests for `GH.finish_test` and the module-level `finish_test`."""
+
+    def test_blocked_issue_xfails(self, monkeypatch: pytest.MonkeyPatch):
+        """Xfail the test when the issue is blocked."""
+        _set_state(monkeypatch, "open")
+        issue = blockers.GH(issue=1, message="msg1")
+        with pytest.raises(pytest.xfail.Exception, match="msg1"):
+            issue.finish_test()
+
+    def test_unblocked_issue_fails(self, monkeypatch: pytest.MonkeyPatch):
+        """Fail the test when the issue is not blocked."""
+        _set_state(monkeypatch, "closed")
+        issue = blockers.GH(issue=1, message="msg1")
+        with pytest.raises(pytest.fail.Exception, match="msg1"):
+            issue.finish_test()
+
+    def test_force_blocked_skips_state_check(self, monkeypatch: pytest.MonkeyPatch):
+        """Xfail without checking the issue state when `force_blocked` is used."""
+        monkeypatch.setattr(
+            gh_issue.GHIssue,
+            "get_state",
+            lambda self: pytest.fail("get_state must not be called"),
+        )
+        issue = blockers.GH(issue=1, message="msg1")
+        with pytest.raises(pytest.xfail.Exception, match="msg1"):
+            issue.finish_test(force_blocked=True)
+
+    def test_no_issues(self):
+        """Reject an empty issues iterable."""
+        with pytest.raises(ValueError, match="No issues were provided"):
+            blockers.finish_test(issues=[])
+
+    def test_all_blocked_xfails(self, monkeypatch: pytest.MonkeyPatch):
+        """Xfail the test when all issues are blocked."""
+        _set_state(monkeypatch, "open")
+        issues = [blockers.GH(issue=1, message="msg1"), blockers.GH(issue=2, message="msg2")]
+        with pytest.raises(pytest.xfail.Exception, match="msg1.*msg2"):
+            blockers.finish_test(issues=issues)
+
+    def test_some_unblocked_fails(self, monkeypatch: pytest.MonkeyPatch):
+        """Fail the test when at least one issue is not blocked."""
+        states = {1: "open", 2: "closed"}
+        monkeypatch.setattr(
+            gh_issue.GHIssue, "get_state", lambda self: states[self.number]
+        )
+        issues = [blockers.GH(issue=1, message="msg1"), blockers.GH(issue=2, message="msg2")]
+        with pytest.raises(pytest.fail.Exception, match="XFAIL.*msg1.*FAIL.*msg2"):
+            blockers.finish_test(issues=issues)

--- a/framework_tests/test_blockers.py
+++ b/framework_tests/test_blockers.py
@@ -14,7 +14,7 @@ PRODUCT_VERSION = version.parse("2.0.0")
 
 
 @pytest.fixture
-def gh_token(monkeypatch: pytest.MonkeyPatch):
+def gh_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set a dummy GitHub token so the blocked check is not skipped."""
     monkeypatch.setattr(gh_issue.GHIssue, "TOKEN", "dummy_token")
 

--- a/framework_tests/test_blockers.py
+++ b/framework_tests/test_blockers.py
@@ -4,8 +4,6 @@ The tests must not touch the GitHub API. The issue state is controlled by monkey
 `GHIssue.get_state` and the token by monkeypatching `GHIssue.TOKEN`.
 """
 
-import logging
-
 import pytest
 from packaging import version
 
@@ -21,9 +19,18 @@ def gh_token(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(gh_issue.GHIssue, "TOKEN", "dummy_token")
 
 
-def _set_state(monkeypatch: pytest.MonkeyPatch, state: str | None) -> None:
+def _set_state(monkeypatch: pytest.MonkeyPatch, state: str) -> None:
     """Make `GHIssue.get_state` return the given state without any API call."""
-    monkeypatch.setattr(gh_issue.GHIssue, "get_state", lambda self: state)
+    monkeypatch.setattr(gh_issue.GHIssue, "get_state", lambda *_a, **_kw: state)
+
+
+def _forbid_get_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make any `GHIssue.get_state` call fail the test."""
+    monkeypatch.setattr(
+        gh_issue.GHIssue,
+        "get_state",
+        lambda *_a, **_kw: pytest.fail("get_state must not be called"),
+    )
 
 
 class TestFixedIn:
@@ -37,13 +44,31 @@ class TestFixedIn:
     @pytest.mark.usefixtures("gh_token")
     def test_fixed_in_changed_after_copy(self, monkeypatch: pytest.MonkeyPatch):
         """Respect a `fixed_in` value that was changed after init."""
-        _set_state(monkeypatch, "closed")
+        _set_state(monkeypatch, gh_issue.STATE_CLOSED)
         issue = blockers.GH(issue=1, fixed_in="1.0.0")
         assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
 
         issue_copy = issue.copy()
         issue_copy.fixed_in = "3.0.0"
         assert issue_copy._issue_blocked_in_version(PRODUCT_VERSION) is True
+
+
+class TestDispatch:
+    """Tests for the `is_blocked` dispatch based on repo."""
+
+    @pytest.mark.parametrize(
+        ("repo", "expected"),
+        [
+            ("IntersectMBO/cardano-cli", "_cli_issue_is_blocked"),
+            ("IntersectMBO/cardano-db-sync", "_dbsync_issue_is_blocked"),
+            ("IntersectMBO/cardano-node", "_issue_is_blocked"),
+            ("IntersectMBO/ouroboros-consensus", "_issue_is_blocked"),
+        ],
+    )
+    def test_is_blocked_dispatch(self, repo: str, expected: str):
+        """Select the version check that corresponds to the repo."""
+        issue = blockers.GH(issue=1, repo=repo)
+        assert issue.is_blocked.__name__ == expected
 
 
 @pytest.mark.usefixtures("gh_token")
@@ -58,19 +83,19 @@ class TestIsBlocked:
 
     def test_closed_issue_is_not_blocked(self, monkeypatch: pytest.MonkeyPatch):
         """Treat a closed issue without `fixed_in` as not blocked."""
-        _set_state(monkeypatch, "closed")
+        _set_state(monkeypatch, gh_issue.STATE_CLOSED)
         issue = blockers.GH(issue=1)
         assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
 
     def test_closed_fixed_in_future_version(self, monkeypatch: pytest.MonkeyPatch):
         """Treat a closed issue as blocked when the fix is in a newer product version."""
-        _set_state(monkeypatch, "closed")
+        _set_state(monkeypatch, gh_issue.STATE_CLOSED)
         issue = blockers.GH(issue=1, fixed_in="3.0.0")
         assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
 
     def test_closed_fixed_in_current_version(self, monkeypatch: pytest.MonkeyPatch):
         """Treat a closed issue as not blocked when the fix is in the current version."""
-        _set_state(monkeypatch, "closed")
+        _set_state(monkeypatch, gh_issue.STATE_CLOSED)
         issue = blockers.GH(issue=1, fixed_in="2.0.0")
         assert issue._issue_blocked_in_version(PRODUCT_VERSION) is False
 
@@ -81,18 +106,13 @@ class TestIsBlocked:
         with pytest.raises(ValueError, match="Issue 'r/r#1' doesn't exist"):
             issue._issue_blocked_in_version(PRODUCT_VERSION)
 
-    @pytest.mark.parametrize("state", [gh_issue.STATE_FAILURE, None])
     def test_undetermined_state_is_blocked(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
-        state: str | None,
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):
         """Assume blocked and warn when the issue state could not be determined."""
-        _set_state(monkeypatch, state)
+        _set_state(monkeypatch, gh_issue.STATE_FAILURE)
         issue = blockers.GH(issue=1)
-        with caplog.at_level(logging.WARNING):
-            assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
         assert "Could not determine state" in caplog.text
 
     def test_no_token_is_blocked(
@@ -100,14 +120,9 @@ class TestIsBlocked:
     ):
         """Assume blocked and warn when no GitHub token is available."""
         monkeypatch.setattr(gh_issue.GHIssue, "TOKEN", None)
-        monkeypatch.setattr(
-            gh_issue.GHIssue,
-            "get_state",
-            lambda self: pytest.fail("get_state must not be called"),
-        )
+        _forbid_get_state(monkeypatch)
         issue = blockers.GH(issue=1)
-        with caplog.at_level(logging.WARNING):
-            assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
+        assert issue._issue_blocked_in_version(PRODUCT_VERSION) is True
         assert "No GitHub token provided" in caplog.text
 
 
@@ -124,24 +139,20 @@ class TestFinishTest:
 
     def test_unblocked_issue_fails(self, monkeypatch: pytest.MonkeyPatch):
         """Fail the test when the issue is not blocked."""
-        _set_state(monkeypatch, "closed")
+        _set_state(monkeypatch, gh_issue.STATE_CLOSED)
         issue = blockers.GH(issue=1, message="msg1")
         with pytest.raises(pytest.fail.Exception, match="msg1"):
             issue.finish_test()
 
     def test_force_blocked_skips_state_check(self, monkeypatch: pytest.MonkeyPatch):
         """Xfail without checking the issue state when `force_blocked` is used."""
-        monkeypatch.setattr(
-            gh_issue.GHIssue,
-            "get_state",
-            lambda self: pytest.fail("get_state must not be called"),
-        )
+        _forbid_get_state(monkeypatch)
         issue = blockers.GH(issue=1, message="msg1")
         with pytest.raises(pytest.xfail.Exception, match="msg1"):
             issue.finish_test(force_blocked=True)
 
     def test_no_issues(self):
-        """Reject an empty issues iterable."""
+        """Reject an empty issues collection."""
         with pytest.raises(ValueError, match="No issues were provided"):
             blockers.finish_test(issues=[])
 
@@ -149,15 +160,13 @@ class TestFinishTest:
         """Xfail the test when all issues are blocked."""
         _set_state(monkeypatch, "open")
         issues = [blockers.GH(issue=1, message="msg1"), blockers.GH(issue=2, message="msg2")]
-        with pytest.raises(pytest.xfail.Exception, match="msg1.*msg2"):
+        with pytest.raises(pytest.xfail.Exception, match=r"msg1.*msg2"):
             blockers.finish_test(issues=issues)
 
     def test_some_unblocked_fails(self, monkeypatch: pytest.MonkeyPatch):
         """Fail the test when at least one issue is not blocked."""
-        states = {1: "open", 2: "closed"}
-        monkeypatch.setattr(
-            gh_issue.GHIssue, "get_state", lambda self: states[self.number]
-        )
+        states = {1: "open", 2: gh_issue.STATE_CLOSED}
+        monkeypatch.setattr(gh_issue.GHIssue, "get_state", lambda self: states[self.number])
         issues = [blockers.GH(issue=1, message="msg1"), blockers.GH(issue=2, message="msg2")]
-        with pytest.raises(pytest.fail.Exception, match="XFAIL.*msg1.*FAIL.*msg2"):
+        with pytest.raises(pytest.fail.Exception, match=r"XFAIL.*msg1.*FAIL.*msg2"):
             blockers.finish_test(issues=issues)

--- a/framework_tests/test_gh_issue.py
+++ b/framework_tests/test_gh_issue.py
@@ -4,6 +4,7 @@ The tests must not touch the GitHub API. The `GHIssue._get_github` classmethod i
 monkeypatched with a fake that returns canned issue states.
 """
 
+import types
 import typing as tp
 
 import github
@@ -16,18 +17,18 @@ class _FakeGithub:
     """Fake `github.Github` returning canned issue states and counting API calls."""
 
     def __init__(self, responses: tp.Sequence[str | Exception]) -> None:
-        self.responses = list(responses)
+        self.responses = iter(responses)
         self.calls = 0
 
-    def get_repo(self, _repo: str) -> "_FakeGithub":
+    def get_repo(self, _repo: str) -> tp.Self:
         return self
 
-    def get_issue(self, _number: int) -> tp.Any:
+    def get_issue(self, _number: int) -> types.SimpleNamespace:
         self.calls += 1
-        response = self.responses.pop(0)
+        response = next(self.responses)
         if isinstance(response, Exception):
             raise response
-        return type("FakeIssue", (), {"state": response})
+        return types.SimpleNamespace(state=response)
 
 
 @pytest.fixture

--- a/framework_tests/test_gh_issue.py
+++ b/framework_tests/test_gh_issue.py
@@ -1,0 +1,80 @@
+"""Unit tests for `cardano_node_tests.utils.gh_issue`.
+
+The tests must not touch the GitHub API. The `GHIssue._get_github` classmethod is
+monkeypatched with a fake that returns canned issue states.
+"""
+
+import typing as tp
+
+import github
+import pytest
+
+from cardano_node_tests.utils import gh_issue
+
+
+class _FakeGithub:
+    """Fake `github.Github` returning canned issue states and counting API calls."""
+
+    def __init__(self, responses: tp.Sequence[str | Exception]) -> None:
+        self.responses = list(responses)
+        self.calls = 0
+
+    def get_repo(self, _repo: str) -> "_FakeGithub":
+        return self
+
+    def get_issue(self, _number: int) -> tp.Any:
+        self.calls += 1
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return type("FakeIssue", (), {"state": response})
+
+
+@pytest.fixture
+def clean_cache(monkeypatch: pytest.MonkeyPatch):
+    """Give each test a fresh issue cache."""
+    monkeypatch.setattr(gh_issue.GHIssue, "issue_cache", {})
+
+
+def _set_github(monkeypatch: pytest.MonkeyPatch, fake: _FakeGithub | None) -> None:
+    """Make `GHIssue` use the given fake GitHub instance."""
+    monkeypatch.setattr(gh_issue.GHIssue, "_get_github", classmethod(lambda _cls: fake))
+
+
+@pytest.mark.usefixtures("clean_cache")
+class TestGetState:
+    """Tests for `GHIssue.get_state`."""
+
+    def test_state_cached(self, monkeypatch: pytest.MonkeyPatch):
+        """Retrieve the state once and serve subsequent calls from the cache."""
+        fake = _FakeGithub(responses=["CLOSED"])
+        _set_github(monkeypatch, fake)
+        issue = gh_issue.GHIssue(number=1, repo="r/r")
+        assert issue.get_state() == gh_issue.STATE_CLOSED
+        assert issue.get_state() == gh_issue.STATE_CLOSED
+        assert fake.calls == 1
+
+    def test_unknown_issue_cached(self, monkeypatch: pytest.MonkeyPatch):
+        """Cache the state of a nonexistent issue, it cannot appear later."""
+        fake = _FakeGithub(responses=[github.UnknownObjectException(status=404)])
+        _set_github(monkeypatch, fake)
+        issue = gh_issue.GHIssue(number=1, repo="r/r")
+        assert issue.get_state() == gh_issue.STATE_UNKNOWN
+        assert issue.get_state() == gh_issue.STATE_UNKNOWN
+        assert fake.calls == 1
+
+    def test_transient_failure_not_cached(self, monkeypatch: pytest.MonkeyPatch):
+        """Don't cache a failed state retrieval, the next call may succeed."""
+        fake = _FakeGithub(responses=[RuntimeError("API is down"), "OPEN"])
+        _set_github(monkeypatch, fake)
+        issue = gh_issue.GHIssue(number=1, repo="r/r")
+        assert issue.get_state() == gh_issue.STATE_FAILURE
+        assert not gh_issue.GHIssue.issue_cache
+        assert issue.get_state() == "open"
+        assert fake.calls == 2
+
+    def test_no_github_instance(self, monkeypatch: pytest.MonkeyPatch):
+        """Report a state retrieval failure when the GitHub instance is not available."""
+        _set_github(monkeypatch, None)
+        issue = gh_issue.GHIssue(number=1, repo="r/r")
+        assert issue.get_state() == gh_issue.STATE_FAILURE

--- a/framework_tests/test_gh_issue.py
+++ b/framework_tests/test_gh_issue.py
@@ -32,7 +32,7 @@ class _FakeGithub:
 
 
 @pytest.fixture
-def clean_cache(monkeypatch: pytest.MonkeyPatch):
+def clean_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """Give each test a fresh issue cache."""
     monkeypatch.setattr(gh_issue.GHIssue, "issue_cache", {})
 


### PR DESCRIPTION
## Summary

Fixes several silent-failure modes in `blockers.py` / `gh_issue.py` and adds unit test
coverage for both modules.

### Bug fixes

- **Nonexistent issue no longer silently xfails forever.** A typo in an issue number or
  repo name used to be treated as an open issue, so the test was xfailed indefinitely
  with no signal. It now raises `ValueError` pointing at the bad reference.
- **Undetermined issue state is now logged.** When the state cannot be retrieved (API
  failure, rate limiting, missing GitHub instance), the issue is still conservatively
  treated as blocked, but a warning is logged instead of pretending the issue is known
  to be open.
- **Transient API failures are no longer cached for the whole session.** Previously a
  single rate-limit burst or network blip marked the issue as failed for the entire
  pytest run, silencing all subsequent logging. Retrieval is now retried on the next
  call and the failure is logged on every attempt.
- **Invalid `fixed_in` version fails at issue definition time** (import of `issues.py`,
  i.e. test collection) with the issue reference in the error message, instead of
  surfacing as a confusing `InvalidVersion` inside the first test that runs the check.
- **`finish_test()` with an empty issue list raises `ValueError`** instead of xfailing
  the test with an empty reason, and the check runs before any GitHub API call.

### Documentation

- Corrected the `fixed_in` docstring: it claimed the value is ignored on unknown
  projects, but it is in fact compared against the cardano-node version, which is what
  the existing issue definitions rely on (e.g. `consensus_*`, `ledger_*`).
- Added missing `Args`/`Returns`/`Raises` docstring sections and fixed stale comments.

### Refactoring

- Named state sentinels (`STATE_CLOSED`, `STATE_UNKNOWN`, `STATE_FAILURE`) in
  `gh_issue` replace bare strings shared across the two modules.
- `get_state()` always returns `str`; the `None` case (no GitHub instance) is folded
  into `STATE_FAILURE`, which the only caller handled identically anyway.
- Removed the now-unused `GHIssue.is_closed()`.

### Tests

- New `framework_tests/test_blockers.py`: eager `fixed_in` validation, the blocked
  check for all issue states, version comparison, the no-token path, repo-to-version
  dispatch, and both `finish_test` variants (GitHub API fully mocked).
- New `framework_tests/test_gh_issue.py`: `get_state` caching semantics, including
  that transient failures are not cached.

### Notes for reviewers

- `force_blocked=True` still skips the issue existence check on purpose: that path
  deliberately avoids any API dependence.
- Possibly stale data noticed while reviewing (not touched in this PR): `api_829`
  (`fixed_in="10.5.0.0"`) and `api_1261` (`fixed_in="11.0.2"`) in `tests/issues.py`
  look like cardano-api release numbers, but the value is compared against the
  cardano-node version. Worth double-checking which product version was meant.