### PR TITLE
feat(runner): give .bin binaries priority and skip their builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,15 @@ Or run the upgrade test suite:
 
 ## 🧪 Running Individual Tests with Custom Binaries
 
-1. Add your custom `cardano-cli` / `cardano-node` binaries to the `.bin` directory.
+1. Create the `.bin` directory in the repo root and add your custom `cardano-cli` /
+   `cardano-node` / `cardano-db-sync` binaries there.
+
+   > ℹ️ **Note:** When running in a container via `runner/runc.sh`, `.bin` entries
+   > must be statically linked binaries, or - for containers that bind-mount the
+   > host `/nix` store (the default when the host has `/nix`) - symlinks pointing
+   > directly into `/nix` or binaries whose dynamic dependencies all live under
+   > `/nix`. A NixOS container has its own `/nix` store, so only statically linked
+   > binaries work there.
 
 2. Run a specific test:
 

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -18,7 +18,18 @@ readonly REPODIR
 cd "$REPODIR"
 
 export WORKDIR="$REPODIR/run_workdir"
-export PATH_PREPEND="${PWD}/.bin"
+
+# Usable executables present in `.bin` take priority over the binaries built
+# by this script, and their (nix) build is skipped. For db-sync, the repo is
+# still cloned (schema files are needed) and the release tarball path is
+# unaffected (`.bin` still wins in PATH).
+# The built bin dirs are appended to PATH_PREPEND in setup order. Their
+# relative order mostly doesn't matter, as each nix build output contains a
+# single executable; the db-sync release-tarball bin dir can contain several,
+# which is one reason why the db-sync setup runs last.
+BIN_DIR="${REPODIR}/.bin"
+readonly BIN_DIR
+export PATH_PREPEND="$BIN_DIR"
 
 # shellcheck disable=SC1091
 . scripts/common.sh
@@ -27,6 +38,44 @@ if is_venv_active; then
   echo "This script should be run outside of any virtual environment." >&2
   exit 1
 fi
+
+# Categorize `.bin` entries. Usable executables take priority on PATH. Entries
+# that PATH lookup cannot use (no exec bit, directories, dangling symlinks)
+# are merely ignored. An executable regular file that is not a usable binary
+# (e.g. an empty file) would still shadow the built binaries on PATH, so it is
+# a fatal error.
+_bin_usable=()
+_bin_ignored=()
+_bin_dangerous=()
+for _f in "$BIN_DIR"/*; do
+  { [ -e "$_f" ] || [ -L "$_f" ]; } || continue  # skip unmatched glob
+  if is_usable_binary "$_f"; then
+    _bin_usable+=("${_f##*/}")
+  elif [ -f "$_f" ] && [ -x "$_f" ]; then
+    _bin_dangerous+=("${_f##*/}")
+  else
+    _bin_ignored+=("${_f##*/}")
+  fi
+done
+if [ "${#_bin_dangerous[@]}" -gt 0 ]; then
+  {
+    echo "Error: executable but unusable entries in ${BIN_DIR} would shadow the built binaries on PATH:"
+    printf '%s\n' "${_bin_dangerous[@]}"
+  } >&2
+  exit 1
+fi
+if [ "${#_bin_usable[@]}" -gt 0 ]; then
+  echo
+  echo "WARNING: using following binaries from ${BIN_DIR}:"
+  printf '%s\n' "${_bin_usable[@]}"
+  echo
+fi
+if [ "${#_bin_ignored[@]}" -gt 0 ]; then
+  echo "WARNING: ignoring unusable entries in ${BIN_DIR} (not an executable regular file; invisible to PATH lookup):"
+  printf '%s\n' "${_bin_ignored[@]}"
+  echo
+fi
+unset _bin_usable _bin_ignored _bin_dangerous _f
 
 # Refuse to start if another testrun is already using this workdir.
 # `lock_fd` is set so background processes (e.g. monitor_system) can drop the
@@ -51,6 +100,10 @@ mkdir -p "$TMPDIR"
 export ARTIFACTS_DIR="${WORKDIR}/artifacts"
 export COVERAGE_DIR="${WORKDIR}/cli_coverage"
 export REPORTS_DIR="${WORKDIR}/reports"
+# Create the dirs upfront so that consumers like `grep_errors.sh` don't fail
+# (and mask the real exit code) when a setup error prevents the testrun from
+# ever starting.
+mkdir -p "$ARTIFACTS_DIR" "$COVERAGE_DIR" "$REPORTS_DIR"
 
 export SCHEDULING_LOG="${WORKDIR}/scheduling.log"
 : > "$SCHEDULING_LOG"
@@ -103,20 +156,8 @@ fi
 
 echo "### Dependencies setup ###"
 
-# setup dbsync (disabled by default)
-case "${DBSYNC_REV:-}" in
-  "" )
-    ;;
-  "none" )
-    unset DBSYNC_REV
-    ;;
-  * )
-    # shellcheck disable=SC1091
-    . runner/source_dbsync.sh
-    ;;
-esac
-
-# setup cardano-cli (use the built-in version by default)
+# setup cardano-cli (use the built-in version by default; a binary in `.bin`
+# takes priority over either)
 case "${CARDANO_CLI_REV:-}" in
   "" )
     ;;
@@ -124,11 +165,21 @@ case "${CARDANO_CLI_REV:-}" in
     unset CARDANO_CLI_REV
     ;;
   * )
-    # shellcheck disable=SC1091
-    . runner/source_cardano_cli.sh
-    cardano_cli_build "$CARDANO_CLI_REV"
-    PATH_PREPEND="$(cardano_cli_print_path_prepend "")${PATH_PREPEND}"
-    export PATH_PREPEND
+    if is_usable_binary "${BIN_DIR}/cardano-cli"; then
+      echo "Skipping build of 'cardano-cli'"
+      report_existing_binary "${BIN_DIR}/cardano-cli" || exit 1
+    else
+      # shellcheck disable=SC1091
+      . runner/source_cardano_cli.sh
+      cardano_cli_build "$CARDANO_CLI_REV"
+      _cli_bins="$(cardano_cli_print_path_prepend "")"
+      _cli_bins="${_cli_bins%:}"
+      if [ -n "$_cli_bins" ]; then
+        PATH_PREPEND="${PATH_PREPEND}:${_cli_bins}"
+      fi
+      export PATH_PREPEND
+      unset _cli_bins
+    fi
     ;;
 esac
 
@@ -140,18 +191,47 @@ case "${NODE_REV:-}" in
 esac
 # shellcheck disable=SC1091
 . runner/source_cardano_node.sh
-cardano_bins_build_all "$NODE_REV" "${CARDANO_CLI_REV:-}"
-PATH_PREPEND="$(cardano_bins_print_path_prepend "${CARDANO_CLI_REV:-}")${PATH_PREPEND}"
+cardano_bins_build_all "$NODE_REV" "${CARDANO_CLI_REV:-}" "" "$BIN_DIR"
+_node_bins="$(cardano_bins_print_path_prepend "${CARDANO_CLI_REV:-}" "" "$BIN_DIR")"
+_node_bins="${_node_bins%:}"
+if [ -n "$_node_bins" ]; then
+  PATH_PREPEND="${PATH_PREPEND}:${_node_bins}"
+fi
 export PATH_PREPEND
+unset _node_bins
 
 # setup tx-centrifuge (only when it is enabled); it lives on its own cardano-node ref
 if is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
-  # shellcheck disable=SC1091
-  . runner/source_tx_centrifuge.sh
-  tx_centrifuge_build "${TX_CENTRIFUGE_REV:-bench/leios-11.0.1}"
-  PATH_PREPEND="$(tx_centrifuge_print_path_prepend "")${PATH_PREPEND}"
-  export PATH_PREPEND
+  if is_usable_binary "${BIN_DIR}/tx-centrifuge"; then
+    echo "Skipping build of 'tx-centrifuge'"
+    report_existing_binary "${BIN_DIR}/tx-centrifuge" || exit 1
+  else
+    # shellcheck disable=SC1091
+    . runner/source_tx_centrifuge.sh
+    tx_centrifuge_build "${TX_CENTRIFUGE_REV:-bench/leios-11.0.1}"
+    _centrifuge_bins="$(tx_centrifuge_print_path_prepend "")"
+    _centrifuge_bins="${_centrifuge_bins%:}"
+    if [ -n "$_centrifuge_bins" ]; then
+      PATH_PREPEND="${PATH_PREPEND}:${_centrifuge_bins}"
+    fi
+    export PATH_PREPEND
+    unset _centrifuge_bins
+  fi
 fi
+
+# setup dbsync (disabled by default); placed after the node/cli setup so its
+# bin dirs come after theirs in PATH_PREPEND
+case "${DBSYNC_REV:-}" in
+  "" )
+    ;;
+  "none" )
+    unset DBSYNC_REV
+    ;;
+  * )
+    # shellcheck disable=SC1091
+    . runner/source_dbsync.sh
+    ;;
+esac
 
 # optimize nix store if running in GitHub Actions
 if [ -n "${GITHUB_ACTIONS:-}" ]; then
@@ -237,13 +317,6 @@ echo "::endgroup::"  # end group for "Script setup"
 echo "::group::Nix env setup"
 printf "start: %(%H:%M:%S)T\n" -1
 
-if [ "$(echo "$PWD"/.bin/*)" != "${PWD}/.bin/*" ]; then
-  echo
-  echo "WARNING: using following binaries from ${PWD}/.bin:"
-  ls -1 "${PWD}/.bin"
-  echo
-fi
-
 # Function to monitor system resources and log them every 10 minutes
 monitor_system() {
   # Drop the inherited workdir lock FD so this background subshell does not
@@ -310,6 +383,21 @@ nix develop --accept-flake-config .#testenv --command bash -c '
   df -h .
   export PATH="$PATH_PREPEND":"$PATH"
   export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
+
+  # Source the helpers explicitly rather than relying on setup_venv.sh doing
+  # it transitively.
+  . scripts/common.sh
+
+  # Re-verify that all required binaries are available on the final PATH.
+  # Entries in `.bin` are user-managed and could have changed since the
+  # setup-time checks. Exit code 3 distinguishes this setup failure from
+  # pytest'\''s "some tests failed" (1).
+  _req_cmds=( cardano-node cardano-cli cardano-submit-api bech32 tx-generator )
+  if [ -n "${DBSYNC_REV:-}" ]; then _req_cmds+=( cardano-db-sync ); fi
+  if is_truthy "${SMASH:-}"; then _req_cmds+=( cardano-smash-server ); fi
+  if is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then _req_cmds+=( tx-centrifuge ); fi
+  assert_cmds_available "${_req_cmds[@]}" || exit 3
+
   retval=0
   ./runner/run_tests.sh "${RUN_TARGET:-"tests"}" || retval="$?"
   df -h .
@@ -331,7 +419,7 @@ if is_truthy "${KEEP_CLUSTERS_RUNNING:-}"; then
   echo
   echo "KEEP_CLUSTERS_RUNNING is set, leaving clusters running until any key is pressed."
   echo "Press any key to continue..."
-  read -r
+  read -r || :
 fi
 
 _last_cleanup

--- a/runner/source_cardano_node.sh
+++ b/runner/source_cardano_node.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-# Build all required binaries into $WORKDIR/*-build<postfix>
+# Build all required binaries into $WORKDIR/*-build<postfix>.
+# When `skip_bindir` (absolute path) is given, usable executables already
+# present there are not built. The `skip_bindir` support requires
+# `is_usable_binary` and `report_existing_binary` from `scripts/common.sh`.
 cardano_bins_build_all() {
   : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local node_rev="${1:?}"
   local cli_rev="${2:-}"
   local node_bindir_postfix="${3:-}"
+  local skip_bindir="${4:-}"
   local origpwd="$PWD"
 
   if [ -z "$node_rev" ]; then
@@ -19,6 +23,12 @@ cardano_bins_build_all() {
     local flake_attr="$1"   # e.g. cardano-node
     local exe="$2"          # e.g. cardano-node
     local out="${flake_attr}-build${node_bindir_postfix}"
+
+    if [ -n "$skip_bindir" ] && is_usable_binary "${skip_bindir}/${exe}"; then
+      echo "Skipping build of '${exe}'"
+      report_existing_binary "${skip_bindir}/${exe}" || return 1
+      return 0
+    fi
 
     nix build \
       --accept-flake-config \
@@ -41,11 +51,17 @@ cardano_bins_build_all() {
   cd "$origpwd" || return 1
 }
 
-# Print PATH to prepend based on previously built outputs
+# Print PATH to prepend based on previously built outputs.
+# When `skip_bindir` (absolute path) is given, entries for usable executables
+# already present there are omitted (their build was skipped in
+# `cardano_bins_build_all`). The `skip_bindir` support requires
+# `is_usable_binary` from `scripts/common.sh`.
+# The output may be empty when all binaries are present in `skip_bindir`.
 cardano_bins_print_path_prepend() {
   : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
   local cli_rev="${1:-}"
   local node_bindir_postfix="${2:-}"
+  local skip_bindir="${3:-}"
   local origpwd="$PWD"
 
   cd "$WORKDIR" || return 1
@@ -54,20 +70,28 @@ cardano_bins_print_path_prepend() {
 
   _cardano_bins_add_bin_dir() {
     local out_prefix="$1"
+    local exe="$2"
     local out="${out_prefix}-build${node_bindir_postfix}"
     local bin_dir
 
-    bin_dir="$(readlink -f "${out}/bin")" || return 1
+    if [ -n "$skip_bindir" ] && is_usable_binary "${skip_bindir}/${exe}"; then
+      return 0
+    fi
+
+    bin_dir="$(readlink -f "${out}/bin")" || {
+      echo "Missing build output '${out}/bin' for '${exe}'" >&2
+      return 1
+    }
     node_path_prepend="${node_path_prepend:+"${node_path_prepend}:"}${bin_dir}"
   }
 
-  _cardano_bins_add_bin_dir "cardano-node" || { cd "$origpwd" || true; return 1; }
-  _cardano_bins_add_bin_dir "cardano-submit-api" || { cd "$origpwd" || true; return 1; }
-  _cardano_bins_add_bin_dir "bech32" || { cd "$origpwd" || true; return 1; }
-  _cardano_bins_add_bin_dir "tx-generator" || { cd "$origpwd" || true; return 1; }
+  _cardano_bins_add_bin_dir "cardano-node" "cardano-node" || { cd "$origpwd" || true; return 1; }
+  _cardano_bins_add_bin_dir "cardano-submit-api" "cardano-submit-api" || { cd "$origpwd" || true; return 1; }
+  _cardano_bins_add_bin_dir "bech32" "bech32" || { cd "$origpwd" || true; return 1; }
+  _cardano_bins_add_bin_dir "tx-generator" "tx-generator" || { cd "$origpwd" || true; return 1; }
 
   if [ -z "$cli_rev" ]; then
-    _cardano_bins_add_bin_dir "cardano-cli" || { cd "$origpwd" || true; return 1; }
+    _cardano_bins_add_bin_dir "cardano-cli" "cardano-cli" || { cd "$origpwd" || true; return 1; }
   fi
 
   cd "$origpwd" || return 1

--- a/runner/source_dbsync.sh
+++ b/runner/source_dbsync.sh
@@ -2,6 +2,16 @@
 
 : "${WORKDIR:?"WORKDIR must be set to a writable directory"}"
 : "${REPODIR:?"REPODIR must be set to the root of the cardano-node repository"}"
+
+# This script relies on helpers from `scripts/common.sh`, sourced by the
+# calling script.
+for _helper in is_truthy is_usable_binary report_existing_binary; do
+  if ! command -v "$_helper" >/dev/null 2>&1; then
+    echo "scripts/common.sh must be sourced before this script ('$_helper' is missing)" >&2
+    exit 1
+  fi
+done
+unset _helper
 TEST_THREADS="${TEST_THREADS:-15}"
 CLUSTERS_COUNT="${CLUSTERS_COUNT:-4}"
 export TEST_THREADS CLUSTERS_COUNT
@@ -59,8 +69,16 @@ if [[ -z "$DBSYNC_TAR_URL" && "$DBSYNC_REV" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
   fi
 fi
 
+# Whether the nix build of `cardano-db-sync` / `cardano-smash-server` was
+# skipped in favor of a `BIN_DIR` binary (build-from-source path only).
+# Controls the existence asserts and PATH_PREPEND appends below.
+_dbsync_from_bin_dir=0
+_smash_from_bin_dir=0
+
 if [ -n "${DBSYNC_TAR_URL:-}" ]; then
-  # Download db-sync
+  # Download db-sync. The tarball is always downloaded (it also provides the
+  # schema files), but binaries from the `BIN_DIR` directory still take PATH
+  # priority over the downloaded ones.
   dbsync_tar_file="${WORKDIR}/dbsync_bins.tar.gz"
   curl -sSL "$DBSYNC_TAR_URL" > "$dbsync_tar_file" || exit 1
   rm -rf dbsync_download
@@ -74,8 +92,20 @@ if [ -n "${DBSYNC_TAR_URL:-}" ]; then
   rm -f smash-server || rm -f smash-server/bin/cardano-smash-server
   mkdir -p smash-server/bin
   ln -s "${WORKDIR}/dbsync_download/bin/cardano-smash-server" smash-server/bin/cardano-smash-server || exit 1
+
+  # Report `BIN_DIR` binaries that will shadow the downloaded ones on PATH
+  if [ -n "${BIN_DIR:-}" ] && is_usable_binary "${BIN_DIR}/cardano-db-sync"; then
+    report_existing_binary "${BIN_DIR}/cardano-db-sync" || exit 1
+    echo "NOTE: db-sync schema files are taken from the release tarball;" \
+      "make sure they match the binary version above"
+  fi
+  if [ -n "${BIN_DIR:-}" ] && is_usable_binary "${BIN_DIR}/cardano-smash-server"; then
+    report_existing_binary "${BIN_DIR}/cardano-smash-server" || exit 1
+  fi
 else
-  # Build db-sync
+  # Build db-sync from source. The nix build may be skipped in favor of a
+  # binary from the `BIN_DIR` directory, but the repo is still cloned for the
+  # schema files.
   case "${DBSYNC_REV:-}" in
     "" )
       echo "The value for DBSYNC_REV cannot be empty" >&2
@@ -107,14 +137,31 @@ else
   git checkout "$DBSYNC_REV"
   git rev-parse HEAD
 
-  # Build cardano-db-sync
-  nix build --accept-flake-config .#cardano-db-sync -o "${WORKDIR}/db-sync-node" \
-    || nix build --accept-flake-config .#cardano-db-sync:exe:cardano-db-sync -o "${WORKDIR}/db-sync-node" \
-    || exit 1
+  # Build cardano-db-sync, unless a usable executable is already present in the
+  # `BIN_DIR` directory. The repo above is cloned even when the build is
+  # skipped, as the schema files are needed in any case.
+  if [ -n "${BIN_DIR:-}" ] && is_usable_binary "${BIN_DIR}/cardano-db-sync"; then
+    echo "Skipping build of 'cardano-db-sync'"
+    report_existing_binary "${BIN_DIR}/cardano-db-sync" || exit 1
+    echo "NOTE: db-sync schema files are taken from DBSYNC_REV=${DBSYNC_REV};" \
+      "make sure they match the binary version above"
+    _dbsync_from_bin_dir=1
+  else
+    nix build --accept-flake-config .#cardano-db-sync -o "${WORKDIR}/db-sync-node" \
+      || nix build --accept-flake-config .#cardano-db-sync:exe:cardano-db-sync -o "${WORKDIR}/db-sync-node" \
+      || exit 1
+  fi
 
-  # Build cardano-smash-server
+  # Build cardano-smash-server, unless a usable executable is already present
+  # in the `BIN_DIR` directory
   if is_truthy "${SMASH:-}"; then
-    nix build --accept-flake-config .#cardano-smash-server -o "${WORKDIR}/smash-server" || exit 1
+    if [ -n "${BIN_DIR:-}" ] && is_usable_binary "${BIN_DIR}/cardano-smash-server"; then
+      echo "Skipping build of 'cardano-smash-server'"
+      report_existing_binary "${BIN_DIR}/cardano-smash-server" || exit 1
+      _smash_from_bin_dir=1
+    else
+      nix build --accept-flake-config .#cardano-smash-server -o "${WORKDIR}/smash-server" || exit 1
+    fi
   fi
 
   mv "$PWD/schema" "${WORKDIR}/db-sync-schema"
@@ -125,21 +172,27 @@ else
   rm -rf cardano-db-sync # Save space by removing the source code
 fi
 
-if [ ! -e "${WORKDIR}/db-sync-node/bin/cardano-db-sync" ]; then
+if [ "$_dbsync_from_bin_dir" -eq 0 ] && [ ! -e "${WORKDIR}/db-sync-node/bin/cardano-db-sync" ]; then
   echo "The \`cardano-db-sync\` binary not found, line $LINENO in sourced db-sync setup" >&2  # assert
   exit 1
 fi
-if is_truthy "${SMASH:-}" && [ ! -e "${WORKDIR}/smash-server/bin/cardano-smash-server" ]; then
+if is_truthy "${SMASH:-}" && [ "$_smash_from_bin_dir" -eq 0 ] \
+    && [ ! -e "${WORKDIR}/smash-server/bin/cardano-smash-server" ]; then
   echo "The \`cardano-smash-server\` binary not found, line $LINENO in sourced db-sync setup" >&2  # assert
   exit 1
 fi
 
-# Add `cardano-db-sync` and `cardano-smash-server` to PATH_PREPEND
-PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -f "${WORKDIR}/db-sync-node/bin")"
-if [ -e smash-server/bin/cardano-smash-server ]; then
+# Add `cardano-db-sync` and `cardano-smash-server` to PATH_PREPEND. Skipped for
+# binaries that come from the `BIN_DIR` directory, which the calling script is
+# expected to have put on PATH_PREPEND already.
+if [ "$_dbsync_from_bin_dir" -eq 0 ]; then
+  PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -f "${WORKDIR}/db-sync-node/bin")"
+fi
+if [ "$_smash_from_bin_dir" -eq 0 ] && [ -e smash-server/bin/cardano-smash-server ]; then
   PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -f "${WORKDIR}/smash-server/bin")"
 fi
 export PATH_PREPEND
+unset _dbsync_from_bin_dir _smash_from_bin_dir
 
 # Remove migration files that create indexes
 if [ -n "${DBSYNC_SKIP_INDEXES:-}" ]; then

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -18,6 +18,62 @@ is_venv_active() {
   [ -n "${VIRTUAL_ENV:-}" ]
 }
 
+# Check that the given path is a usable executable: a regular non-empty file
+# (or a symlink to one) with the executable bit set. Rules out directories,
+# dangling symlinks, empty files and symlinks to directories (e.g. a
+# `nix build -o` result pointing to a store output dir).
+is_usable_binary() {
+  local bin="${1:?Missing binary path}"
+  [ -f "$bin" ] && [ -s "$bin" ] && [ -x "$bin" ]
+}
+
+# Report that an existing binary (given as an absolute path, typically in the
+# `.bin` dir) will be used instead of a built one, and log its version
+# (best effort) for traceability.
+# Fails when the binary cannot run at all (e.g. wrong architecture, missing
+# dynamic libraries, or crashing on startup), because such a binary would
+# still shadow working ones on PATH.
+report_existing_binary() {
+  local bin="${1:?Missing binary path}"
+  local rc=0 ver
+  echo "Using existing binary '$bin'"
+  # Probe from `/` so a binary that writes state files to its cwd on startup
+  # cannot pollute the caller's working directory.
+  ver="$(cd / && timeout -k 5 10 "$bin" --version </dev/null 2>&1)" || rc="$?"
+  ver="${ver%%$'\n'*}"
+  # 124 is a `--version` timeout and 137 its SIGKILL escalation (both
+  # tolerated, same as a binary that doesn't support `--version`); other
+  # 125+ statuses mean the binary could not run (126/127) or died from
+  # a signal (128+N), or `timeout` itself failed (125).
+  if [ "$rc" -ge 125 ] && [ "$rc" -ne 137 ]; then
+    echo "Error: '$bin' is not runnable (exit status ${rc}): ${ver:-no output}" >&2
+    return 1
+  fi
+  if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    ver="unknown ('--version' timed out)"
+  elif [ "$rc" -ne 0 ]; then
+    ver="unknown ('--version' exited ${rc}: ${ver:-no output})"
+  fi
+  echo "  version: ${ver:-unknown}"
+}
+
+# Assert that all given commands are available on PATH and resolve to usable
+# binaries.
+# Usage: assert_cmds_available <command> [<command> ...]
+assert_cmds_available() {
+  local cmd bin found_all=1
+  for cmd in "$@"; do
+    if ! bin="$(command -v "$cmd")"; then
+      echo "Error: required command '$cmd' not found on PATH." >&2
+      found_all=0
+    elif ! is_usable_binary "$bin"; then
+      echo "Error: required command '$cmd' resolves to unusable '$bin'." >&2
+      found_all=0
+    fi
+  done
+  [ "$found_all" -eq 1 ]
+}
+
 # Acquire an exclusive, non-blocking lock tied to the given workdir to prevent
 # concurrent testruns from clobbering each other's workdir. The lock is held
 # for the lifetime of the calling shell; it is released automatically on exit.


### PR DESCRIPTION
Binaries placed in the repo's .bin directory were always shadowed by the nix-built ones, because the built bin dirs were prepended in front of .bin in PATH_PREPEND. Reverse the order so that .bin always wins, and skip the (nix) build of any binary for which a usable executable is already present in .bin.

- Append built bin dirs after .bin in PATH_PREPEND instead of prepending, and move the db-sync setup after the node/cli setup so its bin dirs also come after theirs.
- Add is_usable_binary and report_existing_binary helpers. The latter logs the binary's version (best effort) and hard-fails binaries that cannot run at all (wrong arch, missing libs, crash on startup), since they would still shadow working ones on PATH.
- Skip builds per binary: node bundle (via new skip_bindir args), standalone cardano-cli, tx-centrifuge, cardano-db-sync and cardano-smash-server. The db-sync repo is still cloned for the schema files and the release tarball is still downloaded.
- Categorize .bin entries early and fail fast on executable but unusable entries (e.g. empty files) that would shadow built binaries as silent no-ops.
- Re-verify all required binaries on the final PATH before the testrun and exit 3 (distinct from pytest's 1) when any is missing or unusable. Create the artifacts dirs upfront so this exit code is not masked by grep_errors.sh.
- Document the .bin behavior in the README.